### PR TITLE
Update Rust API Documentation

### DIFF
--- a/auditor/sqlx-data.json
+++ b/auditor/sqlx-data.json
@@ -268,6 +268,22 @@
     },
     "query": "SELECT value as \"name!\", count(*) as \"num!\"\n               FROM meta\n               WHERE key = $1 \n               GROUP BY value;\n            "
   },
+  "6ba76bcc9e877d3b6e353a4b85a1115d4821d4304b91593614ea39597ae29bc1": {
+    "describe": {
+      "columns": [],
+      "nullable": [],
+      "parameters": {
+        "Left": [
+          "Text",
+          "Int8",
+          "TextArray",
+          "Float8Array",
+          "Int4"
+        ]
+      }
+    },
+    "query": "\n            WITH insert_components AS (\n                INSERT INTO components (name, amount)\n                VALUES ($1, $2)\n                RETURNING id\n            ),\n            insert_scores AS (\n                INSERT INTO scores (name, value)\n                SELECT * FROM UNNEST($3::text[], $4::double precision[])\n                -- Update if already in table. This isn't great, but \n                -- otherwise RETURNING won't return anything.\n                ON CONFLICT (name, value) DO UPDATE\n                SET value = EXCLUDED.value, name = EXCLUDED.name\n                RETURNING id\n            ),\n            insert_components_scores AS (\n                INSERT INTO components_scores (component_id, score_id)\n                SELECT (SELECT id FROM insert_components), id\n                FROM insert_scores\n            )\n            INSERT INTO records_components (record_id, component_id)\n            SELECT $5, (SELECT id from insert_components) \n            "
+  },
   "6c7c9b840bd8bf36dd80484f6c82787423b2304ccff83a98a57ec398c1b46ddb": {
     "describe": {
       "columns": [
@@ -308,22 +324,6 @@
       }
     },
     "query": "\n        UPDATE accounting\n        SET stop_time = $2,\n            runtime = $3,\n            updated_at = $4\n        WHERE\n            record_id = $1\n        "
-  },
-  "909d8a192fb7cbf882d2e2b759df5c3d09455c45e2c68d64f10e40ac9229a1b5": {
-    "describe": {
-      "columns": [],
-      "nullable": [],
-      "parameters": {
-        "Left": [
-          "Text",
-          "Int8",
-          "TextArray",
-          "Float8Array",
-          "Int4"
-        ]
-      }
-    },
-    "query": "\n            WITH insert_components AS (\n                INSERT INTO components (name, amount)\n                VALUES ($1, $2)\n                RETURNING id\n            ),\n            insert_scores AS (\n                INSERT INTO scores (name, value)\n                SELECT * FROM UNNEST($3::text[], $4::double precision[])\n                -- Update if already in table. This isn't great, but \n                -- otherwise RETURNING won't return anything.\n                ON CONFLICT (name, value) DO UPDATE\n                SET value = EXCLUDED.value, name = EXCLUDED.name\n                RETURNING id\n            ),\n            insert_components_scores AS (\n                INSERT INTO components_scores (component_id, score_id)\n                SELECT (SELECT id FROM insert_components), id\n                FROM insert_scores\n            )\n            INSERT INTO records_components (record_id, component_id)\n            SELECT $5, (SELECT id from insert_components) \n            -- FROM accounting WHERE id = $5\n            "
   },
   "b205b9e460541ad09dcd6de4d75df490a88f4b31b3ef45a9ec68047c39081eb5": {
     "describe": {

--- a/auditor/src/client/mod.rs
+++ b/auditor/src/client/mod.rs
@@ -58,22 +58,28 @@ impl From<chrono::OutOfRangeError> for ClientError {
 /// Using the `address` and `port` of the Auditor instance:
 ///
 /// ```
-/// # use auditor::client::AuditorClientBuilder;
+/// # use auditor::client::{AuditorClientBuilder, ClientError};
 /// #
+/// # fn main() -> Result<(), ClientError> {
 /// let client = AuditorClientBuilder::new()
 ///     .address(&"localhost", 8000)
 ///     .timeout(20)
-///     .build();
+///     .build()?;
+/// # Ok(())
+/// # }
 /// ```
 ///
 /// Using an connection string:
 ///
 /// ```
-/// # use auditor::client::AuditorClientBuilder;
+/// # use auditor::client::{AuditorClientBuilder, ClientError};
 /// #
+/// # fn main() -> Result<(), ClientError> {
 /// let client = AuditorClientBuilder::new()
 ///     .connection_string(&"http://localhost:8000")
-///     .build();
+///     .build()?;
+/// # Ok(())
+/// # }
 /// ```
 #[derive(Clone)]
 pub struct AuditorClientBuilder {

--- a/auditor/src/client/mod.rs
+++ b/auditor/src/client/mod.rs
@@ -50,7 +50,7 @@ impl From<chrono::OutOfRangeError> for ClientError {
     }
 }
 
-/// The [`AuditorClientBuilder`] is used to build an instance of
+/// The `AuditorClientBuilder` is used to build an instance of
 /// either [`AuditorClient`] or [`AuditorClientBlocking`].
 ///
 /// # Examples
@@ -130,7 +130,7 @@ impl AuditorClientBuilder {
         self
     }
 
-    /// Build an [`AuditorClient`] from [`AuditorClientBuilder`].
+    /// Build an [`AuditorClient`] from `AuditorClientBuilder`.
     ///
     /// # Errors
     ///
@@ -146,7 +146,7 @@ impl AuditorClientBuilder {
         })
     }
 
-    /// Build an [`AuditorClientBlocking`] from [`AuditorClientBuilder`].
+    /// Build an [`AuditorClientBlocking`] from `AuditorClientBuilder`.
     ///
     /// # Errors
     ///
@@ -173,9 +173,11 @@ impl Default for AuditorClientBuilder {
     }
 }
 
-/// The [`AuditorClient`] handles the interaction with the Auditor instances and allows one to add
+/// The `AuditorClient` handles the interaction with the Auditor instances and allows one to add
 /// records to the database, update records in the database and retrieve the records from the
 /// database.
+///
+/// It is constructed using the [`AuditorClientBuilder`].
 #[derive(Clone)]
 pub struct AuditorClient {
     address: String,
@@ -320,9 +322,11 @@ impl AuditorClient {
     }
 }
 
-/// The [`AuditorClientBlocking`] handles the interaction with the Auditor instances and allows one to add
+/// The `AuditorClientBlocking` handles the interaction with the Auditor instances and allows one to add
 /// records to the database, update records in the database and retrieve the records from the
 /// database. In contrast to [`AuditorClient`], no async runtime is needed here.
+///
+/// It is constructed using the [`AuditorClientBuilder`].
 #[derive(Clone)]
 pub struct AuditorClientBlocking {
     address: String,

--- a/auditor/src/domain/component.rs
+++ b/auditor/src/domain/component.rs
@@ -15,15 +15,42 @@ use sqlx::{
     Postgres, Type,
 };
 
+/// A `Component` represents a single component that is to be accounted for.
+///
+/// A component has an associated `name` and `amount` (how many or how much of this component is to
+/// be accounted for).
+/// Optionally, multiple [`Score`]s can be attached to a single component.
+///
+/// # Example:
+///
+/// Create a component that represents 10 CPU cores with a HEPSPEC06 value of 9.2.
+///
+/// ```
+/// # use auditor::domain::{Component, Score};
+/// # fn main() -> Result<(), anyhow::Error> {
+/// let component = Component::new("CPU", 10)?
+///     .with_score(Score::new("HEPSPEC06", 9.2)?);
+/// # Ok(())
+/// # }
+/// ```
 #[derive(Debug, PartialEq, Eq, Serialize, Deserialize, sqlx::Encode, Clone, PartialOrd, Ord)]
 #[sqlx(type_name = "component")]
 pub struct Component {
+    /// Name of the component.
     pub name: ValidName,
+    /// Amount of the component (how many or how much of this component is to be accounted for).
     pub amount: ValidAmount,
+    /// Scores that are attached to the component.
     pub scores: Vec<Score>,
 }
 
 impl Component {
+    /// Create a new component.
+    ///
+    /// # Errors
+    ///
+    /// * [`anyhow::Error`] - If there was an invalid character (`/()"<>\{}`) in the `name`
+    /// or if a negative `amount` was given.
     pub fn new<T: AsRef<str>>(name: T, amount: i64) -> Result<Self, Error> {
         Ok(Component {
             name: ValidName::parse(name.as_ref().to_string())
@@ -33,11 +60,13 @@ impl Component {
         })
     }
 
+    /// Attach a [`Score`] to the component.
     pub fn with_score(mut self, score: Score) -> Self {
         self.scores.push(score);
         self
     }
 
+    /// Attach multiple [`Score`]s to the component.
     pub fn with_scores(mut self, mut scores: Vec<Score>) -> Self {
         self.scores.append(&mut scores);
         self

--- a/auditor/src/domain/meta.rs
+++ b/auditor/src/domain/meta.rs
@@ -88,22 +88,39 @@ impl TryFrom<Meta> for ValidMeta {
     }
 }
 
+/// `Meta` stores a list of key-value pairs of the form `String` -> `Vec<String>`.
+///
+/// # Example
+///
+/// Create a new meta list and insert two key-value pairs:
+///
+/// ```
+/// # use auditor::domain::Meta;
+/// #
+/// let mut meta = Meta::new();
+/// meta.insert("site_id".to_string(), vec!["site1".to_string()]);
+/// meta.insert("features".to_string(), vec!["ssd".to_string(), "gpu".to_string()]);
+/// ```
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Default)]
 pub struct Meta(pub HashMap<String, Vec<String>>);
 
 impl Meta {
+    /// Constructor.
     pub fn new() -> Self {
         Self(HashMap::new())
     }
 
+    /// Returns the number of key-value pairs that are stored inside the meta list.
     pub fn len(&self) -> usize {
         self.0.len()
     }
 
+    /// Returns `true` if no information is stored in the meta list.
     pub fn is_empty(&self) -> bool {
         self.len() == 0
     }
 
+    /// Convert to a vector.
     pub fn to_vec(&self) -> Vec<(String, Vec<String>)> {
         self.0
             .iter()
@@ -111,10 +128,12 @@ impl Meta {
             .collect::<Vec<_>>()
     }
 
+    /// Insert a new key-value pair.
     pub fn insert(&mut self, name: String, values: Vec<String>) {
         self.0.insert(name, values);
     }
 
+    /// Returns a reference to the value corresponding to the `key`.
     pub fn get<T: AsRef<str>>(&self, key: T) -> Option<&Vec<String>> {
         self.0.get(key.as_ref())
     }

--- a/auditor/src/domain/record.rs
+++ b/auditor/src/domain/record.rs
@@ -36,13 +36,46 @@ pub struct RecordUpdate {
     pub stop_time: DateTime<Utc>,
 }
 
+/// A `Record` represents a single accountable unit.
+///
+/// Records can be sent to and received from Auditor with the [`AuditorClient`](`crate::client::AuditorClient`).
+/// When initially inserting a record in Auditor, the record is represented as [`RecordAdd`].
+/// The `stop_time` can be updated at a later time by pushing a [`RecordUpdate`] to Auditor.
+///
+/// Records that are retrieved from Auditor are returned as `Record`.
+///
+/// # Example
+///
+/// Retrieve all records from Auditor:
+///
+/// ```no_run
+/// # use auditor::client::{AuditorClientBuilder, ClientError};
+/// #
+/// # fn main() -> Result<(), ClientError> {
+/// // Create client by using the builder
+/// let client = AuditorClientBuilder::new()
+///     .address(&"localhost", 8000)
+///     .timeout(20)
+///     .build()?;
+///
+/// // Get all records
+/// let records = client.get();
+/// # Ok(())
+/// # }
+/// ```
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Record {
+    /// Unique identifier of the record.
     pub record_id: String,
+    /// Meta information, a collection of key value pairs in the form of `String` -> `Vec<String>`.
     pub meta: Option<Meta>,
+    /// List of components that are accounted for.
     pub components: Option<Vec<Component>>,
+    /// Start time of the record.
     pub start_time: Option<DateTime<Utc>>,
+    /// Stop time of the record.
     pub stop_time: Option<DateTime<Utc>>,
+    /// Runtime of the record, i.e. the difference between stop and start time.
     pub runtime: Option<i64>,
 }
 

--- a/auditor/src/domain/record.rs
+++ b/auditor/src/domain/record.rs
@@ -95,6 +95,30 @@ impl RecordAdd {
     }
 }
 
+impl RecordUpdate {
+    pub fn new<T: AsRef<str>>(
+        record_id: T,
+        meta: HashMap<T, Vec<T>>,
+        components: Vec<Component>,
+        stop_time: DateTime<Utc>,
+    ) -> Result<Self, Error> {
+        Ok(RecordUpdate {
+            record_id: ValidName::parse(record_id.as_ref().to_string())
+                .context("Failed to parse record_id.")?,
+            meta: {
+                if meta.is_empty() {
+                    None
+                } else {
+                    Some(meta.try_into()?)
+                }
+            },
+            components,
+            start_time: None,
+            stop_time,
+        })
+    }
+}
+
 impl RecordTest {
     pub fn new() -> Self {
         RecordTest::default()

--- a/auditor/src/domain/record.rs
+++ b/auditor/src/domain/record.rs
@@ -224,6 +224,7 @@ pub struct Record {
     pub runtime: Option<i64>,
 }
 
+#[doc(hidden)]
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub struct RecordDatabase {
     pub record_id: String,
@@ -234,6 +235,7 @@ pub struct RecordDatabase {
     pub runtime: Option<i64>,
 }
 
+#[doc(hidden)]
 #[derive(Serialize, Deserialize, Clone, Debug, Default)]
 pub struct RecordTest {
     pub record_id: Option<String>,

--- a/auditor/src/domain/score.rs
+++ b/auditor/src/domain/score.rs
@@ -13,6 +13,24 @@ use serde::{Deserialize, Serialize};
 use sqlx::postgres::PgHasArrayType;
 use std::cmp::Ordering;
 
+/// `Score`s are attached to a [`Component`](`crate::domain::Component`)
+/// and are used to relate different components of the same kind to each other in some
+/// kind of performance characteristic.
+///
+/// For example, in case of CPUs, a score could be the corresponding HEPSPEC06 value.
+///
+/// An individual score consists of a `name` and a `value`.
+///
+/// # Example
+///
+/// Create a score that represents a HEPSPEC06 value of 9.2:
+///
+/// ```
+/// # use auditor::domain::{Component, Score};
+/// # fn main() -> Result<(), anyhow::Error> {
+/// let score =  Score::new("HEPSPEC06", 9.2)?;
+/// # Ok(())
+/// # }
 #[derive(Debug, Serialize, Deserialize, sqlx::Type, Clone)]
 #[sqlx(type_name = "score")]
 pub struct Score {
@@ -21,6 +39,12 @@ pub struct Score {
 }
 
 impl Score {
+    /// Create a new score.
+    ///
+    /// # Errors
+    ///
+    /// * [`anyhow::Error`] - If there was an invalid character (`/()"<>\{}`) in the `name`
+    /// or if a negative `value` was given.
     pub fn new<T: AsRef<str>>(name: T, value: f64) -> Result<Self, Error> {
         Ok(Score {
             name: ValidName::parse(name.as_ref().to_string())

--- a/auditor/src/lib.rs
+++ b/auditor/src/lib.rs
@@ -5,6 +5,184 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
+//! # Tutorial
+//! This section walks you through several basic usecases of the Auditor software.
+//!
+//! Auditor is designed around so-called records, which are the unit of accountable resources.
+//! Records are created and pushed to Auditor, which stores them in a database.
+//! These records can then be requested again from Auditor to take an action
+//! based on the information stored in the records.
+//!
+//! A record consists of a unique identifier and meta information
+//! that provides some context (associated site, group, user, ...).
+//! Furthermore, a record also contains an arbitrary number of `components`
+//! that are to be accounted for (CPU, RAM, Disk, ...) and the amount of each of these components.
+//! The components can optionally be enhanced with `scores`, which are floating point values
+//! that put components of the same kind, but different performance in relation to each other.
+//!
+//! ## Creating a Record
+//!
+//! ```
+//! use auditor::domain::{Component, RecordAdd, Score};
+//! use chrono::{DateTime, TimeZone, Utc};
+//! use std::collections::HashMap;
+//!
+//! # fn main() -> Result<(), anyhow::Error> {
+//! // Define unique identifier
+//! let record_id = "record-1"; // Must be unique for all records in Auditor!
+//!
+//! // Time when the resource became available
+//! let start_time: DateTime<Utc> = Utc.with_ymd_and_hms(2023, 1, 1, 0, 0, 0).unwrap();
+//!
+//! // Create a component (10 CPU cores)
+//! // and attache a score (HEPSPEC06) to it
+//! let component_cpu = Component::new("CPU", 10)?
+//!     .with_score(Score::new("HEPSPEC06", 9.2)?);
+//!
+//! // Create a second component (32 GB memory)
+//! let component_mem = Component::new("MEM", 32)?;
+//!
+//! // Store components in a vector
+//! let components = vec![component_cpu, component_mem];
+//!
+//! // Create meta information
+//! let mut meta = HashMap::new();
+//! meta.insert("site_id", vec!["site1"]);
+//! meta.insert("features", vec!["ssd", "gpu"]);
+//!
+//! let record = RecordAdd::new(record_id, meta, components, start_time)?;
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! ## Connecting to Auditor
+//!
+//! The [`AuditorClientBuilder`](`crate::client::AuditorClientBuilder`) is used to build an [`AuditorClient`](`crate::client::AuditorClient`) object
+//! that can be used for interacting with Auditor.
+//!
+//! ```
+//! use auditor::client::AuditorClientBuilder;
+//! # use auditor::client::ClientError;
+//!
+//! # fn main() -> Result<(), ClientError> {
+//! let client = AuditorClientBuilder::new()
+//!     .address(&"localhost", 8000)
+//!     .timeout(20)
+//!     .build()?;
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! ## Pushing records to Auditor
+//!
+//! Assuming that a record and a client were already created,
+//! the record can be pushed to Auditor with
+//!
+//! ```no_run
+//! # use auditor::client::{AuditorClientBuilder, ClientError};
+//! # use auditor::domain::RecordAdd;
+//! # use chrono::{DateTime, TimeZone, Utc};
+//! # use std::collections::HashMap;
+//! # #[tokio::main]
+//! # async fn main() -> Result<(), anyhow::Error> {
+//! # let client = AuditorClientBuilder::new()
+//! #     .address(&"localhost", 8000)
+//! #     .timeout(20)
+//! #     .build()?;
+//! # let start_time: DateTime<Utc> = Utc.with_ymd_and_hms(2023, 1, 1, 0, 0, 0).unwrap();
+//! # let record = RecordAdd::new("record-1", HashMap::new(), vec![], start_time)?;
+//! client.add(&record).await?;
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! ## Updating records in Auditor
+//!
+//! Auditor accepts incomplete records. In particular, the stop time can be missing.
+//! These records can be updated at a later time, by adding the same record which includes a stop time.
+//! Note that the `record_id` must match the one already in the database!
+//! Fields other than the stop time cannot be updated.
+//!
+//! ```no_run
+//! # use auditor::client::{AuditorClientBuilder, ClientError};
+//! use auditor::domain::RecordUpdate;
+//! use chrono::{DateTime, TimeZone, Utc};
+//! # use std::collections::HashMap;
+//! # #[tokio::main]
+//! # async fn main() -> Result<(), anyhow::Error> {
+//! # let client = AuditorClientBuilder::new()
+//! #     .address(&"localhost", 8000)
+//! #     .timeout(20)
+//! #     .build()?;
+//!
+//! let stop_time: DateTime<Utc> = Utc.with_ymd_and_hms(2023, 1, 1, 12, 0, 0).unwrap();
+//! let record = RecordUpdate::new("record-1", HashMap::new(), vec![], stop_time)?;
+//!
+//! client.update(&record).await?;
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! ## Receiving all records from Auditor
+//!
+//! The complete set of records can be retrieved from Auditor with the `get()` method:
+//!
+//! ```no_run
+//! # use auditor::client::{AuditorClientBuilder, ClientError};
+//! # #[tokio::main]
+//! # async fn main() -> Result<(), ClientError> {
+//! # let client = AuditorClientBuilder::new()
+//! #     .address(&"localhost", 8000)
+//! #     .timeout(20)
+//! #     .build()?;
+//! let records = client.get().await?;
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! ## Receiving all records started/stopped since a given timestamp
+//!
+//! Instead of retrieving all records, the query can be limited to records
+//! that have been started or stopped since a given timestamp:
+//!
+//! ```no_run
+//! # use auditor::client::{AuditorClientBuilder, ClientError};
+//! use chrono::{DateTime, TimeZone, Utc};
+//! # #[tokio::main]
+//! # async fn main() -> Result<(), ClientError> {
+//! # let client = AuditorClientBuilder::new()
+//! #     .address(&"localhost", 8000)
+//! #     .timeout(20)
+//! #     .build()?;
+//!
+//! let since: DateTime<Utc> = Utc.with_ymd_and_hms(2023, 1, 1, 12, 0, 0).unwrap();
+//!
+//! let records_started_since = client.get_started_since(&since).await?;
+//! let records_stopped_since = client.get_stopped_since(&since).await?;
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! ## Checking the health of Auditor
+//!
+//! The health of Auditor can be checked with
+//!
+//! ```no_run
+//! # use auditor::client::{AuditorClientBuilder, ClientError};
+//! # #[tokio::main]
+//! # async fn main() -> Result<(), ClientError> {
+//! # let client = AuditorClientBuilder::new()
+//! #     .address(&"localhost", 8000)
+//! #     .timeout(20)
+//! #     .build()?;
+//! #
+//! if client.health_check().await {
+//!     println!(":)");
+//! } else {
+//!     println!(":(");
+//! }
+//! # Ok(())
+//! # }
 #[cfg(test)]
 #[macro_use(quickcheck)]
 extern crate quickcheck_macros;

--- a/auditor/src/routes/add.rs
+++ b/auditor/src/routes/add.rs
@@ -139,7 +139,6 @@ pub async fn add_record(record: &RecordAdd, pool: &PgPool) -> Result<(), AddReco
             )
             INSERT INTO records_components (record_id, component_id)
             SELECT $5, (SELECT id from insert_components) 
-            -- FROM accounting WHERE id = $5
             "#,
             component.name.as_ref(),
             component.amount,

--- a/pyauditor/docs/examples.rst
+++ b/pyauditor/docs/examples.rst
@@ -18,7 +18,7 @@ These records can then be requested again from Auditor to take an action based o
 
 A record consists of a unique identifier and meta information which provides some context (associated site, group, user).
 It also contains an arbitrary number of `components` that are to be accounted for (CPU, RAM, Disk, ...) and the amount of each of these components.
-The components can optionally be enhanced with `scores`  which are are floating point values which put components of the same kind, but different performance in relation to each other.
+The components can optionally be enhanced with `scores`, which are floating point values which put components of the same kind, but different performance in relation to each other.
 For instance, in case of CPUs these could be HEPSPEC06 benchmark values.
 
 pyauditor is an async library and as such requires an event loop.
@@ -136,11 +136,11 @@ The records to be retrieved can be limited to the ones started or stopped since 
 Checking the health of Auditor
 ==============================
 
-Assuming that a record and a client were already created, the record can be pushed to Auditor like this:
+The health of Auditor can be checked with
 
 .. code-block:: python
 
-   healthy = await client.health_check(record)
+   healthy = await client.health_check()
    if healthy:
        print(":)")
    else:

--- a/pyauditor/src/domain/record.rs
+++ b/pyauditor/src/domain/record.rs
@@ -40,7 +40,7 @@ use pyo3_chrono::NaiveDateTime;
 /// Components are added via ``with_component``. Call this method multiple times for adding
 /// multiple components.
 ///
-/// Meta information is added via `with_meta`.
+/// Meta information is added via ``with_meta``.
 ///
 /// The individual fields of the record can be accessed using the getter methods described below.
 ///


### PR DESCRIPTION
This PR includes various additions to the Rust API documentation.

In particular, documentation has been added for `Record`, `RecordAdd`, `RecordUpdate`, `Component`, `Score`, and `Meta`.
Furthermore, a tutorial for the Rust client similar to the one for the Python client has been added.