### PR TITLE
Use older versions of the pyo3 dependencies to support Python 3.6

### DIFF
--- a/.github/workflows/pyauditor.yml
+++ b/.github/workflows/pyauditor.yml
@@ -23,7 +23,7 @@ jobs:
           target: x86_64
           manylinux: auto
           command: build
-          args: --release --sdist -o dist --interpreter python3.7 python3.8 python3.9 python3.10 --manifest-path pyauditor/Cargo.toml
+          args: --release --sdist -o dist --interpreter python3.6 python3.7 python3.8 python3.9 python3.10 --manifest-path pyauditor/Cargo.toml
 
       - name: Upload wheels
         uses: actions/upload-artifact@v2
@@ -61,6 +61,7 @@ jobs:
       - uses: messense/maturin-action@v1
         with:
           command: build
+          # Note: No python3.6 on Windows!
           args: --release -o dist --interpreter python3.7 python3.8 python3.9 python3.10 --manifest-path pyauditor/Cargo.toml
       - name: Upload wheels
         uses: actions/upload-artifact@v2
@@ -90,7 +91,7 @@ jobs:
       - uses: messense/maturin-action@v1
         with:
           command: build
-          args: --release -o dist --universal2 --interpreter python3.7 python3.8 python3.9 python3.10 --manifest-path pyauditor/Cargo.toml
+          args: --release -o dist --universal2 --interpreter python3.6 python3.7 python3.8 python3.9 python3.10 --manifest-path pyauditor/Cargo.toml
       - name: Upload wheels
         uses: actions/upload-artifact@v2
         with:

--- a/pyauditor/Cargo.toml
+++ b/pyauditor/Cargo.toml
@@ -27,8 +27,8 @@ crate-type = ["cdylib"]
 [dependencies]
 auditor = { path = "../auditor", version = "0.0.4" }
 anyhow = "1"
-pyo3 = { version = "0.16.6", features = ["extension-module", "anyhow"] }
-pyo3-asyncio = { version = "0.16", features = ["attributes", "tokio-runtime"] }
+pyo3 = { version = "0.15.2", features = ["extension-module", "anyhow"] }
+pyo3-asyncio = { version = "0.15", features = ["attributes", "tokio-runtime"] }
 tokio = "1"
 chrono = { version = "0.4.22", features = ["serde"] }
-pyo3-chrono = { version = "0.4.0", features = [] }
+pyo3-chrono = { version = "0.3.0", features = [] }

--- a/pyauditor/pyproject.toml
+++ b/pyauditor/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "python-auditor"
-requires-python = ">=3.7"
+requires-python = ">=3.6"
 authors = [
     { name = "Stefan Kroboth", email = "stefan.kroboth@gmail.com" }
 ]


### PR DESCRIPTION
Downgrades pyo3 libraries to enable building python3.6 wheels which are needed for TARDIS. Does unfortunately not work for windows builds because the python3.6 interpreter is not available in the `windows-latest` CI image.