### PR TITLE
make computed resource available in commands in priority plugin

### DIFF
--- a/containers/docker-centos7-slurm/plugin_config.yaml
+++ b/containers/docker-centos7-slurm/plugin_config.yaml
@@ -14,7 +14,8 @@ group_mapping:
     - "part3"
   group4:
     - "part4"
-  ## this one has no records.
+  ## group 5 deliberately does not exist
+  ## group 6 has no records.
   group6:
     - "part6"
 command: "/usr/bin/scontrol update PartitionName={1} PriorityJobFactor={priority}"

--- a/src/domain/component.rs
+++ b/src/domain/component.rs
@@ -14,7 +14,7 @@ use sqlx::{
     Postgres, Type,
 };
 
-#[derive(Debug, PartialEq, Serialize, Deserialize, sqlx::Encode, Clone)]
+#[derive(Debug, PartialEq, Eq, Serialize, Deserialize, sqlx::Encode, Clone)]
 #[sqlx(type_name = "component")]
 pub struct Component {
     pub name: ValidName,

--- a/src/domain/validamount.rs
+++ b/src/domain/validamount.rs
@@ -12,7 +12,7 @@ use std::fmt;
 // possible to create this type outside of this module, hence enforcing the use of `parse`. This
 // ensures that every string stored in this type satisfies the validation criteria checked by
 // `parse`.
-#[derive(Debug, Clone, PartialEq, sqlx::Decode, sqlx::Encode)]
+#[derive(Debug, Clone, PartialEq, Eq, sqlx::Decode, sqlx::Encode)]
 pub struct ValidAmount(i64);
 
 impl ValidAmount {

--- a/src/domain/validname.rs
+++ b/src/domain/validname.rs
@@ -13,7 +13,7 @@ use unicode_segmentation::UnicodeSegmentation;
 // possible to create this type outside of this module, hence enforcing the use of `parse`. This
 // ensures that every string stored in this type satisfies the validation criteria checked by
 // `parse`.
-#[derive(Debug, Clone, PartialEq, sqlx::Type)]
+#[derive(Debug, Clone, PartialEq, Eq, sqlx::Type)]
 #[sqlx(transparent)]
 pub struct ValidName(String);
 

--- a/src/plugins/priority/main.rs
+++ b/src/plugins/priority/main.rs
@@ -18,8 +18,13 @@ use tracing::{debug, error, info, warn};
 
 mod configuration;
 
+type ResourceName = String;
+type ResourceValue = f64;
+type PriorityName = String;
+type PriorityValue = i64;
+
 #[tracing::instrument(name = "Extracting resources from records", skip(records, config))]
-fn extract(records: Vec<Record>, config: &Settings) -> HashMap<String, f64> {
+fn extract(records: Vec<Record>, config: &Settings) -> HashMap<ResourceName, ResourceValue> {
     if config.components.is_empty() {
         warn!(concat!(
             "Not configured how to extract metrics to account for ",
@@ -116,7 +121,10 @@ fn extract(records: Vec<Record>, config: &Settings) -> HashMap<String, f64> {
 }
 
 #[tracing::instrument(name = "Computing priorities", skip(config))]
-fn compute_priorities(resources: HashMap<String, f64>, config: &Settings) -> HashMap<String, i64> {
+fn compute_priorities(
+    resources: &HashMap<ResourceName, ResourceValue>,
+    config: &Settings,
+) -> HashMap<PriorityName, PriorityValue> {
     let (v_min, v_max) = resources.iter().fold(
         (f64::INFINITY, f64::NEG_INFINITY),
         |(cur_min, cur_max), (_, v)| {
@@ -131,10 +139,10 @@ fn compute_priorities(resources: HashMap<String, f64>, config: &Settings) -> Has
     let min_priority = f64::from_u64(config.min_priority).unwrap();
 
     resources
-        .into_iter()
+        .iter()
         .map(|(k, v)| {
             (
-                k,
+                k.clone(),
                 ((v - v_min) / (v_max - v_min) * (max_priority - min_priority) + min_priority)
                     .round() as i64,
             )
@@ -146,11 +154,13 @@ fn compute_priorities(resources: HashMap<String, f64>, config: &Settings) -> Has
 fn construct_command(
     cmd: &[String],
     priority: i64,
+    resource: f64,
     group: &String,
     params: &[String],
 ) -> Vec<String> {
     cmd.iter()
         .map(|c| c.replace("{priority}", &format!("{}", priority)))
+        .map(|c| c.replace("{resource}", &format!("{}", resource)))
         .map(|c| c.replace("{group}", group))
         .map(|c| {
             let mut cc = c;
@@ -163,13 +173,18 @@ fn construct_command(
 }
 
 #[tracing::instrument(name = "Setting priorities", skip(config))]
-fn set_priorities(priorities: HashMap<String, i64>, config: &Settings) -> Result<(), Error> {
+fn set_priorities(
+    priorities: &HashMap<PriorityName, PriorityValue>,
+    resources: &HashMap<ResourceName, ResourceValue>,
+    config: &Settings,
+) -> Result<(), Error> {
     for command in config.commands.iter() {
         let command = shell_words::split(command)?;
         for (group, params) in config.group_mapping.iter() {
             // Only set priority if group actually exists.
             if let Some(prio) = priorities.get(group) {
-                let command = construct_command(&command.clone(), *prio, group, params);
+                let resource = resources.get(group).unwrap();
+                let command = construct_command(&command.clone(), *prio, *resource, group, params);
 
                 let mut cmd = Command::new(&command[0]);
                 cmd.args(&command[1..]);
@@ -186,8 +201,6 @@ fn set_priorities(priorities: HashMap<String, i64>, config: &Settings) -> Result
                 if !status.success() {
                     error!("Setting priority failed!");
                 }
-                // let output = std::str::from_utf8(&cmd_run.stdout)?;
-                // info!(command_output = %output, "Command output");
             }
         }
     }
@@ -217,10 +230,11 @@ async fn main() -> Result<(), Error> {
         None => client.get().await?,
     };
 
-    set_priorities(
-        compute_priorities(extract(records, &config), &config),
-        &config,
-    )?;
+    let resources = extract(records, &config);
+
+    let priorities = compute_priorities(&resources, &config);
+
+    set_priorities(&priorities, &resources, &config)?;
 
     Ok(())
 }
@@ -247,7 +261,7 @@ mod tests {
             duration: None,
         };
 
-        let prios = compute_priorities(resources, &config);
+        let prios = compute_priorities(&resources, &config);
 
         assert_eq!(*prios.get("blah1").unwrap(), 1i64);
         assert_eq!(*prios.get("blah2").unwrap(), 6i64);
@@ -262,18 +276,21 @@ mod tests {
             "PartitionName={1}".to_string(),
             "PriorityFactor={priority}".to_string(),
             "SomeGroup={group}".to_string(),
+            "SomeResourceStuff={resource}".to_string(),
             "SomethingElse={2}".to_string(),
         ];
         let priority = 10i64;
         let group = "atlas".to_string();
         let params = vec!["some_partition".to_string(), "blah".to_string()];
+        let resource = 1.2;
 
-        let cmd = construct_command(&cmd, priority, &group, &params);
+        let cmd = construct_command(&cmd, priority, resource, &group, &params);
         assert_eq!(cmd[0], "/usr/bin/scontrol");
         assert_eq!(cmd[1], "update");
         assert_eq!(cmd[2], "PartitionName=some_partition");
         assert_eq!(cmd[3], "PriorityFactor=10");
         assert_eq!(cmd[4], "SomeGroup=atlas");
-        assert_eq!(cmd[5], "SomethingElse=blah");
+        assert_eq!(cmd[5], "SomeResourceStuff=1.2");
+        assert_eq!(cmd[6], "SomethingElse=blah");
     }
 }


### PR DESCRIPTION
Allows to use `{resource}` in commands to allow one to do something with the computed raw values. 