### PR TITLE
Support multiple priority computation modes in priority plugin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -379,9 +379,9 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "bytes"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
+checksum = "f0b3de4a0c5e67e16066a0715723abd91edc2f9001d09c46e1dca929351e130e"
 
 [[package]]
 name = "bytestring"
@@ -501,9 +501,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-queue"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f25d8400f4a7a5778f0e4e52384a48cbd9b5c495d110786187fc750075277a2"
+checksum = "1cd42583b04998a5363558e5f9291ee5a5ff6b49944332103f251e7479a82aa7"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
@@ -511,9 +511,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.10"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d82ee10ce34d7bc12c2122495e7593a9c41347ecdd64185af4ecf72cb1a7f83"
+checksum = "51887d4adc7b564537b15adcfb307936f8075dfcd5f00dde9a9f1d29383682bc"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -1397,9 +1397,9 @@ checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.40"
+version = "1.0.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd96a1e8ed2596c337f8eae5f24924ec83f5ad5ab21ea8e455d3566c69fbcaf7"
+checksum = "cdcc2916cde080c1876ff40292a396541241fe0072ef928cd76582e9ea5d60d2"
 dependencies = [
  "unicode-ident",
 ]
@@ -1467,9 +1467,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.13"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62f25bc4c7e55e0b0b7a1d43fb893f4fa1361d0abe38b9ce4f323c2adfe6ef42"
+checksum = "534cfe58d6a18cc17120fbf4635d53d14691c1fe4d951064df9bd326178d7d5a"
 dependencies = [
  "bitflags",
 ]
@@ -1830,9 +1830,12 @@ dependencies = [
 
 [[package]]
 name = "slab"
-version = "0.4.6"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb703cfe953bccee95685111adeedb76fabe4e97549a58d16f03ea7b9367bb32"
+checksum = "4614a76b2a8be0058caa9dbbaf66d988527d86d003c11a94fbd335d7661edcef"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "smallvec"
@@ -2595,9 +2598,9 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.5.6"
+version = "1.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20b578acffd8516a6c3f2a1bdefc1ec37e547bb4e0fb8b6b01a4cafc886b4442"
+checksum = "c394b5bd0c6f669e7275d9c20aa90ae064cb22e75a1cad54e1b34088034b149f"
 
 [[package]]
 name = "zstd"

--- a/containers/docker-centos7-slurm/plugin_config_fullspread.yaml
+++ b/containers/docker-centos7-slurm/plugin_config_fullspread.yaml
@@ -5,6 +5,7 @@ components:
   NumCPUs: "HEPSPEC"
 min_priority: 1
 max_priority: 65335
+computation_mode: FullSpread
 group_mapping:
   group1: 
     - "part1"
@@ -18,4 +19,5 @@ group_mapping:
   ## group 6 has no records.
   group6:
     - "part6"
-command: "/usr/bin/scontrol update PartitionName={1} PriorityJobFactor={priority}"
+command:
+  - "/usr/bin/scontrol update PartitionName={1} PriorityJobFactor={priority}"

--- a/containers/docker-centos7-slurm/plugin_config_scaledbysum.yaml
+++ b/containers/docker-centos7-slurm/plugin_config_scaledbysum.yaml
@@ -1,0 +1,23 @@
+addr: "host.docker.internal"
+port: 8000
+record_prefix: "slurm"
+components:
+  NumCPUs: "HEPSPEC"
+min_priority: 1
+max_priority: 65335
+computation_mode: ScaledBySum
+group_mapping:
+  group1: 
+    - "part1"
+  group2:
+    - "part2"
+  group3:
+    - "part3"
+  group4:
+    - "part4"
+  ## group 5 deliberately does not exist
+  ## group 6 has no records.
+  group6:
+    - "part6"
+command:
+  - "/usr/bin/scontrol update PartitionName={1} PriorityJobFactor={priority}"

--- a/src/plugins/priority/configuration.rs
+++ b/src/plugins/priority/configuration.rs
@@ -9,6 +9,12 @@ use chrono::Duration;
 use serde_aux::field_attributes::deserialize_number_from_string;
 use std::collections::HashMap;
 
+#[derive(serde::Deserialize, Debug, Clone)]
+pub enum ComputationMode {
+    FullSpread,
+    ScaledBySum,
+}
+
 #[serde_with::serde_as]
 #[derive(serde::Deserialize, Debug, Clone)]
 pub struct Settings {
@@ -29,6 +35,8 @@ pub struct Settings {
     pub commands: Vec<String>,
     #[serde_as(as = "Option<serde_with::DurationSeconds<i64>>")]
     pub duration: Option<Duration>,
+    #[serde(default = "default_computation_mode")]
+    pub computation_mode: ComputationMode,
 }
 
 fn default_addr() -> String {
@@ -49,6 +57,10 @@ fn default_max_priority() -> u64 {
 
 fn default_command() -> Vec<String> {
     vec!["/usr/bin/scontrol update PartitionName={1} PriorityJobFactor={priority}".to_string()]
+}
+
+fn default_computation_mode() -> ComputationMode {
+    ComputationMode::ScaledBySum
 }
 
 /// Loads the configuration from a file `configuration.{yaml,json,toml,...}`


### PR DESCRIPTION
computation modes can be configured in config. Currently there are two:

* `FullSpread` will spread the computed provided resources over the entire range the priority is configured in `(min_priority, max_priority)`. This will use the configured range to the full extent, but may cause heavy jumps in the computed priority from one run of the plugin to the other.
*  `ScaledBySum`: `max_priority` is equal to the sum of all provided resources. This leads to generally lower priority for all groups, but should lead to a smoother behaviour. A single group can only reach `max_priority` if the other groups provided no resources.