### PR TITLE
Dependabot checks for APEL plugin and GitHub actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,17 @@
 version: 2
 updates:
-- package-ecosystem: cargo
-  directory: "/"
-  schedule:
-    interval: daily
-  open-pull-requests-limit: 10
+  # Rust code
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "daily"
+  # APEL plugin
+  - package-ecosystem: "pip"
+    directory: "/plugins/apel"
+    schedule:
+      interval: "daily"
+  # GitHub action
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
This PR adds Dependabot checks for the APEL plugin and for the GitHub actions.
Solves part of #339.