### PR TITLE
Fix parsing of scontrol output in slurm epilog collector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Correctly parse scontrol output in slurm epilog collector (Thanks to Raphael Kleinemuehl for the hint!) ([@stefan-k](https://github.com/stefan-k)).
 
 ## [0.0.1] - 2022-07-26
 ### Added

--- a/src/collectors/slurm_epilog/main.rs
+++ b/src/collectors/slurm_epilog/main.rs
@@ -39,9 +39,12 @@ fn get_slurm_job_info(job_id: u64) -> Result<Job, Error> {
             .stdout,
     )?
     .split_whitespace()
-    .map(|s| {
-        let t = s.split('=').take(2).collect::<Vec<_>>();
-        (t[0].to_string(), t[1].to_string())
+    .filter_map(|s| {
+        if let Some((k, v)) = s.split_once('=') {
+            Some((k.to_string(), v.to_string()))
+        } else {
+            None
+        }
     })
     .collect())
 }


### PR DESCRIPTION
The previous implementation assumed that the output of scontrol would consist only of key-value pairs of the form `key=value`. As pointed out by Raphael Kleinemuehl, this is not necessarily the case. Also, cases where `key=something=blah` where also parsed wrong, leading to `(key, something)`, ignoring `=blah`. This is fixed in this commit. Strings not containing an `=` are ignored and `key=v1=v2` is correctly parsed to `(key, v1=v2)`.