### PR TITLE
Adapted Python AuditorClient to new interface

### DIFF
--- a/client/auditorclient/client.py
+++ b/client/auditorclient/client.py
@@ -157,8 +157,14 @@ class AuditorClient:
         ) as response:
             return await response.json()
 
-    async def get_since(self, timestamp: str) -> dict:
+    async def get_started_since(self, timestamp: str) -> dict:
         async with self._session.get(
-            f"http://{self._host}:{self._port}/get/since/{timestamp}"
+            f"http://{self._host}:{self._port}/get/started/since/{timestamp}"
+        ) as response:
+            return await response.json()
+
+    async def get_stopped_since(self, timestamp: str) -> dict:
+        async with self._session.get(
+            f"http://{self._host}:{self._port}/get/stopped/since/{timestamp}"
         ) as response:
             return await response.json()

--- a/client/tests/test_client.py
+++ b/client/tests/test_client.py
@@ -104,11 +104,19 @@ class TestAuditorClient(IsolatedAsyncioTestCase):
         self.assertEqual(response, self.get_response)
 
         mocked.get(
-            "http://localhost:8080/get/since/2021-06-08T00:00:00.000000Z",
+            "http://localhost:8080/get/started/since/2021-06-08T00:00:00.000000Z",
             status=200,
             body=json.dumps(self.get_response),
         )
-        response = await client.get_since("2021-06-08T00:00:00.000000Z")
+        response = await client.get_started_since("2021-06-08T00:00:00.000000Z")
+        self.assertEqual(response, self.get_response)
+
+        mocked.get(
+            "http://localhost:8080/get/stopped/since/2021-06-08T00:00:00.000000Z",
+            status=200,
+            body=json.dumps(self.get_response),
+        )
+        response = await client.get_stopped_since("2021-06-08T00:00:00.000000Z")
         self.assertEqual(response, self.get_response)
 
         mocked.post("http://localhost:8080/add", status=409, body="test")


### PR DESCRIPTION
Changes the `get_since` method to `get_started_since` and `get_stopped_since`.