### PR TITLE
Validate amount and factor when deserializing, impl Fake for ComponentTest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -258,6 +258,7 @@ dependencies = [
  "once_cell",
  "quickcheck",
  "quickcheck_macros",
+ "rand 0.7.3",
  "reqwest",
  "secrecy",
  "serde 1.0.136",
@@ -588,6 +589,7 @@ version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6479fa2c7e83ddf8be7d435421e093b072ca891b99a49bc84eba098f4044f818"
 dependencies = [
+ "chrono",
  "rand 0.7.3",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,8 @@ tracing-log = "0.1"
 tracing-actix-web = "0.5"
 secrecy = { version = "0.8", features = ["serde"] }
 unicode-segmentation = "1"
+fake = { version = "~2.3", features = ["chrono"] }
+rand = "0.7"
 
 [dependencies.sqlx]
 version = "0.5.7"
@@ -43,6 +45,5 @@ features = [
 reqwest = { version = "0.11.10", features = ["json"] }
 once_cell = "1"
 claim = "0.5"
-fake = "~2.3"
 quickcheck = "0.9.2"
 quickcheck_macros = "0.9.1"

--- a/src/domain/component.rs
+++ b/src/domain/component.rs
@@ -1,4 +1,6 @@
-use super::ValidName;
+use super::{ValidAmount, ValidFactor, ValidName};
+use fake::{Dummy, Fake, Faker, StringFaker};
+use rand::Rng;
 use serde::{Deserialize, Serialize};
 use sqlx::postgres::PgHasArrayType;
 
@@ -6,8 +8,8 @@ use sqlx::postgres::PgHasArrayType;
 #[sqlx(type_name = "component")]
 pub struct Component {
     pub name: ValidName,
-    pub amount: i64,
-    pub factor: f64,
+    pub amount: ValidAmount,
+    pub factor: ValidFactor,
 }
 
 impl PgHasArrayType for Component {
@@ -16,9 +18,53 @@ impl PgHasArrayType for Component {
     }
 }
 
+impl TryFrom<ComponentTest> for Component {
+    type Error = String;
+
+    fn try_from(value: ComponentTest) -> Result<Self, Self::Error> {
+        Ok(Component {
+            name: ValidName::parse(value.name.ok_or_else(|| "name is None".to_string())?)?,
+            amount: ValidAmount::parse(value.amount.ok_or_else(|| "amount is None".to_string())?)?,
+            factor: ValidFactor::parse(value.factor.ok_or_else(|| "factor is None".to_string())?)?,
+        })
+    }
+}
+
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct ComponentTest {
     pub name: Option<String>,
     pub amount: Option<i64>,
     pub factor: Option<f64>,
+}
+
+impl Dummy<Faker> for ComponentTest {
+    fn dummy_with_rng<R: Rng + ?Sized>(_: &Faker, rng: &mut R) -> ComponentTest {
+        let name = StringFaker::with(
+            String::from("ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789*&^%$#@!~").into_bytes(),
+            1..256,
+        )
+        .fake_with_rng(rng);
+        ComponentTest {
+            name: Some(name),
+            amount: Some((0..i64::MAX).fake_with_rng(rng)),
+            factor: Some((0.0..f64::MAX).fake_with_rng(rng)),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use claim::assert_ok;
+
+    impl quickcheck::Arbitrary for ComponentTest {
+        fn arbitrary<G: quickcheck::Gen>(g: &mut G) -> Self {
+            Faker.fake_with_rng(g)
+        }
+    }
+
+    #[quickcheck_macros::quickcheck]
+    fn a_valid_name_is_parsed_successfully(component: ComponentTest) {
+        assert_ok!(Component::try_from(component));
+    }
 }

--- a/src/domain/mod.rs
+++ b/src/domain/mod.rs
@@ -1,7 +1,11 @@
 mod component;
 mod record;
+mod validamount;
+mod validfactor;
 mod validname;
 
 pub use component::{Component, ComponentTest};
 pub use record::{Record, RecordAdd, RecordTest, RecordUpdate};
+pub use validamount::ValidAmount;
+pub use validfactor::ValidFactor;
 pub use validname::ValidName;

--- a/src/domain/validamount.rs
+++ b/src/domain/validamount.rs
@@ -1,0 +1,101 @@
+use sqlx::{postgres::PgTypeInfo, Postgres, Type};
+use std::fmt;
+
+// never turn this into `ValidAmount(pub i64)`. By keeping the inner field private, it is not
+// possible to create this type outside of this module, hence enforcing the use of `parse`. This
+// ensures that every string stored in this type satisfies the validation criteria checked by
+// `parse`.
+#[derive(Debug, Clone, PartialEq, sqlx::Decode, sqlx::Encode)]
+pub struct ValidAmount(i64);
+
+impl ValidAmount {
+    /// Returns `ValidAmount` only if input satisfies validation criteria, otherwise panics.
+    pub fn parse(s: i64) -> Result<ValidAmount, String> {
+        if s < 0 {
+            Err(format!("Invalid amount: {}", s))
+        } else {
+            Ok(Self(s))
+        }
+    }
+}
+
+impl AsRef<i64> for ValidAmount {
+    fn as_ref(&self) -> &i64 {
+        &self.0
+    }
+}
+
+impl Type<Postgres> for ValidAmount {
+    fn type_info() -> PgTypeInfo {
+        <&i64 as Type<Postgres>>::type_info()
+    }
+
+    fn compatible(ty: &PgTypeInfo) -> bool {
+        <&i64 as Type<Postgres>>::compatible(ty)
+    }
+}
+
+impl serde::Serialize for ValidAmount {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_i64(self.0)
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for ValidAmount {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let buf = i64::deserialize(deserializer)?;
+        ValidAmount::parse(buf).map_err(serde::de::Error::custom)
+    }
+}
+
+impl fmt::Display for ValidAmount {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{:?}", self.0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::domain::ValidAmount;
+    use claim::{assert_err, assert_ok};
+    use fake::Fake;
+
+    #[derive(Debug, Clone)]
+    struct ValidAmountI64(pub i64);
+
+    impl quickcheck::Arbitrary for ValidAmountI64 {
+        fn arbitrary<G: quickcheck::Gen>(g: &mut G) -> Self {
+            Self((0..i64::MAX).fake_with_rng(g))
+        }
+    }
+
+    #[derive(Debug, Clone)]
+    struct InValidAmountI64(pub i64);
+
+    impl quickcheck::Arbitrary for InValidAmountI64 {
+        fn arbitrary<G: quickcheck::Gen>(g: &mut G) -> Self {
+            Self((i64::MIN..-1).fake_with_rng(g))
+        }
+    }
+
+    #[quickcheck_macros::quickcheck]
+    fn a_negative_amount_is_rejected(amount: InValidAmountI64) {
+        assert_err!(ValidAmount::parse(amount.0));
+    }
+
+    #[test]
+    fn a_zero_amount_is_valid() {
+        assert_ok!(ValidAmount::parse(0));
+    }
+
+    #[quickcheck_macros::quickcheck]
+    fn a_valid_amount_is_parsed_successfully(amount: ValidAmountI64) {
+        assert_ok!(ValidAmount::parse(amount.0));
+    }
+}

--- a/src/domain/validfactor.rs
+++ b/src/domain/validfactor.rs
@@ -1,0 +1,101 @@
+use sqlx::{postgres::PgTypeInfo, Postgres, Type};
+use std::fmt;
+
+// never turn this into `ValidFactor(pub f64)`. By keeping the inner field private, it is not
+// possible to create this type outside of this module, hence enforcing the use of `parse`. This
+// ensures that every string stored in this type satisfies the validation criteria checked by
+// `parse`.
+#[derive(Debug, Clone, PartialEq, sqlx::Decode, sqlx::Encode)]
+pub struct ValidFactor(f64);
+
+impl ValidFactor {
+    /// Returns `ValidFactor` only if input satisfies validation criteria, otherwise panics.
+    pub fn parse(s: f64) -> Result<ValidFactor, String> {
+        if s < 0.0 {
+            Err(format!("Invalid factor: {}", s))
+        } else {
+            Ok(Self(s))
+        }
+    }
+}
+
+impl AsRef<f64> for ValidFactor {
+    fn as_ref(&self) -> &f64 {
+        &self.0
+    }
+}
+
+impl Type<Postgres> for ValidFactor {
+    fn type_info() -> PgTypeInfo {
+        <&f64 as Type<Postgres>>::type_info()
+    }
+
+    fn compatible(ty: &PgTypeInfo) -> bool {
+        <&f64 as Type<Postgres>>::compatible(ty)
+    }
+}
+
+impl serde::Serialize for ValidFactor {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_f64(self.0)
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for ValidFactor {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let buf = f64::deserialize(deserializer)?;
+        ValidFactor::parse(buf).map_err(serde::de::Error::custom)
+    }
+}
+
+impl fmt::Display for ValidFactor {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{:?}", self.0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::domain::ValidFactor;
+    use claim::{assert_err, assert_ok};
+    use fake::Fake;
+
+    #[derive(Debug, Clone)]
+    struct ValidFactorF64(pub f64);
+
+    impl quickcheck::Arbitrary for ValidFactorF64 {
+        fn arbitrary<G: quickcheck::Gen>(g: &mut G) -> Self {
+            Self((0.0..f64::MAX).fake_with_rng(g))
+        }
+    }
+
+    #[derive(Debug, Clone)]
+    struct InValidFactorF64(pub f64);
+
+    impl quickcheck::Arbitrary for InValidFactorF64 {
+        fn arbitrary<G: quickcheck::Gen>(g: &mut G) -> Self {
+            Self((f64::MIN..-f64::EPSILON).fake_with_rng(g))
+        }
+    }
+
+    #[quickcheck_macros::quickcheck]
+    fn a_negative_factor_is_rejected(factor: InValidFactorF64) {
+        assert_err!(ValidFactor::parse(factor.0));
+    }
+
+    #[test]
+    fn a_zero_factor_is_valid() {
+        assert_ok!(ValidFactor::parse(0.0));
+    }
+
+    #[quickcheck_macros::quickcheck]
+    fn a_valid_factor_is_parsed_successfully(factor: ValidFactorF64) {
+        assert_ok!(ValidFactor::parse(factor.0));
+    }
+}

--- a/tests/health_check.rs
+++ b/tests/health_check.rs
@@ -122,18 +122,24 @@ async fn add_returns_a_200_for_valid_json_data() {
     assert_eq!(saved.user_id.unwrap(), "user1");
     assert_eq!(saved.group_id.unwrap(), "group1");
     assert_eq!(saved.components.as_ref().unwrap()[0].name.as_ref(), "CPU");
-    assert_eq!(saved.components.as_ref().unwrap()[0].amount, 10);
+    assert_eq!(*saved.components.as_ref().unwrap()[0].amount.as_ref(), 10);
     assert_eq!(
-        saved.components.as_ref().unwrap()[0].factor.to_ne_bytes(),
+        saved.components.as_ref().unwrap()[0]
+            .factor
+            .as_ref()
+            .to_ne_bytes(),
         1.3f64.to_ne_bytes()
     );
     assert_eq!(
         saved.components.as_ref().unwrap()[1].name.as_ref(),
         "Memory"
     );
-    assert_eq!(saved.components.as_ref().unwrap()[1].amount, 120);
+    assert_eq!(*saved.components.as_ref().unwrap()[1].amount.as_ref(), 120);
     assert_eq!(
-        saved.components.as_ref().unwrap()[1].factor.to_ne_bytes(),
+        saved.components.as_ref().unwrap()[1]
+            .factor
+            .as_ref()
+            .to_ne_bytes(),
         1.0f64.to_ne_bytes()
     );
     assert_eq!(saved.start_time.to_string(), "2022-03-01 12:00:00 UTC");
@@ -348,18 +354,24 @@ async fn update_returns_a_200_for_valid_form_data() {
     assert_eq!(saved.user_id.unwrap(), "user1");
     assert_eq!(saved.group_id.unwrap(), "group1");
     assert_eq!(saved.components.as_ref().unwrap()[0].name.as_ref(), "CPU");
-    assert_eq!(saved.components.as_ref().unwrap()[0].amount, 10);
+    assert_eq!(*saved.components.as_ref().unwrap()[0].amount.as_ref(), 10);
     assert_eq!(
-        saved.components.as_ref().unwrap()[0].factor.to_ne_bytes(),
+        saved.components.as_ref().unwrap()[0]
+            .factor
+            .as_ref()
+            .to_ne_bytes(),
         1.3f64.to_ne_bytes()
     );
     assert_eq!(
         saved.components.as_ref().unwrap()[1].name.as_ref(),
         "Memory"
     );
-    assert_eq!(saved.components.as_ref().unwrap()[1].amount, 120);
+    assert_eq!(*saved.components.as_ref().unwrap()[1].amount.as_ref(), 120);
     assert_eq!(
-        saved.components.as_ref().unwrap()[1].factor.to_ne_bytes(),
+        saved.components.as_ref().unwrap()[1]
+            .factor
+            .as_ref()
+            .to_ne_bytes(),
         1.0f64.to_ne_bytes()
     );
     assert_eq!(saved.start_time.to_string(), "2022-03-01 12:00:00 UTC");
@@ -437,7 +449,7 @@ async fn get_returns_a_200_and_list_of_records() {
         );
         assert_eq!(
             record.components.as_ref().unwrap()[0].amount.unwrap(),
-            received.components.as_ref().unwrap()[0].amount
+            *received.components.as_ref().unwrap()[0].amount.as_ref()
         );
         assert_eq!(
             record.components.as_ref().unwrap()[0]
@@ -446,6 +458,7 @@ async fn get_returns_a_200_and_list_of_records() {
                 .to_ne_bytes(),
             received.components.as_ref().unwrap()[0]
                 .factor
+                .as_ref()
                 .to_ne_bytes()
         );
         assert_eq!(
@@ -457,7 +470,7 @@ async fn get_returns_a_200_and_list_of_records() {
         );
         assert_eq!(
             record.components.as_ref().unwrap()[1].amount.unwrap(),
-            received.components.as_ref().unwrap()[1].amount
+            *received.components.as_ref().unwrap()[1].amount.as_ref()
         );
         assert_eq!(
             record.components.as_ref().unwrap()[1]
@@ -466,6 +479,7 @@ async fn get_returns_a_200_and_list_of_records() {
                 .to_ne_bytes(),
             received.components.as_ref().unwrap()[1]
                 .factor
+                .as_ref()
                 .to_ne_bytes()
         );
         assert_eq!(*record.start_time.as_ref().unwrap(), received.start_time);
@@ -572,7 +586,7 @@ async fn get_started_since_returns_a_200_and_list_of_records() {
         );
         assert_eq!(
             record.components.as_ref().unwrap()[0].amount.unwrap(),
-            received.components.as_ref().unwrap()[0].amount
+            *received.components.as_ref().unwrap()[0].amount.as_ref()
         );
         assert_eq!(
             record.components.as_ref().unwrap()[0]
@@ -581,6 +595,7 @@ async fn get_started_since_returns_a_200_and_list_of_records() {
                 .to_ne_bytes(),
             received.components.as_ref().unwrap()[0]
                 .factor
+                .as_ref()
                 .to_ne_bytes()
         );
         assert_eq!(
@@ -592,7 +607,7 @@ async fn get_started_since_returns_a_200_and_list_of_records() {
         );
         assert_eq!(
             record.components.as_ref().unwrap()[1].amount.unwrap(),
-            received.components.as_ref().unwrap()[1].amount
+            *received.components.as_ref().unwrap()[1].amount.as_ref()
         );
         assert_eq!(
             record.components.as_ref().unwrap()[1]
@@ -601,6 +616,7 @@ async fn get_started_since_returns_a_200_and_list_of_records() {
                 .to_ne_bytes(),
             received.components.as_ref().unwrap()[1]
                 .factor
+                .as_ref()
                 .to_ne_bytes()
         );
         assert_eq!(record.start_time.unwrap(), received.start_time);
@@ -710,7 +726,7 @@ async fn get_stopped_since_returns_a_200_and_list_of_records() {
         );
         assert_eq!(
             record.components.as_ref().unwrap()[0].amount.unwrap(),
-            received.components.as_ref().unwrap()[0].amount
+            *received.components.as_ref().unwrap()[0].amount.as_ref()
         );
         assert_eq!(
             record.components.as_ref().unwrap()[0]
@@ -719,6 +735,7 @@ async fn get_stopped_since_returns_a_200_and_list_of_records() {
                 .to_ne_bytes(),
             received.components.as_ref().unwrap()[0]
                 .factor
+                .as_ref()
                 .to_ne_bytes()
         );
         assert_eq!(
@@ -730,7 +747,7 @@ async fn get_stopped_since_returns_a_200_and_list_of_records() {
         );
         assert_eq!(
             record.components.as_ref().unwrap()[1].amount.unwrap(),
-            received.components.as_ref().unwrap()[1].amount
+            *received.components.as_ref().unwrap()[1].amount.as_ref()
         );
         assert_eq!(
             record.components.as_ref().unwrap()[1]
@@ -739,6 +756,7 @@ async fn get_stopped_since_returns_a_200_and_list_of_records() {
                 .to_ne_bytes(),
             received.components.as_ref().unwrap()[1]
                 .factor
+                .as_ref()
                 .to_ne_bytes()
         );
         assert_eq!(record.start_time.unwrap(), received.start_time);


### PR DESCRIPTION
Validates the input of `amount` and `factor` in `Components` during deserialization of the request's JSON data. `amount` and `factor` must be non-zero. In case of `amount` this could be achieved by using `u64` instead of `i64`; however, apparently there is no support for unsigned integers in Postgres. 

Also implements `Fake` for `ComponentTest` as a preparation for more concise tests.