### PR TITLE
Add option to allow for empty sacct fields

### DIFF
--- a/collectors/slurm/src/main.rs
+++ b/collectors/slurm/src/main.rs
@@ -25,7 +25,7 @@ use uuid::Uuid;
 
 use crate::{
     auditorsender::AuditorSender,
-    configuration::{get_configuration, ParsableType, Settings},
+    configuration::{get_configuration, KeyConfig, ParsableType, Settings},
     database::Database,
     sacctcaller::run_sacct_monitor,
     shutdown::{Shutdown, ShutdownSender},
@@ -38,14 +38,38 @@ const GROUP: &str = "Group";
 const START: &str = "Start";
 const END: &str = "End";
 const STATE: &str = "State";
-static KEYS: Lazy<Vec<(String, ParsableType)>> = Lazy::new(|| {
+static KEYS: Lazy<Vec<KeyConfig>> = Lazy::new(|| {
     let mut keys = CONFIG.get_keys();
-    keys.push((JOBID.to_owned(), ParsableType::String));
-    keys.push((START.to_owned(), ParsableType::DateTime));
-    keys.push((END.to_owned(), ParsableType::DateTime));
-    keys.push((GROUP.to_owned(), ParsableType::String));
-    keys.push((USER.to_owned(), ParsableType::String));
-    keys.push((STATE.to_owned(), ParsableType::String));
+    keys.push(KeyConfig {
+        name: JOBID.to_owned(),
+        key_type: ParsableType::String,
+        allow_empty: false,
+    });
+    keys.push(KeyConfig {
+        name: START.to_owned(),
+        key_type: ParsableType::DateTime,
+        allow_empty: false,
+    });
+    keys.push(KeyConfig {
+        name: END.to_owned(),
+        key_type: ParsableType::DateTime,
+        allow_empty: false,
+    });
+    keys.push(KeyConfig {
+        name: GROUP.to_owned(),
+        key_type: ParsableType::String,
+        allow_empty: false,
+    });
+    keys.push(KeyConfig {
+        name: USER.to_owned(),
+        key_type: ParsableType::String,
+        allow_empty: false,
+    });
+    keys.push(KeyConfig {
+        name: STATE.to_owned(),
+        key_type: ParsableType::String,
+        allow_empty: false,
+    });
     keys
 });
 static CONFIG: Lazy<Settings> =

--- a/collectors/slurm/src/sacctcaller.rs
+++ b/collectors/slurm/src/sacctcaller.rs
@@ -166,12 +166,12 @@ async fn get_job_info(database: &Database) -> Result<Vec<RecordAdd>> {
                                 match map2.get(&k) {
                                     Some(Some(v)) => Some(v.clone()),
                                     _ => {
-                                        tracing::error!("Something went wrong during parsing (id: {id}, key: {k})");
+                                        tracing::error!("Something went wrong during parsing (map1, id: {id}, key: {k}, value: {:?})", map2.get(&k));
                                         None
                                     },
                                 }
                             } else {
-                                tracing::error!("Something went wrong during parsing (id: {id}, key: {k})");
+                                tracing::error!("Something went wrong during parsing (map2, id: {id}, key: {k}, value: {:?})", map1.get(&k));
                                 None
                             }
                         },


### PR DESCRIPTION
This PR adds the setting `key_allow_empty` to the key config. With this, one can allow an empty field to be kept when parsing the `sacct` output. The setting is optional with a default value of `false`, i.e. keeping backward compatibility.

During the development of this change, the code that checks for empty values has been refactored into its own function, `parse_sacct_output`, and the key config from a tuple, `(String, ParsableType)`, into a struct, `KeyConfig`.

Closes #304 