### PR TITLE
Use `fake` to create `Records` in tests, impl PartialEq for `Records`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -50,7 +50,7 @@ dependencies = [
  "mime",
  "percent-encoding",
  "pin-project-lite",
- "rand 0.8.5",
+ "rand",
  "sha-1",
  "smallvec",
  "zstd",
@@ -193,7 +193,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
 dependencies = [
- "getrandom 0.2.6",
+ "getrandom",
  "once_cell",
  "version_check",
 ]
@@ -258,7 +258,7 @@ dependencies = [
  "once_cell",
  "quickcheck",
  "quickcheck_macros",
- "rand 0.7.3",
+ "rand",
  "reqwest",
  "secrecy",
  "serde 1.0.136",
@@ -569,9 +569,9 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.7.1"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44533bbbb3bb3c1fa17d9f2e4e38bbbaf8396ba82193c4cb1b6445d711445d36"
+checksum = "a19187fea3ac7e84da7dacf48de0c45d63c6a76f9490dae389aead16c243fce3"
 dependencies = [
  "log",
  "regex",
@@ -585,12 +585,12 @@ checksum = "77f3309417938f28bf8228fcff79a4a37103981e3e186d2ccd19c74b38f4eb71"
 
 [[package]]
 name = "fake"
-version = "2.3.0"
+version = "2.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6479fa2c7e83ddf8be7d435421e093b072ca891b99a49bc84eba098f4044f818"
+checksum = "21a8531dd3a64fd1cfbe92fad4160bc2060489c6195fe847e045e5788f710bae"
 dependencies = [
  "chrono",
- "rand 0.7.3",
+ "rand",
 ]
 
 [[package]]
@@ -721,17 +721,6 @@ checksum = "c1ebd34e35c46e00bb73e81363248d627782724609fe1b6396f553f68fe3862e"
 dependencies = [
  "libc",
  "winapi",
-]
-
-[[package]]
-name = "getrandom"
-version = "0.1.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
-dependencies = [
- "cfg-if",
- "libc",
- "wasi 0.9.0+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -1360,21 +1349,20 @@ dependencies = [
 
 [[package]]
 name = "quickcheck"
-version = "0.9.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a44883e74aa97ad63db83c4bf8ca490f02b2fc02f92575e720c8551e843c945f"
+checksum = "588f6378e4dd99458b60ec275b4477add41ce4fa9f64dcba6f15adccb19b50d6"
 dependencies = [
  "env_logger",
  "log",
- "rand 0.7.3",
- "rand_core 0.5.1",
+ "rand",
 ]
 
 [[package]]
 name = "quickcheck_macros"
-version = "0.9.1"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "608c156fd8e97febc07dc9c2e2c80bf74cfc6ef26893eae3daf8bc2bc94a4b7f"
+checksum = "b22a693222d716a9587786f37ac3f6b4faedb5b80c23914e7303ff5a1d8016e9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1392,36 +1380,13 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
-dependencies = [
- "getrandom 0.1.16",
- "libc",
- "rand_chacha 0.2.2",
- "rand_core 0.5.1",
- "rand_hc",
-]
-
-[[package]]
-name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha 0.3.1",
- "rand_core 0.6.3",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.5.1",
+ "rand_chacha",
+ "rand_core",
 ]
 
 [[package]]
@@ -1431,16 +1396,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.6.3",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
-dependencies = [
- "getrandom 0.1.16",
+ "rand_core",
 ]
 
 [[package]]
@@ -1449,16 +1405,7 @@ version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
 dependencies = [
- "getrandom 0.2.6",
-]
-
-[[package]]
-name = "rand_hc"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
-dependencies = [
- "rand_core 0.5.1",
+ "getrandom",
 ]
 
 [[package]]
@@ -1476,7 +1423,7 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
 dependencies = [
- "getrandom 0.2.6",
+ "getrandom",
  "redox_syscall",
  "thiserror",
 ]
@@ -1862,7 +1809,7 @@ dependencies = [
  "once_cell",
  "paste",
  "percent-encoding",
- "rand 0.8.5",
+ "rand",
  "rustls",
  "serde 1.0.136",
  "serde_json",
@@ -2299,7 +2246,7 @@ version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
 dependencies = [
- "getrandom 0.2.6",
+ "getrandom",
 ]
 
 [[package]]
@@ -2329,12 +2276,6 @@ dependencies = [
  "log",
  "try-lock",
 ]
-
-[[package]]
-name = "wasi"
-version = "0.9.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,8 +25,8 @@ tracing-log = "0.1"
 tracing-actix-web = "0.5"
 secrecy = { version = "0.8", features = ["serde"] }
 unicode-segmentation = "1"
-fake = { version = "~2.3", features = ["chrono"] }
-rand = "0.7"
+fake = { version = "2.4", features = ["chrono"] }
+rand = "0.8"
 
 [dependencies.sqlx]
 version = "0.5.7"
@@ -45,5 +45,5 @@ features = [
 reqwest = { version = "0.11.10", features = ["json"] }
 once_cell = "1"
 claim = "0.5"
-quickcheck = "0.9.2"
-quickcheck_macros = "0.9.1"
+quickcheck = "1"
+quickcheck_macros = "1"

--- a/src/domain/component.rs
+++ b/src/domain/component.rs
@@ -66,7 +66,7 @@ impl PartialEq<Component> for ComponentTest {
 
         s_name.as_ref().unwrap() == o_name.as_ref()
             && s_amount.as_ref().unwrap() == o_amount.as_ref()
-            && (diff < f64::EPSILON || diff < biggest * f64::EPSILON)
+            && (diff < f64::EPSILON || diff < biggest * f64::EPSILON.sqrt())
     }
 }
 

--- a/src/domain/record.rs
+++ b/src/domain/record.rs
@@ -2,6 +2,10 @@
 
 use super::{Component, ComponentTest, ValidName};
 use chrono::{DateTime, Utc};
+use fake::{Dummy, Fake, Faker, StringFaker};
+#[cfg(test)]
+use quickcheck;
+use rand::Rng;
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
@@ -102,5 +106,106 @@ impl RecordTest {
                 .with_timezone(&Utc),
         );
         self
+    }
+}
+
+impl Dummy<Faker> for RecordTest {
+    fn dummy_with_rng<R: Rng + ?Sized>(_: &Faker, rng: &mut R) -> RecordTest {
+        let fakename = || -> String {
+            StringFaker::with(
+                String::from("ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789*&^%$#@!~").into_bytes(),
+                1..256,
+            )
+            .fake()
+        };
+        let fakeamount = || (0..i64::MAX).fake();
+        let fakefactor = || (0.0..f64::MAX).fake();
+        let fakedate = || -> DateTime<Utc> { Faker.fake() };
+
+        let mut out = RecordTest::new()
+            .with_record_id(fakename())
+            .with_site_id(fakename())
+            .with_user_id(fakename())
+            .with_group_id(fakename())
+            .with_start_time(fakedate().to_rfc3339())
+            .with_stop_time(fakedate().to_rfc3339());
+        for _ in 0..(1..10).fake_with_rng(rng) {
+            out = out.with_component(fakename(), fakeamount(), fakefactor());
+        }
+        out
+    }
+}
+
+impl PartialEq<Record> for RecordTest {
+    fn eq(&self, other: &Record) -> bool {
+        let RecordTest {
+            record_id: s_rid,
+            site_id: s_sid,
+            user_id: s_uid,
+            group_id: s_gid,
+            components: s_comp,
+            start_time: s_start,
+            stop_time: s_stop,
+        } = self;
+        let Record {
+            record_id: o_rid,
+            site_id: o_sid,
+            user_id: o_uid,
+            group_id: o_gid,
+            components: o_comp,
+            start_time: o_start,
+            stop_time: o_stop,
+            runtime: _,
+        } = other;
+
+        // Can't be equal if record ID and start_time are not set in `RecordTest`.
+        if s_rid.is_none() || s_start.is_none() {
+            return false;
+        }
+
+        let s_start = s_start.as_ref().unwrap();
+
+        let start_diff = if s_start > o_start {
+            *s_start - *o_start
+        } else {
+            *o_start - *s_start
+        };
+
+        let s_stop = s_stop.as_ref().unwrap();
+        let o_stop = o_stop.as_ref().unwrap();
+
+        let stop_diff = if s_stop > o_stop {
+            *s_stop - *o_stop
+        } else {
+            *o_stop - *s_stop
+        };
+
+        s_rid.as_ref().unwrap() == o_rid
+            && s_sid == o_sid
+            && s_uid == o_uid
+            && s_gid == o_gid
+            && start_diff < chrono::Duration::milliseconds(1)
+            && stop_diff < chrono::Duration::milliseconds(1)
+            && ((s_comp.is_none() && o_comp.is_none())
+                || (s_comp.as_ref().unwrap().len() == o_comp.as_ref().unwrap().len()
+                    && s_comp
+                        .as_ref()
+                        .unwrap()
+                        .iter()
+                        .zip(o_comp.as_ref().unwrap().iter())
+                        .fold(true, |acc, (a, b)| acc && (a == b))))
+    }
+}
+
+impl PartialEq<RecordTest> for Record {
+    fn eq(&self, other: &RecordTest) -> bool {
+        other.eq(self)
+    }
+}
+
+#[cfg(test)]
+impl quickcheck::Arbitrary for RecordTest {
+    fn arbitrary(_g: &mut quickcheck::Gen) -> Self {
+        Faker.fake()
     }
 }

--- a/src/domain/validamount.rs
+++ b/src/domain/validamount.rs
@@ -70,8 +70,8 @@ mod tests {
     struct ValidAmountI64(pub i64);
 
     impl quickcheck::Arbitrary for ValidAmountI64 {
-        fn arbitrary<G: quickcheck::Gen>(g: &mut G) -> Self {
-            Self((0..i64::MAX).fake_with_rng(g))
+        fn arbitrary(_g: &mut quickcheck::Gen) -> Self {
+            Self((0..i64::MAX).fake())
         }
     }
 
@@ -79,8 +79,8 @@ mod tests {
     struct InValidAmountI64(pub i64);
 
     impl quickcheck::Arbitrary for InValidAmountI64 {
-        fn arbitrary<G: quickcheck::Gen>(g: &mut G) -> Self {
-            Self((i64::MIN..-1).fake_with_rng(g))
+        fn arbitrary(_g: &mut quickcheck::Gen) -> Self {
+            Self((i64::MIN..-1).fake())
         }
     }
 

--- a/src/domain/validfactor.rs
+++ b/src/domain/validfactor.rs
@@ -70,8 +70,8 @@ mod tests {
     struct ValidFactorF64(pub f64);
 
     impl quickcheck::Arbitrary for ValidFactorF64 {
-        fn arbitrary<G: quickcheck::Gen>(g: &mut G) -> Self {
-            Self((0.0..f64::MAX).fake_with_rng(g))
+        fn arbitrary(_g: &mut quickcheck::Gen) -> Self {
+            Self((0.0..f64::MAX).fake())
         }
     }
 
@@ -79,12 +79,12 @@ mod tests {
     struct InValidFactorF64(pub f64);
 
     impl quickcheck::Arbitrary for InValidFactorF64 {
-        fn arbitrary<G: quickcheck::Gen>(g: &mut G) -> Self {
-            Self((f64::MIN..-f64::EPSILON).fake_with_rng(g))
+        fn arbitrary(_g: &mut quickcheck::Gen) -> Self {
+            Self((f64::MIN..-f64::EPSILON).fake())
         }
     }
 
-    #[quickcheck_macros::quickcheck]
+    #[quickcheck]
     fn a_negative_factor_is_rejected(factor: InValidFactorF64) {
         assert_err!(ValidFactor::parse(factor.0));
     }
@@ -94,7 +94,7 @@ mod tests {
         assert_ok!(ValidFactor::parse(0.0));
     }
 
-    #[quickcheck_macros::quickcheck]
+    #[quickcheck]
     fn a_valid_factor_is_parsed_successfully(factor: ValidFactorF64) {
         assert_ok!(ValidFactor::parse(factor.0));
     }

--- a/src/domain/validname.rs
+++ b/src/domain/validname.rs
@@ -78,12 +78,12 @@ mod tests {
     struct ValidNameString(pub String);
 
     impl quickcheck::Arbitrary for ValidNameString {
-        fn arbitrary<G: quickcheck::Gen>(g: &mut G) -> Self {
+        fn arbitrary(_g: &mut quickcheck::Gen) -> Self {
             let name = StringFaker::with(
                 String::from("ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789*&^%$#@!~").into_bytes(),
                 1..256,
             )
-            .fake_with_rng::<String, G>(g);
+            .fake();
             Self(name)
         }
     }
@@ -120,10 +120,8 @@ mod tests {
         }
     }
 
-    // #[test]
-    #[quickcheck_macros::quickcheck]
+    #[quickcheck]
     fn a_valid_name_is_parsed_successfully(name: ValidNameString) {
-        // dbg!(&name.0);
         assert_ok!(ValidName::parse(name.0));
     }
 }

--- a/src/domain/validname.rs
+++ b/src/domain/validname.rs
@@ -80,7 +80,10 @@ mod tests {
     impl quickcheck::Arbitrary for ValidNameString {
         fn arbitrary(_g: &mut quickcheck::Gen) -> Self {
             let name = StringFaker::with(
-                String::from("ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789*&^%$#@!~").into_bytes(),
+                String::from(
+                    "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789*&^%$#@!~",
+                )
+                .into_bytes(),
                 1..256,
             )
             .fake();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,7 @@
+#[cfg(test)]
+#[macro_use(quickcheck)]
+extern crate quickcheck_macros;
+
 pub mod configuration;
 pub mod domain;
 pub mod routes;


### PR DESCRIPTION
Prepared the code to allow one to create Records via `fake` instead of manually. Also implemented `PartialEq` where necessary for easier comparison in tests.

Tried to use quickcheck on tests but failed due to tests being `async`. I managed to get it to work with `block_on` of `tokio`, but then the TRACING static somehow breaks (claims it was poisoned). Instead tests now run 100 times with different (fake) data.