### PR TITLE
Validate user input during deserialization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -50,7 +50,7 @@ dependencies = [
  "mime",
  "percent-encoding",
  "pin-project-lite",
- "rand",
+ "rand 0.8.5",
  "sha-1",
  "smallvec",
  "zstd",
@@ -193,7 +193,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.6",
  "once_cell",
  "version_check",
 ]
@@ -252,8 +252,12 @@ version = "0.1.0"
 dependencies = [
  "actix-web",
  "chrono",
+ "claim",
  "config",
+ "fake",
  "once_cell",
+ "quickcheck",
+ "quickcheck_macros",
  "reqwest",
  "secrecy",
  "serde 1.0.136",
@@ -265,14 +269,15 @@ dependencies = [
  "tracing-bunyan-formatter",
  "tracing-log",
  "tracing-subscriber",
+ "unicode-segmentation",
  "uuid",
 ]
 
 [[package]]
 name = "autocfg"
-version = "1.1.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
 name = "base64"
@@ -370,6 +375,15 @@ dependencies = [
  "serde 1.0.136",
  "time 0.1.44",
  "winapi",
+]
+
+[[package]]
+name = "claim"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f81099d6bb72e1df6d50bb2347224b666a670912bb7f06dbe867a4a070ab3ce8"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]
@@ -553,10 +567,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "env_logger"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44533bbbb3bb3c1fa17d9f2e4e38bbbaf8396ba82193c4cb1b6445d711445d36"
+dependencies = [
+ "log",
+ "regex",
+]
+
+[[package]]
 name = "event-listener"
 version = "2.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77f3309417938f28bf8228fcff79a4a37103981e3e186d2ccd19c74b38f4eb71"
+
+[[package]]
+name = "fake"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6479fa2c7e83ddf8be7d435421e093b072ca891b99a49bc84eba098f4044f818"
+dependencies = [
+ "rand 0.7.3",
+]
 
 [[package]]
 name = "fastrand"
@@ -686,6 +719,17 @@ checksum = "c1ebd34e35c46e00bb73e81363248d627782724609fe1b6396f553f68fe3862e"
 dependencies = [
  "libc",
  "winapi",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi 0.9.0+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -975,11 +1019,10 @@ checksum = "902eb695eb0591864543cbfbf6d742510642a605a61fc5e97fe6ceb5a30ac4fb"
 
 [[package]]
 name = "lock_api"
-version = "0.4.7"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "327fa5b6a6940e4699ec49a9beae1ea4845c6bab9314e4f84ac68742139d8c53"
+checksum = "88943dd7ef4a2e5a4bfa2753aaab3013e34ce2533d1996fb18ef591e315e2b3b"
 dependencies = [
- "autocfg",
  "scopeguard",
 ]
 
@@ -1314,6 +1357,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "quickcheck"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a44883e74aa97ad63db83c4bf8ca490f02b2fc02f92575e720c8551e843c945f"
+dependencies = [
+ "env_logger",
+ "log",
+ "rand 0.7.3",
+ "rand_core 0.5.1",
+]
+
+[[package]]
+name = "quickcheck_macros"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "608c156fd8e97febc07dc9c2e2c80bf74cfc6ef26893eae3daf8bc2bc94a4b7f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1324,13 +1390,36 @@ dependencies = [
 
 [[package]]
 name = "rand"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
+dependencies = [
+ "getrandom 0.1.16",
+ "libc",
+ "rand_chacha 0.2.2",
+ "rand_core 0.5.1",
+ "rand_hc",
+]
+
+[[package]]
+name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.3",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.5.1",
 ]
 
 [[package]]
@@ -1340,7 +1429,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.3",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
+dependencies = [
+ "getrandom 0.1.16",
 ]
 
 [[package]]
@@ -1349,7 +1447,16 @@ version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.6",
+]
+
+[[package]]
+name = "rand_hc"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
+dependencies = [
+ "rand_core 0.5.1",
 ]
 
 [[package]]
@@ -1367,7 +1474,7 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.6",
  "redox_syscall",
  "thiserror",
 ]
@@ -1753,7 +1860,7 @@ dependencies = [
  "once_cell",
  "paste",
  "percent-encoding",
- "rand",
+ "rand 0.8.5",
  "rustls",
  "serde 1.0.136",
  "serde_json",
@@ -2190,7 +2297,7 @@ version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.6",
 ]
 
 [[package]]
@@ -2220,6 +2327,12 @@ dependencies = [
  "log",
  "try-lock",
 ]
+
+[[package]]
+name = "wasi"
+version = "0.9.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ tracing-bunyan-formatter = "0.3"
 tracing-log = "0.1"
 tracing-actix-web = "0.5"
 secrecy = { version = "0.8", features = ["serde"] }
+unicode-segmentation = "1"
 
 [dependencies.sqlx]
 version = "0.5.7"
@@ -41,3 +42,7 @@ features = [
 [dev-dependencies]
 reqwest = { version = "0.11.10", features = ["json"] }
 once_cell = "1"
+claim = "0.5"
+fake = "~2.3"
+quickcheck = "0.9.2"
+quickcheck_macros = "0.9.1"

--- a/src/domain/component.rs
+++ b/src/domain/component.rs
@@ -1,0 +1,17 @@
+use super::ValidName;
+use serde::{Deserialize, Serialize};
+use sqlx::postgres::PgHasArrayType;
+
+#[derive(Debug, PartialEq, Serialize, Deserialize, sqlx::Type, Clone)]
+#[sqlx(type_name = "component")]
+pub struct Component {
+    pub name: ValidName,
+    pub amount: i64,
+    pub factor: f64,
+}
+
+impl PgHasArrayType for Component {
+    fn array_type_info() -> sqlx::postgres::PgTypeInfo {
+        sqlx::postgres::PgTypeInfo::with_name("_component")
+    }
+}

--- a/src/domain/component.rs
+++ b/src/domain/component.rs
@@ -15,3 +15,10 @@ impl PgHasArrayType for Component {
         sqlx::postgres::PgTypeInfo::with_name("_component")
     }
 }
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct ComponentTest {
+    pub name: Option<String>,
+    pub amount: Option<i64>,
+    pub factor: Option<f64>,
+}

--- a/src/domain/mod.rs
+++ b/src/domain/mod.rs
@@ -1,0 +1,7 @@
+mod component;
+mod record;
+mod validname;
+
+pub use component::Component;
+pub use record::{Record, RecordAdd, RecordUpdate};
+pub use validname::ValidName;

--- a/src/domain/mod.rs
+++ b/src/domain/mod.rs
@@ -2,6 +2,6 @@ mod component;
 mod record;
 mod validname;
 
-pub use component::Component;
-pub use record::{Record, RecordAdd, RecordUpdate};
+pub use component::{Component, ComponentTest};
+pub use record::{Record, RecordAdd, RecordTest, RecordUpdate};
 pub use validname::ValidName;

--- a/src/domain/record.rs
+++ b/src/domain/record.rs
@@ -1,29 +1,15 @@
 //! Record related types used for deserializing HTTP requests and serializing HTTP responses.
 
+use super::{Component, ValidName};
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
-use sqlx::postgres::PgHasArrayType;
-
-#[derive(Debug, PartialEq, Serialize, Deserialize, sqlx::Type, Clone)]
-#[sqlx(type_name = "component")]
-pub struct Component {
-    pub name: String,
-    pub amount: i64,
-    pub factor: f64,
-}
-
-impl PgHasArrayType for Component {
-    fn array_type_info() -> sqlx::postgres::PgTypeInfo {
-        sqlx::postgres::PgTypeInfo::with_name("_component")
-    }
-}
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct RecordAdd {
-    pub record_id: String,
-    pub site_id: String,
-    pub user_id: String,
-    pub group_id: String,
+    pub record_id: ValidName,
+    pub site_id: ValidName,
+    pub user_id: ValidName,
+    pub group_id: ValidName,
     pub components: Vec<Component>,
     pub start_time: DateTime<Utc>,
     pub stop_time: Option<DateTime<Utc>>,
@@ -31,10 +17,10 @@ pub struct RecordAdd {
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct RecordUpdate {
-    pub record_id: String,
-    pub site_id: String,
-    pub user_id: String,
-    pub group_id: String,
+    pub record_id: ValidName,
+    pub site_id: ValidName,
+    pub user_id: ValidName,
+    pub group_id: ValidName,
     pub components: Vec<Component>,
     pub start_time: Option<DateTime<Utc>>,
     pub stop_time: DateTime<Utc>,

--- a/src/domain/record.rs
+++ b/src/domain/record.rs
@@ -1,6 +1,6 @@
 //! Record related types used for deserializing HTTP requests and serializing HTTP responses.
 
-use super::{Component, ValidName};
+use super::{Component, ComponentTest, ValidName};
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
@@ -36,4 +36,71 @@ pub struct Record {
     pub start_time: DateTime<Utc>,
     pub stop_time: Option<DateTime<Utc>>,
     pub runtime: Option<i64>,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, Default)]
+pub struct RecordTest {
+    pub record_id: Option<String>,
+    pub site_id: Option<String>,
+    pub user_id: Option<String>,
+    pub group_id: Option<String>,
+    pub components: Option<Vec<ComponentTest>>,
+    pub start_time: Option<DateTime<Utc>>,
+    pub stop_time: Option<DateTime<Utc>>,
+}
+
+impl RecordTest {
+    pub fn new() -> Self {
+        RecordTest::default()
+    }
+
+    pub fn with_record_id<T: AsRef<str>>(mut self, record_id: T) -> Self {
+        self.record_id = Some(record_id.as_ref().to_string());
+        self
+    }
+
+    pub fn with_site_id<T: AsRef<str>>(mut self, site_id: T) -> Self {
+        self.site_id = Some(site_id.as_ref().to_string());
+        self
+    }
+
+    pub fn with_user_id<T: AsRef<str>>(mut self, user_id: T) -> Self {
+        self.user_id = Some(user_id.as_ref().to_string());
+        self
+    }
+
+    pub fn with_group_id<T: AsRef<str>>(mut self, group_id: T) -> Self {
+        self.group_id = Some(group_id.as_ref().to_string());
+        self
+    }
+
+    pub fn with_component<T: AsRef<str>>(mut self, name: T, amount: i64, factor: f64) -> Self {
+        if self.components.is_none() {
+            self.components = Some(vec![])
+        }
+        self.components.as_mut().unwrap().push(ComponentTest {
+            name: Some(name.as_ref().to_string()),
+            amount: Some(amount),
+            factor: Some(factor),
+        });
+        self
+    }
+
+    pub fn with_start_time<T: AsRef<str>>(mut self, start_time: T) -> Self {
+        self.start_time = Some(
+            DateTime::parse_from_rfc3339(start_time.as_ref())
+                .unwrap()
+                .with_timezone(&Utc),
+        );
+        self
+    }
+
+    pub fn with_stop_time<T: AsRef<str>>(mut self, stop_time: T) -> Self {
+        self.stop_time = Some(
+            DateTime::parse_from_rfc3339(stop_time.as_ref())
+                .unwrap()
+                .with_timezone(&Utc),
+        );
+        self
+    }
 }

--- a/src/domain/validname.rs
+++ b/src/domain/validname.rs
@@ -1,0 +1,129 @@
+use sqlx::{postgres::PgTypeInfo, Postgres, Type};
+use std::fmt;
+use unicode_segmentation::UnicodeSegmentation;
+
+// never turn this into `ValidName(pub String)`. By keeping the inner field private, it is not
+// possible to create this type outside of this module, hence enforcing the use of `parse`. This
+// ensures that every string stored in this type satisfies the validation criteria checked by
+// `parse`.
+#[derive(Debug, Clone, PartialEq, sqlx::Decode, sqlx::Encode)]
+pub struct ValidName(String);
+
+impl ValidName {
+    /// Returns `ValidName` only if input satisfies validation criteria, otherwise panics.
+    pub fn parse(s: String) -> Result<ValidName, String> {
+        // remove trailing whitespace and check if string is then empty
+        let is_empty_or_whitespace = s.trim().is_empty();
+        // count characters
+        let is_too_long = s.graphemes(true).count() > 256;
+        // check for forbidden characters
+        let forbidden_characters = ['/', '(', ')', '"', '<', '>', '\\', '{', '}'];
+        let contains_forbidden_characters = s.chars().any(|g| forbidden_characters.contains(&g));
+        if is_empty_or_whitespace || is_too_long || contains_forbidden_characters {
+            Err(format!("Invalid record ID: {}", s))
+        } else {
+            Ok(Self(s))
+        }
+    }
+}
+
+impl AsRef<str> for ValidName {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
+impl Type<Postgres> for ValidName {
+    fn type_info() -> PgTypeInfo {
+        <&str as Type<Postgres>>::type_info()
+    }
+
+    fn compatible(ty: &PgTypeInfo) -> bool {
+        <&str as Type<Postgres>>::compatible(ty)
+    }
+}
+
+impl serde::Serialize for ValidName {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str(&self.0)
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for ValidName {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let buf = String::deserialize(deserializer)?;
+        ValidName::parse(buf).map_err(serde::de::Error::custom)
+    }
+}
+
+impl fmt::Display for ValidName {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{:?}", self.0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::domain::ValidName;
+    use claim::{assert_err, assert_ok};
+    use fake::{Fake, StringFaker};
+
+    #[derive(Debug, Clone)]
+    struct ValidNameString(pub String);
+
+    impl quickcheck::Arbitrary for ValidNameString {
+        fn arbitrary<G: quickcheck::Gen>(g: &mut G) -> Self {
+            let name = StringFaker::with(
+                String::from("ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789*&^%$#@!~").into_bytes(),
+                1..256,
+            )
+            .fake_with_rng::<String, G>(g);
+            Self(name)
+        }
+    }
+
+    #[test]
+    fn a_256_grapheme_long_name_is_valid() {
+        let name = "ё".repeat(256);
+        assert_ok!(ValidName::parse(name));
+    }
+
+    #[test]
+    fn a_name_longer_than_256_graphemes_is_rejected() {
+        let name = "a".repeat(257);
+        assert_err!(ValidName::parse(name));
+    }
+
+    #[test]
+    fn whitespace_only_names_are_rejected() {
+        let name = " ".to_string();
+        assert_err!(ValidName::parse(name));
+    }
+
+    #[test]
+    fn empty_string_is_rejected() {
+        let name = "".to_string();
+        assert_err!(ValidName::parse(name));
+    }
+
+    #[test]
+    fn names_containing_an_invalid_character_are_rejected() {
+        for name in &['/', '(', ')', '"', '<', '>', '\\', '{', '}'] {
+            let name = name.to_string();
+            assert_err!(ValidName::parse(name));
+        }
+    }
+
+    // #[test]
+    #[quickcheck_macros::quickcheck]
+    fn a_valid_name_is_parsed_successfully(name: ValidNameString) {
+        // dbg!(&name.0);
+        assert_ok!(ValidName::parse(name.0));
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 pub mod configuration;
-pub mod record;
+pub mod domain;
 pub mod routes;
 pub mod startup;
 pub mod telemetry;

--- a/src/routes/add.rs
+++ b/src/routes/add.rs
@@ -1,4 +1,4 @@
-use crate::record::RecordAdd;
+use crate::domain::RecordAdd;
 use actix_web::{web, HttpResponse};
 use chrono::Utc;
 use sqlx;
@@ -33,10 +33,10 @@ pub async fn add_record(record: &RecordAdd, pool: &PgPool) -> Result<(), sqlx::E
         )
         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
         "#,
-        record.record_id,
-        record.site_id,
-        record.user_id,
-        record.group_id,
+        record.record_id.as_ref(),
+        record.site_id.as_ref(),
+        record.user_id.as_ref(),
+        record.group_id.as_ref(),
         record.components,
         record.start_time,
         record.stop_time,

--- a/src/routes/get.rs
+++ b/src/routes/get.rs
@@ -1,4 +1,4 @@
-use crate::record::{Component, Record};
+use crate::domain::{Component, Record};
 use actix_web::{web, HttpResponse};
 use sqlx;
 use sqlx::PgPool;

--- a/src/routes/get_since.rs
+++ b/src/routes/get_since.rs
@@ -1,4 +1,4 @@
-use crate::record::{Component, Record};
+use crate::domain::{Component, Record};
 use actix_web::{web, HttpResponse};
 use chrono::{DateTime, Utc};
 use sqlx;

--- a/src/routes/update.rs
+++ b/src/routes/update.rs
@@ -1,4 +1,4 @@
-use crate::record::RecordUpdate;
+use crate::domain::RecordUpdate;
 use actix_web::{web, HttpResponse};
 use chrono::Utc;
 use sqlx;
@@ -29,7 +29,7 @@ pub async fn update_record(record: &RecordUpdate, pool: &PgPool) -> Result<(), s
         FROM accounting 
         WHERE record_id = $1
         "#,
-        record.record_id,
+        record.record_id.as_ref(),
     )
     .fetch_one(pool)
     .await
@@ -48,10 +48,10 @@ pub async fn update_record(record: &RecordUpdate, pool: &PgPool) -> Result<(), s
         WHERE
             record_id = $1 and site_id = $2 and user_id = $3 and group_id = $4 and components = $5
         "#,
-        record.record_id,
-        record.site_id,
-        record.user_id,
-        record.group_id,
+        record.record_id.as_ref(),
+        record.site_id.as_ref(),
+        record.user_id.as_ref(),
+        record.group_id.as_ref(),
         record.components,
         record.stop_time,
         (record.stop_time - start_time).num_seconds(),

--- a/tests/health_check.rs
+++ b/tests/health_check.rs
@@ -1,7 +1,6 @@
 use auditor::configuration::{get_configuration, DatabaseSettings};
-use auditor::domain::{Component, Record, RecordAdd, RecordUpdate, ValidName};
+use auditor::domain::{Component, Record, RecordTest};
 use auditor::telemetry::{get_subscriber, init_subscriber};
-use chrono::{DateTime, Utc};
 use once_cell::sync::Lazy;
 use sqlx::{Connection, Executor, PgConnection, PgPool};
 use std::net::TcpListener;
@@ -85,32 +84,15 @@ async fn add_returns_a_200_for_valid_json_data() {
     let client = reqwest::Client::new();
 
     // Act
-    let body = RecordAdd {
-        record_id: ValidName::parse("hpc-1337".into()).unwrap(),
-        site_id: ValidName::parse("cluster1".into()).unwrap(),
-        user_id: ValidName::parse("user1".into()).unwrap(),
-        group_id: ValidName::parse("group1".into()).unwrap(),
-        components: vec![
-            Component {
-                name: ValidName::parse("CPU".into()).unwrap(),
-                amount: 10,
-                factor: 1.3,
-            },
-            Component {
-                name: ValidName::parse("Memory".into()).unwrap(),
-                amount: 120,
-                factor: 1.0,
-            },
-        ],
-        start_time: DateTime::parse_from_rfc3339("2022-03-01T12:00:00-00:00")
-            .unwrap()
-            .with_timezone(&Utc),
-        stop_time: Some(
-            DateTime::parse_from_rfc3339("2022-03-01T13:00:00-00:00")
-                .unwrap()
-                .with_timezone(&Utc),
-        ),
-    };
+    let body = RecordTest::new()
+        .with_record_id("hpc-1337")
+        .with_site_id("cluster1")
+        .with_user_id("user1")
+        .with_group_id("group1")
+        .with_component("CPU", 10, 1.3)
+        .with_component("Memory", 120, 1.0)
+        .with_start_time("2022-03-01T12:00:00-00:00")
+        .with_stop_time("2022-03-01T13:00:00-00:00");
 
     let response = client
         .post(&format!("{}/add", &app.address))
@@ -163,52 +145,63 @@ async fn add_returns_a_200_for_valid_json_data() {
 }
 
 #[tokio::test]
+async fn add_returns_a_400_for_invalid_json_data() {
+    // Arange
+    let app = spawn_app().await;
+    let client = reqwest::Client::new();
+
+    // Act
+    let body = RecordTest::new()
+        .with_record_id("hpc-1337()")
+        .with_site_id("cluster1")
+        .with_user_id("user1")
+        .with_group_id("group1")
+        .with_component("CPU", 10, 1.3)
+        .with_component("Memory", 120, 1.0)
+        .with_start_time("2022-03-01T12:00:00-00:00")
+        .with_stop_time("2022-03-01T13:00:00-00:00");
+
+    let response = client
+        .post(&format!("{}/add", &app.address))
+        .header("Content-Type", "application/json")
+        .json(&body)
+        .send()
+        .await
+        .expect("Failed to execute request.");
+
+    assert_eq!(400, response.status().as_u16());
+
+    let saved = sqlx::query!(
+        r#"SELECT
+           record_id, site_id, user_id, group_id, components as "components: Vec<Component>",
+           start_time, stop_time, runtime
+           FROM accounting
+           WHERE record_id = $1
+        "#,
+        "hpc-1337",
+    )
+    .fetch_all(&app.db_pool)
+    .await
+    .expect("Failed to fetch saved subscription.");
+
+    assert_eq!(saved.len(), 0);
+}
+
+#[tokio::test]
 async fn add_returns_a_400_when_data_is_missing() {
     // Arrange
     let app = spawn_app().await;
     let client = reqwest::Client::new();
 
-    #[derive(serde::Serialize, serde::Deserialize, Clone)]
-    pub struct TestRecord {
-        pub record_id: Option<String>,
-        pub site_id: Option<String>,
-        pub user_id: Option<String>,
-        pub group_id: Option<String>,
-        pub components: Option<Vec<Component>>,
-        pub start_time: Option<DateTime<Utc>>,
-        pub stop_time: Option<DateTime<Utc>>,
-        pub runtime: Option<i64>,
-    }
-
-    let record = TestRecord {
-        record_id: Some("hpc-1337".into()),
-        site_id: Some("cluster1".into()),
-        user_id: Some("user1".into()),
-        group_id: Some("group1".into()),
-        components: Some(vec![
-            Component {
-                name: ValidName::parse("CPU".into()).unwrap(),
-                amount: 10,
-                factor: 1.3,
-            },
-            Component {
-                name: ValidName::parse("Memory".into()).unwrap(),
-                amount: 120,
-                factor: 1.0,
-            },
-        ]),
-        start_time: Some(
-            DateTime::parse_from_rfc3339("2022-03-01T12:00:00-00:00")
-                .unwrap()
-                .with_timezone(&Utc),
-        ),
-        stop_time: Some(
-            DateTime::parse_from_rfc3339("2022-03-01T13:00:00-00:00")
-                .unwrap()
-                .with_timezone(&Utc),
-        ),
-        runtime: Some(3600),
-    };
+    let record = RecordTest::new()
+        .with_record_id("hpc-1337")
+        .with_site_id("cluster1")
+        .with_user_id("user1")
+        .with_group_id("group1")
+        .with_component("CPU", 10, 1.3)
+        .with_component("Memory", 120, 1.0)
+        .with_start_time("2022-03-01T12:00:00-00:00")
+        .with_stop_time("2022-03-01T13:00:00-00:00");
 
     let test_cases = vec![
         ("record_id is missing", {
@@ -270,28 +263,14 @@ async fn update_returns_a_400_for_non_existing_record() {
     let client = reqwest::Client::new();
 
     // Act
-    let body = RecordUpdate {
-        record_id: ValidName::parse("does_not_exist".into()).unwrap(),
-        site_id: ValidName::parse("cluster1".into()).unwrap(),
-        user_id: ValidName::parse("user1".into()).unwrap(),
-        group_id: ValidName::parse("group1".into()).unwrap(),
-        components: vec![
-            Component {
-                name: ValidName::parse("CPU".into()).unwrap(),
-                amount: 10,
-                factor: 1.3,
-            },
-            Component {
-                name: ValidName::parse("Memory".into()).unwrap(),
-                amount: 120,
-                factor: 1.0,
-            },
-        ],
-        start_time: None,
-        stop_time: DateTime::parse_from_rfc3339("2022-03-01T13:00:00-00:00")
-            .unwrap()
-            .with_timezone(&Utc),
-    };
+    let body = RecordTest::new()
+        .with_record_id("does_not_exist")
+        .with_site_id("cluster1")
+        .with_user_id("user1")
+        .with_group_id("group1")
+        .with_component("CPU", 10, 1.3)
+        .with_component("Memory", 120, 1.0)
+        .with_stop_time("2022-03-01T13:00:00-00:00");
 
     let response = client
         .post(&format!("{}/update", &app.address))
@@ -312,28 +291,14 @@ async fn update_returns_a_200_for_valid_form_data() {
 
     // Act
     // first add a record
-    let body = RecordAdd {
-        record_id: ValidName::parse("hpc-1234".into()).unwrap(),
-        site_id: ValidName::parse("cluster1".into()).unwrap(),
-        user_id: ValidName::parse("user1".into()).unwrap(),
-        group_id: ValidName::parse("group1".into()).unwrap(),
-        components: vec![
-            Component {
-                name: ValidName::parse("CPU".into()).unwrap(),
-                amount: 10,
-                factor: 1.3,
-            },
-            Component {
-                name: ValidName::parse("Memory".into()).unwrap(),
-                amount: 120,
-                factor: 1.0,
-            },
-        ],
-        start_time: DateTime::parse_from_rfc3339("2022-03-01T12:00:00-00:00")
-            .unwrap()
-            .with_timezone(&Utc),
-        stop_time: None,
-    };
+    let body = RecordTest::new()
+        .with_record_id("hpc-1234")
+        .with_site_id("cluster1")
+        .with_user_id("user1")
+        .with_group_id("group1")
+        .with_component("CPU", 10, 1.3)
+        .with_component("Memory", 120, 1.0)
+        .with_start_time("2022-03-01T12:00:00-00:00");
 
     let response = client
         .post(&format!("{}/add", &app.address))
@@ -346,28 +311,14 @@ async fn update_returns_a_200_for_valid_form_data() {
     assert_eq!(200, response.status().as_u16());
 
     // Update this record
-    let body = RecordUpdate {
-        record_id: ValidName::parse("hpc-1234".into()).unwrap(),
-        site_id: ValidName::parse("cluster1".into()).unwrap(),
-        user_id: ValidName::parse("user1".into()).unwrap(),
-        group_id: ValidName::parse("group1".into()).unwrap(),
-        components: vec![
-            Component {
-                name: ValidName::parse("CPU".into()).unwrap(),
-                amount: 10,
-                factor: 1.3,
-            },
-            Component {
-                name: ValidName::parse("Memory".into()).unwrap(),
-                amount: 120,
-                factor: 1.0,
-            },
-        ],
-        start_time: None,
-        stop_time: DateTime::parse_from_rfc3339("2022-03-01T13:00:00-00:00")
-            .unwrap()
-            .with_timezone(&Utc),
-    };
+    let body = RecordTest::new()
+        .with_record_id("hpc-1234")
+        .with_site_id("cluster1")
+        .with_user_id("user1")
+        .with_group_id("group1")
+        .with_component("CPU", 10, 1.3)
+        .with_component("Memory", 120, 1.0)
+        .with_stop_time("2022-03-01T13:00:00-00:00");
 
     let response = client
         .post(&format!("{}/update", &app.address))
@@ -426,49 +377,20 @@ async fn get_returns_a_200_and_list_of_records() {
     let client = reqwest::Client::new();
 
     // First send a couple of records
-    let record = RecordAdd {
-        record_id: ValidName::parse("hpc-1337".into()).unwrap(),
-        site_id: ValidName::parse("cluster1".into()).unwrap(),
-        user_id: ValidName::parse("user1".into()).unwrap(),
-        group_id: ValidName::parse("group1".into()).unwrap(),
-        components: vec![
-            Component {
-                name: ValidName::parse("CPU".into()).unwrap(),
-                amount: 10,
-                factor: 1.3,
-            },
-            Component {
-                name: ValidName::parse("Memory".into()).unwrap(),
-                amount: 120,
-                factor: 1.0,
-            },
-        ],
-        start_time: DateTime::parse_from_rfc3339("2022-03-01T12:00:00-00:00")
-            .unwrap()
-            .with_timezone(&Utc),
-        stop_time: Some(
-            DateTime::parse_from_rfc3339("2022-03-01T13:00:00-00:00")
-                .unwrap()
-                .with_timezone(&Utc),
-        ),
-    };
+    let record = RecordTest::new()
+        .with_record_id("hpc-1337")
+        .with_site_id("cluster1")
+        .with_user_id("user1")
+        .with_group_id("group1")
+        .with_component("CPU", 10, 1.3)
+        .with_component("Memory", 120, 1.0)
+        .with_start_time("2022-03-01T12:00:00-00:00")
+        .with_stop_time("2022-03-01T13:00:00-00:00");
 
     let test_cases = vec![
-        {
-            let mut r = record.clone();
-            r.record_id = ValidName::parse("r1".to_string()).unwrap();
-            r
-        },
-        {
-            let mut r = record.clone();
-            r.record_id = ValidName::parse("r2".to_string()).unwrap();
-            r
-        },
-        {
-            let mut r = record.clone();
-            r.record_id = ValidName::parse("r3".to_string()).unwrap();
-            r
-        },
+        record.clone().with_record_id("r1"),
+        record.clone().with_record_id("r2"),
+        record.clone().with_record_id("r3"),
     ];
 
     for case in test_cases.iter() {
@@ -493,15 +415,60 @@ async fn get_returns_a_200_and_list_of_records() {
     let received_records = response.json::<Vec<Record>>().await.unwrap();
 
     for (record, received) in test_cases.iter().zip(received_records.iter()) {
-        assert_eq!(record.record_id.as_ref(), received.record_id);
-        assert_eq!(record.site_id.as_ref(), *received.site_id.as_ref().unwrap());
-        assert_eq!(record.user_id.as_ref(), *received.user_id.as_ref().unwrap());
+        assert_eq!(*record.record_id.as_ref().unwrap(), received.record_id);
         assert_eq!(
-            record.group_id.as_ref(),
+            *record.site_id.as_ref().unwrap(),
+            *received.site_id.as_ref().unwrap()
+        );
+        assert_eq!(
+            *record.user_id.as_ref().unwrap(),
+            *received.user_id.as_ref().unwrap()
+        );
+        assert_eq!(
+            *record.group_id.as_ref().unwrap(),
             *received.group_id.as_ref().unwrap()
         );
-        assert_eq!(record.components, *received.components.as_ref().unwrap());
-        assert_eq!(record.start_time, received.start_time);
+        assert_eq!(
+            record.components.as_ref().unwrap()[0]
+                .name
+                .as_ref()
+                .unwrap(),
+            received.components.as_ref().unwrap()[0].name.as_ref()
+        );
+        assert_eq!(
+            record.components.as_ref().unwrap()[0].amount.unwrap(),
+            received.components.as_ref().unwrap()[0].amount
+        );
+        assert_eq!(
+            record.components.as_ref().unwrap()[0]
+                .factor
+                .unwrap()
+                .to_ne_bytes(),
+            received.components.as_ref().unwrap()[0]
+                .factor
+                .to_ne_bytes()
+        );
+        assert_eq!(
+            record.components.as_ref().unwrap()[1]
+                .name
+                .as_ref()
+                .unwrap(),
+            received.components.as_ref().unwrap()[1].name.as_ref()
+        );
+        assert_eq!(
+            record.components.as_ref().unwrap()[1].amount.unwrap(),
+            received.components.as_ref().unwrap()[1].amount
+        );
+        assert_eq!(
+            record.components.as_ref().unwrap()[1]
+                .factor
+                .unwrap()
+                .to_ne_bytes(),
+            received.components.as_ref().unwrap()[1]
+                .factor
+                .to_ne_bytes()
+        );
+        assert_eq!(*record.start_time.as_ref().unwrap(), received.start_time);
         assert_eq!(
             record.stop_time.unwrap(),
             *received.stop_time.as_ref().unwrap()
@@ -533,58 +500,29 @@ async fn get_started_since_returns_a_200_and_list_of_records() {
     let client = reqwest::Client::new();
 
     // First send a couple of records
-    let record = RecordAdd {
-        record_id: ValidName::parse("hpc-1337".into()).unwrap(),
-        site_id: ValidName::parse("cluster1".into()).unwrap(),
-        user_id: ValidName::parse("user1".into()).unwrap(),
-        group_id: ValidName::parse("group1".into()).unwrap(),
-        components: vec![
-            Component {
-                name: ValidName::parse("CPU".into()).unwrap(),
-                amount: 10,
-                factor: 1.3,
-            },
-            Component {
-                name: ValidName::parse("Memory".into()).unwrap(),
-                amount: 120,
-                factor: 1.0,
-            },
-        ],
-        start_time: DateTime::parse_from_rfc3339("2022-03-01T12:00:00-00:00")
-            .unwrap()
-            .with_timezone(&Utc),
-        stop_time: Some(
-            DateTime::parse_from_rfc3339("2022-03-01T13:00:00-00:00")
-                .unwrap()
-                .with_timezone(&Utc),
-        ),
-    };
+    let record = RecordTest::new()
+        .with_record_id("hpc-1337")
+        .with_site_id("cluster1")
+        .with_user_id("user1")
+        .with_group_id("group1")
+        .with_component("CPU", 10, 1.3)
+        .with_component("Memory", 120, 1.0)
+        .with_start_time("2022-03-01T12:00:00-00:00")
+        .with_stop_time("2022-03-01T13:00:00-00:00");
 
     let test_cases = vec![
-        {
-            let mut r = record.clone();
-            r.record_id = ValidName::parse("r1".to_string()).unwrap();
-            r.start_time = DateTime::parse_from_rfc3339("2022-03-01T12:00:00-00:00")
-                .unwrap()
-                .with_timezone(&Utc);
-            r
-        },
-        {
-            let mut r = record.clone();
-            r.record_id = ValidName::parse("r2".to_string()).unwrap();
-            r.start_time = DateTime::parse_from_rfc3339("2022-03-02T12:00:00-00:00")
-                .unwrap()
-                .with_timezone(&Utc);
-            r
-        },
-        {
-            let mut r = record.clone();
-            r.record_id = ValidName::parse("r3".to_string()).unwrap();
-            r.start_time = DateTime::parse_from_rfc3339("2022-03-03T12:00:00-00:00")
-                .unwrap()
-                .with_timezone(&Utc);
-            r
-        },
+        record
+            .clone()
+            .with_record_id("r1")
+            .with_start_time("2022-03-01T12:00:00-00:00"),
+        record
+            .clone()
+            .with_record_id("r2")
+            .with_start_time("2022-03-02T12:00:00-00:00"),
+        record
+            .clone()
+            .with_record_id("r3")
+            .with_start_time("2022-03-03T12:00:00-00:00"),
     ];
 
     for case in test_cases.iter() {
@@ -612,15 +550,60 @@ async fn get_started_since_returns_a_200_and_list_of_records() {
     let received_records = response.json::<Vec<Record>>().await.unwrap();
 
     for (record, received) in test_cases.iter().skip(1).zip(received_records.iter()) {
-        assert_eq!(record.record_id.as_ref(), received.record_id);
-        assert_eq!(record.site_id.as_ref(), *received.site_id.as_ref().unwrap());
-        assert_eq!(record.user_id.as_ref(), *received.user_id.as_ref().unwrap());
+        assert_eq!(*record.record_id.as_ref().unwrap(), received.record_id);
         assert_eq!(
-            record.group_id.as_ref(),
+            *record.site_id.as_ref().unwrap(),
+            *received.site_id.as_ref().unwrap()
+        );
+        assert_eq!(
+            *record.user_id.as_ref().unwrap(),
+            *received.user_id.as_ref().unwrap()
+        );
+        assert_eq!(
+            *record.group_id.as_ref().unwrap(),
             *received.group_id.as_ref().unwrap()
         );
-        assert_eq!(record.components, *received.components.as_ref().unwrap());
-        assert_eq!(record.start_time, received.start_time);
+        assert_eq!(
+            record.components.as_ref().unwrap()[0]
+                .name
+                .as_ref()
+                .unwrap(),
+            received.components.as_ref().unwrap()[0].name.as_ref()
+        );
+        assert_eq!(
+            record.components.as_ref().unwrap()[0].amount.unwrap(),
+            received.components.as_ref().unwrap()[0].amount
+        );
+        assert_eq!(
+            record.components.as_ref().unwrap()[0]
+                .factor
+                .unwrap()
+                .to_ne_bytes(),
+            received.components.as_ref().unwrap()[0]
+                .factor
+                .to_ne_bytes()
+        );
+        assert_eq!(
+            record.components.as_ref().unwrap()[1]
+                .name
+                .as_ref()
+                .unwrap(),
+            received.components.as_ref().unwrap()[1].name.as_ref()
+        );
+        assert_eq!(
+            record.components.as_ref().unwrap()[1].amount.unwrap(),
+            received.components.as_ref().unwrap()[1].amount
+        );
+        assert_eq!(
+            record.components.as_ref().unwrap()[1]
+                .factor
+                .unwrap()
+                .to_ne_bytes(),
+            received.components.as_ref().unwrap()[1]
+                .factor
+                .to_ne_bytes()
+        );
+        assert_eq!(record.start_time.unwrap(), received.start_time);
         assert_eq!(
             record.stop_time.unwrap(),
             *received.stop_time.as_ref().unwrap()
@@ -655,64 +638,29 @@ async fn get_stopped_since_returns_a_200_and_list_of_records() {
     let client = reqwest::Client::new();
 
     // First send a couple of records
-    let record = RecordAdd {
-        record_id: ValidName::parse("hpc-1337".into()).unwrap(),
-        site_id: ValidName::parse("cluster1".into()).unwrap(),
-        user_id: ValidName::parse("user1".into()).unwrap(),
-        group_id: ValidName::parse("group1".into()).unwrap(),
-        components: vec![
-            Component {
-                name: ValidName::parse("CPU".into()).unwrap(),
-                amount: 10,
-                factor: 1.3,
-            },
-            Component {
-                name: ValidName::parse("Memory".into()).unwrap(),
-                amount: 120,
-                factor: 1.0,
-            },
-        ],
-        start_time: DateTime::parse_from_rfc3339("2022-03-01T12:00:00-00:00")
-            .unwrap()
-            .with_timezone(&Utc),
-        stop_time: Some(
-            DateTime::parse_from_rfc3339("2022-03-01T13:00:00-00:00")
-                .unwrap()
-                .with_timezone(&Utc),
-        ),
-    };
+    let record = RecordTest::new()
+        .with_record_id("hpc-1337")
+        .with_site_id("cluster1")
+        .with_user_id("user1")
+        .with_group_id("group1")
+        .with_component("CPU", 10, 1.3)
+        .with_component("Memory", 120, 1.0)
+        .with_start_time("2022-03-01T12:00:00-00:00")
+        .with_stop_time("2022-03-01T13:00:00-00:00");
 
     let test_cases = vec![
-        {
-            let mut r = record.clone();
-            r.record_id = ValidName::parse("r1".to_string()).unwrap();
-            r.stop_time = Some(
-                DateTime::parse_from_rfc3339("2022-03-01T13:00:00-00:00")
-                    .unwrap()
-                    .with_timezone(&Utc),
-            );
-            r
-        },
-        {
-            let mut r = record.clone();
-            r.record_id = ValidName::parse("r2".to_string()).unwrap();
-            r.stop_time = Some(
-                DateTime::parse_from_rfc3339("2022-03-02T13:00:00-00:00")
-                    .unwrap()
-                    .with_timezone(&Utc),
-            );
-            r
-        },
-        {
-            let mut r = record.clone();
-            r.record_id = ValidName::parse("r3".to_string()).unwrap();
-            r.stop_time = Some(
-                DateTime::parse_from_rfc3339("2022-03-03T13:00:00-00:00")
-                    .unwrap()
-                    .with_timezone(&Utc),
-            );
-            r
-        },
+        record
+            .clone()
+            .with_record_id("r1")
+            .with_stop_time("2022-03-01T12:00:00-00:00"),
+        record
+            .clone()
+            .with_record_id("r2")
+            .with_stop_time("2022-03-02T12:00:00-00:00"),
+        record
+            .clone()
+            .with_record_id("r3")
+            .with_stop_time("2022-03-03T12:00:00-00:00"),
     ];
 
     for case in test_cases.iter() {
@@ -740,15 +688,60 @@ async fn get_stopped_since_returns_a_200_and_list_of_records() {
     let received_records = response.json::<Vec<Record>>().await.unwrap();
 
     for (record, received) in test_cases.iter().skip(1).zip(received_records.iter()) {
-        assert_eq!(record.record_id.as_ref(), received.record_id);
-        assert_eq!(record.site_id.as_ref(), *received.site_id.as_ref().unwrap());
-        assert_eq!(record.user_id.as_ref(), *received.user_id.as_ref().unwrap());
+        assert_eq!(*record.record_id.as_ref().unwrap(), received.record_id);
         assert_eq!(
-            record.group_id.as_ref(),
+            *record.site_id.as_ref().unwrap(),
+            *received.site_id.as_ref().unwrap()
+        );
+        assert_eq!(
+            *record.user_id.as_ref().unwrap(),
+            *received.user_id.as_ref().unwrap()
+        );
+        assert_eq!(
+            *record.group_id.as_ref().unwrap(),
             *received.group_id.as_ref().unwrap()
         );
-        assert_eq!(record.components, *received.components.as_ref().unwrap());
-        assert_eq!(record.start_time, received.start_time);
+        assert_eq!(
+            record.components.as_ref().unwrap()[0]
+                .name
+                .as_ref()
+                .unwrap(),
+            received.components.as_ref().unwrap()[0].name.as_ref()
+        );
+        assert_eq!(
+            record.components.as_ref().unwrap()[0].amount.unwrap(),
+            received.components.as_ref().unwrap()[0].amount
+        );
+        assert_eq!(
+            record.components.as_ref().unwrap()[0]
+                .factor
+                .unwrap()
+                .to_ne_bytes(),
+            received.components.as_ref().unwrap()[0]
+                .factor
+                .to_ne_bytes()
+        );
+        assert_eq!(
+            record.components.as_ref().unwrap()[1]
+                .name
+                .as_ref()
+                .unwrap(),
+            received.components.as_ref().unwrap()[1].name.as_ref()
+        );
+        assert_eq!(
+            record.components.as_ref().unwrap()[1].amount.unwrap(),
+            received.components.as_ref().unwrap()[1].amount
+        );
+        assert_eq!(
+            record.components.as_ref().unwrap()[1]
+                .factor
+                .unwrap()
+                .to_ne_bytes(),
+            received.components.as_ref().unwrap()[1]
+                .factor
+                .to_ne_bytes()
+        );
+        assert_eq!(record.start_time.unwrap(), received.start_time);
         assert_eq!(
             record.stop_time.unwrap(),
             *received.stop_time.as_ref().unwrap()

--- a/tests/health_check.rs
+++ b/tests/health_check.rs
@@ -1,5 +1,5 @@
 use auditor::configuration::{get_configuration, DatabaseSettings};
-use auditor::record::{Component, Record, RecordAdd, RecordUpdate};
+use auditor::domain::{Component, Record, RecordAdd, RecordUpdate, ValidName};
 use auditor::telemetry::{get_subscriber, init_subscriber};
 use chrono::{DateTime, Utc};
 use once_cell::sync::Lazy;
@@ -86,18 +86,18 @@ async fn add_returns_a_200_for_valid_json_data() {
 
     // Act
     let body = RecordAdd {
-        record_id: "hpc-1337".into(),
-        site_id: "cluster1".into(),
-        user_id: "user1".into(),
-        group_id: "group1".into(),
+        record_id: ValidName::parse("hpc-1337".into()).unwrap(),
+        site_id: ValidName::parse("cluster1".into()).unwrap(),
+        user_id: ValidName::parse("user1".into()).unwrap(),
+        group_id: ValidName::parse("group1".into()).unwrap(),
         components: vec![
             Component {
-                name: "CPU".into(),
+                name: ValidName::parse("CPU".into()).unwrap(),
                 amount: 10,
                 factor: 1.3,
             },
             Component {
-                name: "Memory".into(),
+                name: ValidName::parse("Memory".into()).unwrap(),
                 amount: 120,
                 factor: 1.0,
             },
@@ -139,13 +139,16 @@ async fn add_returns_a_200_for_valid_json_data() {
     assert_eq!(saved.site_id.unwrap(), "cluster1");
     assert_eq!(saved.user_id.unwrap(), "user1");
     assert_eq!(saved.group_id.unwrap(), "group1");
-    assert_eq!(saved.components.as_ref().unwrap()[0].name, "CPU");
+    assert_eq!(saved.components.as_ref().unwrap()[0].name.as_ref(), "CPU");
     assert_eq!(saved.components.as_ref().unwrap()[0].amount, 10);
     assert_eq!(
         saved.components.as_ref().unwrap()[0].factor.to_ne_bytes(),
         1.3f64.to_ne_bytes()
     );
-    assert_eq!(saved.components.as_ref().unwrap()[1].name, "Memory");
+    assert_eq!(
+        saved.components.as_ref().unwrap()[1].name.as_ref(),
+        "Memory"
+    );
     assert_eq!(saved.components.as_ref().unwrap()[1].amount, 120);
     assert_eq!(
         saved.components.as_ref().unwrap()[1].factor.to_ne_bytes(),
@@ -184,12 +187,12 @@ async fn add_returns_a_400_when_data_is_missing() {
         group_id: Some("group1".into()),
         components: Some(vec![
             Component {
-                name: "CPU".into(),
+                name: ValidName::parse("CPU".into()).unwrap(),
                 amount: 10,
                 factor: 1.3,
             },
             Component {
-                name: "Memory".into(),
+                name: ValidName::parse("Memory".into()).unwrap(),
                 amount: 120,
                 factor: 1.0,
             },
@@ -268,18 +271,18 @@ async fn update_returns_a_400_for_non_existing_record() {
 
     // Act
     let body = RecordUpdate {
-        record_id: "does_not_exist".into(),
-        site_id: "cluster1".into(),
-        user_id: "user1".into(),
-        group_id: "group1".into(),
+        record_id: ValidName::parse("does_not_exist".into()).unwrap(),
+        site_id: ValidName::parse("cluster1".into()).unwrap(),
+        user_id: ValidName::parse("user1".into()).unwrap(),
+        group_id: ValidName::parse("group1".into()).unwrap(),
         components: vec![
             Component {
-                name: "CPU".into(),
+                name: ValidName::parse("CPU".into()).unwrap(),
                 amount: 10,
                 factor: 1.3,
             },
             Component {
-                name: "Memory".into(),
+                name: ValidName::parse("Memory".into()).unwrap(),
                 amount: 120,
                 factor: 1.0,
             },
@@ -310,18 +313,18 @@ async fn update_returns_a_200_for_valid_form_data() {
     // Act
     // first add a record
     let body = RecordAdd {
-        record_id: "hpc-1234".into(),
-        site_id: "cluster1".into(),
-        user_id: "user1".into(),
-        group_id: "group1".into(),
+        record_id: ValidName::parse("hpc-1234".into()).unwrap(),
+        site_id: ValidName::parse("cluster1".into()).unwrap(),
+        user_id: ValidName::parse("user1".into()).unwrap(),
+        group_id: ValidName::parse("group1".into()).unwrap(),
         components: vec![
             Component {
-                name: "CPU".into(),
+                name: ValidName::parse("CPU".into()).unwrap(),
                 amount: 10,
                 factor: 1.3,
             },
             Component {
-                name: "Memory".into(),
+                name: ValidName::parse("Memory".into()).unwrap(),
                 amount: 120,
                 factor: 1.0,
             },
@@ -344,18 +347,18 @@ async fn update_returns_a_200_for_valid_form_data() {
 
     // Update this record
     let body = RecordUpdate {
-        record_id: "hpc-1234".into(),
-        site_id: "cluster1".into(),
-        user_id: "user1".into(),
-        group_id: "group1".into(),
+        record_id: ValidName::parse("hpc-1234".into()).unwrap(),
+        site_id: ValidName::parse("cluster1".into()).unwrap(),
+        user_id: ValidName::parse("user1".into()).unwrap(),
+        group_id: ValidName::parse("group1".into()).unwrap(),
         components: vec![
             Component {
-                name: "CPU".into(),
+                name: ValidName::parse("CPU".into()).unwrap(),
                 amount: 10,
                 factor: 1.3,
             },
             Component {
-                name: "Memory".into(),
+                name: ValidName::parse("Memory".into()).unwrap(),
                 amount: 120,
                 factor: 1.0,
             },
@@ -393,13 +396,16 @@ async fn update_returns_a_200_for_valid_form_data() {
     assert_eq!(saved.site_id.unwrap(), "cluster1");
     assert_eq!(saved.user_id.unwrap(), "user1");
     assert_eq!(saved.group_id.unwrap(), "group1");
-    assert_eq!(saved.components.as_ref().unwrap()[0].name, "CPU");
+    assert_eq!(saved.components.as_ref().unwrap()[0].name.as_ref(), "CPU");
     assert_eq!(saved.components.as_ref().unwrap()[0].amount, 10);
     assert_eq!(
         saved.components.as_ref().unwrap()[0].factor.to_ne_bytes(),
         1.3f64.to_ne_bytes()
     );
-    assert_eq!(saved.components.as_ref().unwrap()[1].name, "Memory");
+    assert_eq!(
+        saved.components.as_ref().unwrap()[1].name.as_ref(),
+        "Memory"
+    );
     assert_eq!(saved.components.as_ref().unwrap()[1].amount, 120);
     assert_eq!(
         saved.components.as_ref().unwrap()[1].factor.to_ne_bytes(),
@@ -421,18 +427,18 @@ async fn get_returns_a_200_and_list_of_records() {
 
     // First send a couple of records
     let record = RecordAdd {
-        record_id: "hpc-1337".into(),
-        site_id: "cluster1".into(),
-        user_id: "user1".into(),
-        group_id: "group1".into(),
+        record_id: ValidName::parse("hpc-1337".into()).unwrap(),
+        site_id: ValidName::parse("cluster1".into()).unwrap(),
+        user_id: ValidName::parse("user1".into()).unwrap(),
+        group_id: ValidName::parse("group1".into()).unwrap(),
         components: vec![
             Component {
-                name: "CPU".into(),
+                name: ValidName::parse("CPU".into()).unwrap(),
                 amount: 10,
                 factor: 1.3,
             },
             Component {
-                name: "Memory".into(),
+                name: ValidName::parse("Memory".into()).unwrap(),
                 amount: 120,
                 factor: 1.0,
             },
@@ -450,17 +456,17 @@ async fn get_returns_a_200_and_list_of_records() {
     let test_cases = vec![
         {
             let mut r = record.clone();
-            r.record_id = "r1".to_string();
+            r.record_id = ValidName::parse("r1".to_string()).unwrap();
             r
         },
         {
             let mut r = record.clone();
-            r.record_id = "r2".to_string();
+            r.record_id = ValidName::parse("r2".to_string()).unwrap();
             r
         },
         {
             let mut r = record.clone();
-            r.record_id = "r3".to_string();
+            r.record_id = ValidName::parse("r3".to_string()).unwrap();
             r
         },
     ];
@@ -487,10 +493,13 @@ async fn get_returns_a_200_and_list_of_records() {
     let received_records = response.json::<Vec<Record>>().await.unwrap();
 
     for (record, received) in test_cases.iter().zip(received_records.iter()) {
-        assert_eq!(record.record_id, received.record_id);
-        assert_eq!(record.site_id, *received.site_id.as_ref().unwrap());
-        assert_eq!(record.user_id, *received.user_id.as_ref().unwrap());
-        assert_eq!(record.group_id, *received.group_id.as_ref().unwrap());
+        assert_eq!(record.record_id.as_ref(), received.record_id);
+        assert_eq!(record.site_id.as_ref(), *received.site_id.as_ref().unwrap());
+        assert_eq!(record.user_id.as_ref(), *received.user_id.as_ref().unwrap());
+        assert_eq!(
+            record.group_id.as_ref(),
+            *received.group_id.as_ref().unwrap()
+        );
         assert_eq!(record.components, *received.components.as_ref().unwrap());
         assert_eq!(record.start_time, received.start_time);
         assert_eq!(
@@ -525,18 +534,18 @@ async fn get_started_since_returns_a_200_and_list_of_records() {
 
     // First send a couple of records
     let record = RecordAdd {
-        record_id: "hpc-1337".into(),
-        site_id: "cluster1".into(),
-        user_id: "user1".into(),
-        group_id: "group1".into(),
+        record_id: ValidName::parse("hpc-1337".into()).unwrap(),
+        site_id: ValidName::parse("cluster1".into()).unwrap(),
+        user_id: ValidName::parse("user1".into()).unwrap(),
+        group_id: ValidName::parse("group1".into()).unwrap(),
         components: vec![
             Component {
-                name: "CPU".into(),
+                name: ValidName::parse("CPU".into()).unwrap(),
                 amount: 10,
                 factor: 1.3,
             },
             Component {
-                name: "Memory".into(),
+                name: ValidName::parse("Memory".into()).unwrap(),
                 amount: 120,
                 factor: 1.0,
             },
@@ -554,7 +563,7 @@ async fn get_started_since_returns_a_200_and_list_of_records() {
     let test_cases = vec![
         {
             let mut r = record.clone();
-            r.record_id = "r1".to_string();
+            r.record_id = ValidName::parse("r1".to_string()).unwrap();
             r.start_time = DateTime::parse_from_rfc3339("2022-03-01T12:00:00-00:00")
                 .unwrap()
                 .with_timezone(&Utc);
@@ -562,7 +571,7 @@ async fn get_started_since_returns_a_200_and_list_of_records() {
         },
         {
             let mut r = record.clone();
-            r.record_id = "r2".to_string();
+            r.record_id = ValidName::parse("r2".to_string()).unwrap();
             r.start_time = DateTime::parse_from_rfc3339("2022-03-02T12:00:00-00:00")
                 .unwrap()
                 .with_timezone(&Utc);
@@ -570,7 +579,7 @@ async fn get_started_since_returns_a_200_and_list_of_records() {
         },
         {
             let mut r = record.clone();
-            r.record_id = "r3".to_string();
+            r.record_id = ValidName::parse("r3".to_string()).unwrap();
             r.start_time = DateTime::parse_from_rfc3339("2022-03-03T12:00:00-00:00")
                 .unwrap()
                 .with_timezone(&Utc);
@@ -603,10 +612,13 @@ async fn get_started_since_returns_a_200_and_list_of_records() {
     let received_records = response.json::<Vec<Record>>().await.unwrap();
 
     for (record, received) in test_cases.iter().skip(1).zip(received_records.iter()) {
-        assert_eq!(record.record_id, received.record_id);
-        assert_eq!(record.site_id, *received.site_id.as_ref().unwrap());
-        assert_eq!(record.user_id, *received.user_id.as_ref().unwrap());
-        assert_eq!(record.group_id, *received.group_id.as_ref().unwrap());
+        assert_eq!(record.record_id.as_ref(), received.record_id);
+        assert_eq!(record.site_id.as_ref(), *received.site_id.as_ref().unwrap());
+        assert_eq!(record.user_id.as_ref(), *received.user_id.as_ref().unwrap());
+        assert_eq!(
+            record.group_id.as_ref(),
+            *received.group_id.as_ref().unwrap()
+        );
         assert_eq!(record.components, *received.components.as_ref().unwrap());
         assert_eq!(record.start_time, received.start_time);
         assert_eq!(
@@ -644,18 +656,18 @@ async fn get_stopped_since_returns_a_200_and_list_of_records() {
 
     // First send a couple of records
     let record = RecordAdd {
-        record_id: "hpc-1337".into(),
-        site_id: "cluster1".into(),
-        user_id: "user1".into(),
-        group_id: "group1".into(),
+        record_id: ValidName::parse("hpc-1337".into()).unwrap(),
+        site_id: ValidName::parse("cluster1".into()).unwrap(),
+        user_id: ValidName::parse("user1".into()).unwrap(),
+        group_id: ValidName::parse("group1".into()).unwrap(),
         components: vec![
             Component {
-                name: "CPU".into(),
+                name: ValidName::parse("CPU".into()).unwrap(),
                 amount: 10,
                 factor: 1.3,
             },
             Component {
-                name: "Memory".into(),
+                name: ValidName::parse("Memory".into()).unwrap(),
                 amount: 120,
                 factor: 1.0,
             },
@@ -673,7 +685,7 @@ async fn get_stopped_since_returns_a_200_and_list_of_records() {
     let test_cases = vec![
         {
             let mut r = record.clone();
-            r.record_id = "r1".to_string();
+            r.record_id = ValidName::parse("r1".to_string()).unwrap();
             r.stop_time = Some(
                 DateTime::parse_from_rfc3339("2022-03-01T13:00:00-00:00")
                     .unwrap()
@@ -683,7 +695,7 @@ async fn get_stopped_since_returns_a_200_and_list_of_records() {
         },
         {
             let mut r = record.clone();
-            r.record_id = "r2".to_string();
+            r.record_id = ValidName::parse("r2".to_string()).unwrap();
             r.stop_time = Some(
                 DateTime::parse_from_rfc3339("2022-03-02T13:00:00-00:00")
                     .unwrap()
@@ -693,7 +705,7 @@ async fn get_stopped_since_returns_a_200_and_list_of_records() {
         },
         {
             let mut r = record.clone();
-            r.record_id = "r3".to_string();
+            r.record_id = ValidName::parse("r3".to_string()).unwrap();
             r.stop_time = Some(
                 DateTime::parse_from_rfc3339("2022-03-03T13:00:00-00:00")
                     .unwrap()
@@ -728,10 +740,13 @@ async fn get_stopped_since_returns_a_200_and_list_of_records() {
     let received_records = response.json::<Vec<Record>>().await.unwrap();
 
     for (record, received) in test_cases.iter().skip(1).zip(received_records.iter()) {
-        assert_eq!(record.record_id, received.record_id);
-        assert_eq!(record.site_id, *received.site_id.as_ref().unwrap());
-        assert_eq!(record.user_id, *received.user_id.as_ref().unwrap());
-        assert_eq!(record.group_id, *received.group_id.as_ref().unwrap());
+        assert_eq!(record.record_id.as_ref(), received.record_id);
+        assert_eq!(record.site_id.as_ref(), *received.site_id.as_ref().unwrap());
+        assert_eq!(record.user_id.as_ref(), *received.user_id.as_ref().unwrap());
+        assert_eq!(
+            record.group_id.as_ref(),
+            *received.group_id.as_ref().unwrap()
+        );
         assert_eq!(record.components, *received.components.as_ref().unwrap());
         assert_eq!(record.start_time, received.start_time);
         assert_eq!(


### PR DESCRIPTION
Does not accept string identifiers which contain potentially harmful characters (`(`, `)`, `/`, `"`, `<`, `>`, `\`, `{`, `}`).