### PR TITLE
Add documenation for the rust client

### DIFF
--- a/auditor/src/client/mod.rs
+++ b/auditor/src/client/mod.rs
@@ -102,17 +102,6 @@ pub struct AuditorClient {
 
 impl AuditorClient {
 
-    pub fn from_connection_string<T: AsRef<str>>(
-        connection_string: &T,
-    ) -> Result<AuditorClient, reqwest::Error> {
-        Ok(AuditorClient {
-            address: connection_string.as_ref().into(),
-            client: reqwest::ClientBuilder::new()
-                .user_agent(APP_USER_AGENT)
-                .build()?,
-        })
-    }
-
     #[tracing::instrument(name = "Checking health of AUDITOR server.", skip(self))]
     pub async fn health_check(&self) -> bool {
         match self
@@ -364,7 +353,10 @@ mod tests {
     #[tokio::test]
     async fn get_succeeds() {
         let mock_server = MockServer::start().await;
-        let client = AuditorClient::from_connection_string(&mock_server.uri()).unwrap();
+        let client = AuditorClientBuilder::new()
+            .connection_string(&mock_server.uri())
+            .build()
+            .unwrap();
 
         let body: Vec<Record> = vec![record()];
 
@@ -417,7 +409,10 @@ mod tests {
     #[tokio::test]
     async fn health_check_succeeds() {
         let mock_server = MockServer::start().await;
-        let client = AuditorClient::from_connection_string(&mock_server.uri()).unwrap();
+        let client = AuditorClientBuilder::new()
+            .connection_string(&mock_server.uri())
+            .build()
+            .unwrap();
 
         Mock::given(method("GET"))
             .and(path("/health_check"))
@@ -554,7 +549,10 @@ mod tests {
     #[tokio::test]
     async fn add_succeeds() {
         let mock_server = MockServer::start().await;
-        let client = AuditorClient::from_connection_string(&mock_server.uri()).unwrap();
+        let client = AuditorClientBuilder::new()
+            .connection_string(&mock_server.uri())
+            .build()
+            .unwrap();
 
         let record: RecordAdd = record();
 
@@ -599,7 +597,10 @@ mod tests {
     #[tokio::test]
     async fn add_fails_on_existing_record() {
         let mock_server = MockServer::start().await;
-        let client = AuditorClient::from_connection_string(&mock_server.uri()).unwrap();
+        let client = AuditorClientBuilder::new()
+            .connection_string(&mock_server.uri())
+            .build()
+            .unwrap();
 
         let record: RecordAdd = record();
 
@@ -639,7 +640,10 @@ mod tests {
     #[tokio::test]
     async fn update_succeeds() {
         let mock_server = MockServer::start().await;
-        let client = AuditorClient::from_connection_string(&mock_server.uri()).unwrap();
+        let client = AuditorClientBuilder::new()
+            .connection_string(&mock_server.uri())
+            .build()
+            .unwrap();
 
         let record: RecordUpdate = record();
 
@@ -684,7 +688,10 @@ mod tests {
     #[tokio::test]
     async fn update_fails_on_500() {
         let mock_server = MockServer::start().await;
-        let client = AuditorClient::from_connection_string(&mock_server.uri()).unwrap();
+        let client = AuditorClientBuilder::new()
+            .connection_string(&mock_server.uri())
+            .build()
+            .unwrap();
 
         let record: RecordUpdate = record();
 
@@ -724,7 +731,10 @@ mod tests {
     #[tokio::test]
     async fn get_started_since_succeeds() {
         let mock_server = MockServer::start().await;
-        let client = AuditorClient::from_connection_string(&mock_server.uri()).unwrap();
+        let client = AuditorClientBuilder::new()
+            .connection_string(&mock_server.uri())
+            .build()
+            .unwrap();
 
         let body: Vec<Record> = vec![record()];
 
@@ -783,7 +793,10 @@ mod tests {
     #[tokio::test]
     async fn get_started_since_fails_on_500() {
         let mock_server = MockServer::start().await;
-        let client = AuditorClient::from_connection_string(&mock_server.uri()).unwrap();
+        let client = AuditorClientBuilder::new()
+            .connection_string(&mock_server.uri())
+            .build()
+            .unwrap();
 
         Mock::given(any())
             .respond_with(ResponseTemplate::new(500))
@@ -826,7 +839,10 @@ mod tests {
     #[tokio::test]
     async fn get_stopped_since_succeeds() {
         let mock_server = MockServer::start().await;
-        let client = AuditorClient::from_connection_string(&mock_server.uri()).unwrap();
+        let client = AuditorClientBuilder::new()
+            .connection_string(&mock_server.uri())
+            .build()
+            .unwrap();
 
         let body: Vec<Record> = vec![record()];
 
@@ -885,7 +901,10 @@ mod tests {
     #[tokio::test]
     async fn get_stopped_since_fails_on_500() {
         let mock_server = MockServer::start().await;
-        let client = AuditorClient::from_connection_string(&mock_server.uri()).unwrap();
+        let client = AuditorClientBuilder::new()
+            .connection_string(&mock_server.uri())
+            .build()
+            .unwrap();
 
         Mock::given(any())
             .respond_with(ResponseTemplate::new(500))

--- a/auditor/src/client/mod.rs
+++ b/auditor/src/client/mod.rs
@@ -46,8 +46,8 @@ impl std::fmt::Display for ClientError {
 /// Using the `address` and `port` of the Auditor instance:
 ///
 /// ```
-/// use auditor::client::AuditorClientBuilder;
-///
+/// # use auditor::client::AuditorClientBuilder;
+/// #
 /// let client = AuditorClientBuilder::new()
 ///     .address(&"localhost", 8000)
 ///     .timeout(20)
@@ -57,8 +57,8 @@ impl std::fmt::Display for ClientError {
 /// Using an connection string:
 ///
 /// ```
-/// use auditor::client::AuditorClientBuilder;
-///
+/// # use auditor::client::AuditorClientBuilder;
+/// #
 /// let client = AuditorClientBuilder::new()
 ///     .connection_string(&"http://localhost:8000")
 ///     .build();

--- a/auditor/src/client/mod.rs
+++ b/auditor/src/client/mod.rs
@@ -217,18 +217,6 @@ pub struct AuditorClientBlocking {
 }
 
 impl AuditorClientBlocking {
-    pub fn new<T: AsRef<str>>(
-        address: &T,
-        port: u16,
-    ) -> Result<AuditorClientBlocking, reqwest::Error> {
-        Ok(AuditorClientBlocking {
-            address: format!("http://{}:{}", address.as_ref(), port),
-            client: reqwest::blocking::ClientBuilder::new()
-                .user_agent(APP_USER_AGENT)
-                .build()?,
-        })
-    }
-
     pub fn from_connection_string<T: AsRef<str>>(
         connection_string: &T,
     ) -> Result<AuditorClientBlocking, reqwest::Error> {

--- a/auditor/src/client/mod.rs
+++ b/auditor/src/client/mod.rs
@@ -217,17 +217,6 @@ pub struct AuditorClientBlocking {
 }
 
 impl AuditorClientBlocking {
-    pub fn from_connection_string<T: AsRef<str>>(
-        connection_string: &T,
-    ) -> Result<AuditorClientBlocking, reqwest::Error> {
-        Ok(AuditorClientBlocking {
-            address: connection_string.as_ref().into(),
-            client: reqwest::blocking::ClientBuilder::new()
-                .user_agent(APP_USER_AGENT)
-                .build()?,
-        })
-    }
-
     #[tracing::instrument(name = "Checking health of AUDITOR server.", skip(self))]
     pub fn health_check(&self) -> bool {
         match self
@@ -369,7 +358,10 @@ mod tests {
         let mock_server = MockServer::start().await;
         let uri = mock_server.uri();
         let client = tokio::task::spawn_blocking(move || {
-            AuditorClientBlocking::from_connection_string(&uri).unwrap()
+            AuditorClientBuilder::new()
+                .connection_string(&uri)
+                .build_blocking()
+                .unwrap()
         })
         .await
         .unwrap();
@@ -417,7 +409,10 @@ mod tests {
         let mock_server = MockServer::start().await;
         let uri = mock_server.uri();
         let client = tokio::task::spawn_blocking(move || {
-            AuditorClientBlocking::from_connection_string(&uri).unwrap()
+            AuditorClientBuilder::new()
+                .connection_string(&uri)
+                .build_blocking()
+                .unwrap()
         })
         .await
         .unwrap();
@@ -561,7 +556,10 @@ mod tests {
         let mock_server = MockServer::start().await;
         let uri = mock_server.uri();
         let client = tokio::task::spawn_blocking(move || {
-            AuditorClientBlocking::from_connection_string(&uri).unwrap()
+            AuditorClientBuilder::new()
+                .connection_string(&uri)
+                .build_blocking()
+                .unwrap()
         })
         .await
         .unwrap();
@@ -606,7 +604,10 @@ mod tests {
         let mock_server = MockServer::start().await;
         let uri = mock_server.uri();
         let client = tokio::task::spawn_blocking(move || {
-            AuditorClientBlocking::from_connection_string(&uri).unwrap()
+            AuditorClientBuilder::new()
+                .connection_string(&uri)
+                .build_blocking()
+                .unwrap()
         })
         .await
         .unwrap();
@@ -652,7 +653,10 @@ mod tests {
         let mock_server = MockServer::start().await;
         let uri = mock_server.uri();
         let client = tokio::task::spawn_blocking(move || {
-            AuditorClientBlocking::from_connection_string(&uri).unwrap()
+            AuditorClientBuilder::new()
+                .connection_string(&uri)
+                .build_blocking()
+                .unwrap()
         })
         .await
         .unwrap();
@@ -697,7 +701,10 @@ mod tests {
         let mock_server = MockServer::start().await;
         let uri = mock_server.uri();
         let client = tokio::task::spawn_blocking(move || {
-            AuditorClientBlocking::from_connection_string(&uri).unwrap()
+            AuditorClientBuilder::new()
+                .connection_string(&uri)
+                .build_blocking()
+                .unwrap()
         })
         .await
         .unwrap();
@@ -750,7 +757,10 @@ mod tests {
         let mock_server = MockServer::start().await;
         let uri = mock_server.uri();
         let client = tokio::task::spawn_blocking(move || {
-            AuditorClientBlocking::from_connection_string(&uri).unwrap()
+            AuditorClientBuilder::new()
+                .connection_string(&uri)
+                .build_blocking()
+                .unwrap()
         })
         .await
         .unwrap();
@@ -804,7 +814,10 @@ mod tests {
         let mock_server = MockServer::start().await;
         let uri = mock_server.uri();
         let client = tokio::task::spawn_blocking(move || {
-            AuditorClientBlocking::from_connection_string(&uri).unwrap()
+            AuditorClientBuilder::new()
+                .connection_string(&uri)
+                .build_blocking()
+                .unwrap()
         })
         .await
         .unwrap();
@@ -858,7 +871,10 @@ mod tests {
         let mock_server = MockServer::start().await;
         let uri = mock_server.uri();
         let client = tokio::task::spawn_blocking(move || {
-            AuditorClientBlocking::from_connection_string(&uri).unwrap()
+            AuditorClientBuilder::new()
+                .connection_string(&uri)
+                .build_blocking()
+                .unwrap()
         })
         .await
         .unwrap();
@@ -912,7 +928,10 @@ mod tests {
         let mock_server = MockServer::start().await;
         let uri = mock_server.uri();
         let client = tokio::task::spawn_blocking(move || {
-            AuditorClientBlocking::from_connection_string(&uri).unwrap()
+            AuditorClientBuilder::new()
+                .connection_string(&uri)
+                .build_blocking()
+                .unwrap()
         })
         .await
         .unwrap();

--- a/auditor/src/client/mod.rs
+++ b/auditor/src/client/mod.rs
@@ -101,14 +101,6 @@ pub struct AuditorClient {
 }
 
 impl AuditorClient {
-    pub fn new<T: AsRef<str>>(address: &T, port: u16) -> Result<AuditorClient, reqwest::Error> {
-        Ok(AuditorClient {
-            address: format!("http://{}:{}", address.as_ref(), port),
-            client: reqwest::ClientBuilder::new()
-                .user_agent(APP_USER_AGENT)
-                .build()?,
-        })
-    }
 
     pub fn from_connection_string<T: AsRef<str>>(
         connection_string: &T,

--- a/auditor/src/constants.rs
+++ b/auditor/src/constants.rs
@@ -6,5 +6,6 @@
 // copied, modified, or distributed except according to those terms.
 
 pub const FORBIDDEN_CHARACTERS: [char; 9] = ['/', '(', ')', '"', '<', '>', '\\', '{', '}'];
+pub const ERR_INVALID_TIMEOUT: &str = "INVALID_TIMEOUT";
 pub const ERR_RECORD_EXISTS: &str = "RECORD_EXISTS";
 pub const ERR_UNEXPECTED_ERROR: &str = "UNEXPECTED_ERROR";

--- a/auditor/tests/api/client.rs
+++ b/auditor/tests/api/client.rs
@@ -1,5 +1,5 @@
 use crate::helpers::spawn_app;
-use auditor::client::AuditorClient;
+use auditor::client::AuditorClientBuilder;
 use auditor::domain::{Component, Record, RecordAdd, RecordDatabase, RecordTest, RecordUpdate};
 use chrono::{TimeZone, Utc};
 use fake::{Fake, Faker};
@@ -8,7 +8,10 @@ use fake::{Fake, Faker};
 async fn add_records() {
     // Arange
     let app = spawn_app().await;
-    let client = AuditorClient::from_connection_string(&app.address).unwrap();
+    let client = AuditorClientBuilder::new()
+        .connection_string(&app.address)
+        .build()
+        .unwrap();
 
     let mut test_cases_comp: Vec<RecordTest> =
         (0..100).map(|_| Faker.fake::<RecordTest>()).collect();
@@ -97,7 +100,10 @@ async fn add_records() {
 async fn update_records() {
     // Arange
     let app = spawn_app().await;
-    let client = AuditorClient::from_connection_string(&app.address).unwrap();
+    let client = AuditorClientBuilder::new()
+        .connection_string(&app.address)
+        .build()
+        .unwrap();
 
     let mut test_cases_comp: Vec<RecordTest> =
         (0..100).map(|_| Faker.fake::<RecordTest>()).collect();
@@ -200,7 +206,10 @@ async fn update_records() {
 async fn get_returns_empty_list_of_records() {
     // Arange
     let app = spawn_app().await;
-    let client = AuditorClient::from_connection_string(&app.address).unwrap();
+    let client = AuditorClientBuilder::new()
+        .connection_string(&app.address)
+        .build()
+        .unwrap();
 
     let records = client.get().await.unwrap();
 
@@ -210,7 +219,10 @@ async fn get_returns_empty_list_of_records() {
 #[tokio::test]
 async fn get_returns_a_list_of_records() {
     let app = spawn_app().await;
-    let client = AuditorClient::from_connection_string(&app.address).unwrap();
+    let client = AuditorClientBuilder::new()
+        .connection_string(&app.address)
+        .build()
+        .unwrap();
 
     let mut test_cases: Vec<RecordTest> = (0..100).map(|_| Faker.fake::<RecordTest>()).collect();
 
@@ -340,7 +352,10 @@ async fn get_returns_a_list_of_records() {
 #[tokio::test]
 async fn get_started_since_returns_a_list_of_records() {
     let app = spawn_app().await;
-    let client = AuditorClient::from_connection_string(&app.address).unwrap();
+    let client = AuditorClientBuilder::new()
+        .connection_string(&app.address)
+        .build()
+        .unwrap();
 
     let mut test_cases: Vec<RecordTest> = (1..=31)
         .map(|i| {
@@ -486,7 +501,10 @@ async fn get_started_since_returns_a_list_of_records() {
 #[tokio::test]
 async fn get_stopped_since_returns_a_list_of_records() {
     let app = spawn_app().await;
-    let client = AuditorClient::from_connection_string(&app.address).unwrap();
+    let client = AuditorClientBuilder::new()
+        .connection_string(&app.address)
+        .build()
+        .unwrap();
 
     let mut test_cases: Vec<RecordTest> = (1..=31)
         .map(|i| {

--- a/collectors/slurm-epilog/src/main.rs
+++ b/collectors/slurm-epilog/src/main.rs
@@ -6,7 +6,7 @@
 // copied, modified, or distributed except according to those terms.
 
 use anyhow::Error;
-use auditor::client::AuditorClient;
+use auditor::client::AuditorClientBuilder;
 use auditor::constants::FORBIDDEN_CHARACTERS;
 use auditor::domain::{Component, RecordAdd, Score};
 use auditor::telemetry::{get_subscriber, init_subscriber};
@@ -137,7 +137,9 @@ async fn main() -> Result<(), Error> {
 
     debug!(?config, "Loaded config");
 
-    let client = AuditorClient::new(&config.addr, config.port)?;
+    let client = AuditorClientBuilder::new()
+        .address(&config.addr, config.port)
+        .build()?;
 
     let job_id = get_slurm_job_id().expect("Collector not run in the context of a Slurm epilog");
 

--- a/plugins/priority/src/main.rs
+++ b/plugins/priority/src/main.rs
@@ -6,7 +6,7 @@
 // copied, modified, or distributed except according to those terms.
 
 use anyhow::Error;
-use auditor::client::AuditorClient;
+use auditor::client::AuditorClientBuilder;
 use auditor::domain::Record;
 use auditor::telemetry::{get_subscriber, init_subscriber};
 use chrono::Utc;
@@ -246,7 +246,9 @@ async fn main() -> Result<(), Error> {
 
     debug!(?config, "Loaded config");
 
-    let client = AuditorClient::new(&config.addr, config.port)?;
+    let client = AuditorClientBuilder::new()
+        .address(&config.addr, config.port)
+        .build()?;
 
     let records = match config.duration {
         Some(duration) => client.get_stopped_since(&(Utc::now() - duration)).await?,

--- a/pyauditor/src/blocking_client.rs
+++ b/pyauditor/src/blocking_client.rs
@@ -11,9 +11,9 @@ use pyo3::prelude::*;
 use pyo3::types::PyDateTime;
 use pyo3_chrono::NaiveDateTime;
 
-/// The `AuditorClient` handles the interaction with the Auditor instances and allows one to add
+/// The `AuditorClientBlocking` handles the interaction with the Auditor instances and allows one to add
 /// records to the database, update records in the database and retrieve the records from the
-/// database.
+/// database. In contrast to `AuditorClient`, no async runtime is needed here.
 #[pyclass]
 #[derive(Clone)]
 pub struct AuditorClientBlocking {


### PR DESCRIPTION
This PR introduces the following changes:

- Add documentation to the client module
- Removed direct constructors for clients (use the client builder instead)
- ClientError is now used as the error type in all methods of the client builder and clients