### PR TITLE
Added logging spans with unique id for plugin and collector.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Logging spans with unique id for priority plugin and slurm epilog collector (helps differentiate different runs in logs) ([@stefan-k](https://github.com/stefan-k)).
+
 ## [0.0.2] - 2022-08-01
 ### Added
 - Documentation of priority plugin on website ([@stefan-k](https://github.com/stefan-k)).

--- a/src/collectors/slurm_epilog/main.rs
+++ b/src/collectors/slurm_epilog/main.rs
@@ -17,6 +17,7 @@ use std::env;
 use std::fmt;
 use std::process::Command;
 use tracing::{debug, info};
+use uuid::Uuid;
 
 mod configuration;
 
@@ -122,7 +123,12 @@ async fn main() -> Result<(), Error> {
     );
     init_subscriber(subscriber);
 
-    info!("AUDITOR-slurm-epilog-collector started.");
+    let run_id = Uuid::new_v4();
+    let span = tracing::info_span!(
+        "Running slurm epilog collector",
+        %run_id,
+    );
+    let _span_guard = span.enter();
 
     let config = configuration::get_configuration()?;
 

--- a/src/plugins/priority/main.rs
+++ b/src/plugins/priority/main.rs
@@ -14,7 +14,8 @@ use configuration::{ComputationMode, Settings};
 use num_traits::cast::FromPrimitive;
 use std::collections::HashMap;
 use std::process::Command;
-use tracing::{debug, error, info, warn};
+use tracing::{debug, error, warn};
+use uuid::Uuid;
 
 mod configuration;
 
@@ -229,7 +230,12 @@ async fn main() -> Result<(), Error> {
     );
     init_subscriber(subscriber);
 
-    info!("AUDITOR-priority-plugin started.");
+    let run_id = Uuid::new_v4();
+    let span = tracing::info_span!(
+        "Running priority plugin",
+        %run_id,
+    );
+    let _span_guard = span.enter();
 
     let config = configuration::get_configuration()?;
 


### PR DESCRIPTION
With this different runs of the priority plugin and the slurm epilog collector can be differentiated in the logs.

Fixes #44