### PR TITLE
Update pyo3 and pyo3-asyncio

### DIFF
--- a/.github/workflows/pyauditor.yml
+++ b/.github/workflows/pyauditor.yml
@@ -113,7 +113,7 @@ jobs:
       - uses: messense/maturin-action@v1
         with:
           command: build
-          args: --release -o dist --universal2 --interpreter python3.7 python3.8 python3.9 python3.10 python3.11 --manifest-path pyauditor/Cargo.toml
+          args: --release -o dist --target universal2-apple-darwin --interpreter python3.7 python3.8 python3.9 python3.10 python3.11 --manifest-path pyauditor/Cargo.toml
 
       - name: Upload wheels
         uses: actions/upload-artifact@v3

--- a/.github/workflows/pyauditor.yml
+++ b/.github/workflows/pyauditor.yml
@@ -34,7 +34,7 @@ jobs:
           target: x86_64
           manylinux: auto
           command: build
-          args: --release --sdist -o dist --interpreter python3.6 python3.7 python3.8 python3.9 python3.10 python3.11 --manifest-path pyauditor/Cargo.toml
+          args: --release --sdist -o dist --interpreter python3.7 python3.8 python3.9 python3.10 python3.11 --manifest-path pyauditor/Cargo.toml
 
       - name: Upload wheels
         uses: actions/upload-artifact@v3
@@ -113,7 +113,7 @@ jobs:
       - uses: messense/maturin-action@v1
         with:
           command: build
-          args: --release -o dist --universal2 --interpreter python3.6 python3.7 python3.8 python3.9 python3.10 python3.11 --manifest-path pyauditor/Cargo.toml
+          args: --release -o dist --universal2 --interpreter python3.7 python3.8 python3.9 python3.10 python3.11 --manifest-path pyauditor/Cargo.toml
 
       - name: Upload wheels
         uses: actions/upload-artifact@v3

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -60,12 +60,12 @@ dependencies = [
 
 [[package]]
 name = "actix-macros"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "465a6172cf69b960917811022d8f29bc0b7fa1398bc4f78b3c466673db1213b6"
+checksum = "e01ed3140b2f8d422c68afa1ed2e85d996ea619c988ac834d255db32138655cb"
 dependencies = [
  "quote",
- "syn 1.0.109",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -116,7 +116,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b894941f818cfdc7ccc4b9e60fa7e53b5042a2e8567270f9147d5591893373a"
 dependencies = [
  "futures-core",
- "paste 1.0.13",
+ "paste",
  "pin-project-lite",
 ]
 
@@ -167,7 +167,7 @@ dependencies = [
  "serde_urlencoded",
  "smallvec",
  "socket2",
- "time 0.3.23",
+ "time 0.3.24",
  "url",
 ]
 
@@ -263,9 +263,9 @@ dependencies = [
 
 [[package]]
 name = "allocator-api2"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56fc6cf8dc8c4158eed8649f9b8b0ea1518eb62b544fe9490d66fa0b349eafe9"
+checksum = "0942ffc6dcaadf03badf6e6a2d0228460359d5e34b57ccdc720b7382dfbd5ec5"
 
 [[package]]
 name = "android-tzdata"
@@ -311,9 +311,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.71"
+version = "0.1.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a564d521dd56509c4c47480d00b80ee55f7e385ae48db5744c67ad50c92d2ebf"
+checksum = "cc6dde6e4ed435a4c1ee4e73592f5ba9da2151af10076cc04858746af9352d09"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -638,7 +638,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e859cd57d0710d9e06c381b550c06e76992472a8c6d527aecd2fc673dcc231fb"
 dependencies = [
  "percent-encoding",
- "time 0.3.23",
+ "time 0.3.24",
  "version_check",
 ]
 
@@ -721,16 +721,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ctor"
-version = "0.1.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d2301688392eb071b0bf1a37be05c469d3cc4dbbd95df672fe28ab021e6a096"
-dependencies = [
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "darling"
 version = "0.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -795,6 +785,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eaa37046cc0f6c3cc6090fbdbf73ef0b8ef4cfcc37f6befc0020f63e8cf121e1"
 
 [[package]]
+name = "deranged"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8810e7e2cf385b1e9b50d68264908ec367ba642c96d02edfe61c39e88e2a3c01"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "derive_more"
 version = "0.99.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -852,9 +851,9 @@ checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
 name = "either"
-version = "1.8.1"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
+checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
 dependencies = [
  "serde",
 ]
@@ -1115,17 +1114,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ghost"
-version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55f62cab8c48c54b8aba6588bd75fd00cdfe8517e79797c3662c5ed0c011d257"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.28",
-]
-
-[[package]]
 name = "gimli"
 version = "0.27.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1368,26 +1356,9 @@ dependencies = [
 
 [[package]]
 name = "indoc"
-version = "0.3.6"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47741a8bc60fb26eb8d6e0238bbb26d8575ff623fdc97b1a2c00c050b9684ed8"
-dependencies = [
- "indoc-impl",
- "proc-macro-hack",
-]
-
-[[package]]
-name = "indoc-impl"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce046d161f000fffde5f432a0d034d0341dc152643b2598ed5bfce44c4f3a8f0"
-dependencies = [
- "proc-macro-hack",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
- "unindent",
-]
+checksum = "bfa799dd5ed20a7e349f3b4639aa80d74549c81716d9ec4f994c9b5815598306"
 
 [[package]]
 name = "infer"
@@ -1402,28 +1373,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
 dependencies = [
  "cfg-if",
-]
-
-[[package]]
-name = "inventory"
-version = "0.1.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0eb5160c60ba1e809707918ee329adb99d222888155835c6feedba19f6c3fd4"
-dependencies = [
- "ctor",
- "ghost",
- "inventory-impl",
-]
-
-[[package]]
-name = "inventory-impl"
-version = "0.1.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e41b53715c6f0c4be49510bb82dee2c1e51c8586d885abe65396e82ed518548"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -1452,9 +1401,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.8"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b02a5381cc465bd3041d84623d0fa3b66738b52b8e2fc3bab8ad63ab032f4a"
+checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
 
 [[package]]
 name = "jobserver"
@@ -1577,6 +1526,15 @@ name = "memchr"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
+
+[[package]]
+name = "memoffset"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a634b1c61a95585bd15607c6ab0c4e5b226e695ff2800ba0cdccddf208c406c"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "mime"
@@ -1786,28 +1744,9 @@ dependencies = [
 
 [[package]]
 name = "paste"
-version = "0.1.18"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45ca20c77d80be666aef2b45486da86238fabe33e38306bd3118fe4af33fa880"
-dependencies = [
- "paste-impl",
- "proc-macro-hack",
-]
-
-[[package]]
-name = "paste"
-version = "1.0.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4b27ab7be369122c218afc2079489cdcb4b517c0a3fc386ff11e1fedfcc2b35"
-
-[[package]]
-name = "paste-impl"
-version = "0.1.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d95a7db200b97ef370c8e6de0088252f7e0dfff7d047a28528e47456c0fc98b6"
-dependencies = [
- "proc-macro-hack",
-]
+checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
 
 [[package]]
 name = "pathdiff"
@@ -1823,9 +1762,9 @@ checksum = "9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94"
 
 [[package]]
 name = "pest"
-version = "2.7.0"
+version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f73935e4d55e2abf7f130186537b19e7a4abc886a0252380b59248af473a3fc9"
+checksum = "1acb4a4365a13f749a93f1a094a7805e5cfa0955373a9de860d962eaa3a5fe5a"
 dependencies = [
  "thiserror",
  "ucd-trie",
@@ -1833,9 +1772,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.7.0"
+version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aef623c9bbfa0eedf5a0efba11a5ee83209c326653ca31ff019bec3a95bfff2b"
+checksum = "666d00490d4ac815001da55838c500eafb0320019bbaa44444137c48b443a853"
 dependencies = [
  "pest",
  "pest_generator",
@@ -1843,9 +1782,9 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.7.0"
+version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3e8cba4ec22bada7fc55ffe51e2deb6a0e0db2d0b7ab0b103acc80d2510c190"
+checksum = "68ca01446f50dbda87c1786af8770d535423fa8a53aec03b8f4e3d7eb10e0929"
 dependencies = [
  "pest",
  "pest_meta",
@@ -1856,9 +1795,9 @@ dependencies = [
 
 [[package]]
 name = "pest_meta"
-version = "2.7.0"
+version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a01f71cb40bd8bb94232df14b946909e14660e33fc05db3e50ae2a82d7ea0ca0"
+checksum = "56af0a30af74d0445c0bf6d9d051c979b516a1a5af790d251daee76005420a48"
 dependencies = [
  "once_cell",
  "pest",
@@ -1910,16 +1849,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
-name = "proc-macro-hack"
-version = "0.5.20+deprecated"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
-
-[[package]]
 name = "proc-macro2"
-version = "1.0.64"
+version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78803b62cbf1f46fde80d7c0e803111524b9877184cfe7c3033659490ac7a7da"
+checksum = "18fb31db3f9bddb2ea821cde30a9f70117e3f119938b5ee630b7403aa6e2ead9"
 dependencies = [
  "unicode-ident",
 ]
@@ -1947,29 +1880,30 @@ checksum = "106dd99e98437432fed6519dedecfade6a06a73bb7b2a1e019fdd2bee5778d94"
 
 [[package]]
 name = "pyo3"
-version = "0.15.2"
+version = "0.19.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d41d50a7271e08c7c8a54cd24af5d62f73ee3a6f6a314215281ebdec421d5752"
+checksum = "e681a6cfdc4adcc93b4d3cf993749a4552018ee0a9b65fc0ccfad74352c72a38"
 dependencies = [
  "anyhow",
  "cfg-if",
+ "chrono",
  "indoc",
  "libc",
- "parking_lot 0.11.2",
- "paste 0.1.18",
+ "memoffset",
+ "parking_lot 0.12.1",
  "pyo3-build-config",
+ "pyo3-ffi",
  "pyo3-macros",
  "unindent",
 ]
 
 [[package]]
 name = "pyo3-asyncio"
-version = "0.15.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0897c7e36110a32b726b975359b2bbe90c37fcf1266046d3b1c08c616a47a886"
+checksum = "a2cc34c1f907ca090d7add03dc523acdd91f3a4dab12286604951e2f5152edad"
 dependencies = [
  "futures",
- "inventory",
  "once_cell",
  "pin-project-lite",
  "pyo3",
@@ -1979,9 +1913,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-asyncio-macros"
-version = "0.15.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4daada7260db6d6dbc1f9b50f3e3d21f9eb28c034722c9a61ac05ff56ffd62db"
+checksum = "e4045f06429547179e4596f5c0b13c82efc8b04296016780133653ed69ce26b3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1990,29 +1924,31 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.15.2"
+version = "0.19.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "779239fc40b8e18bc8416d3a37d280ca9b9fb04bda54b98037bb6748595c2410"
+checksum = "076c73d0bc438f7a4ef6fdd0c3bb4732149136abd952b110ac93e4edb13a6ba5"
 dependencies = [
  "once_cell",
+ "target-lexicon",
 ]
 
 [[package]]
-name = "pyo3-chrono"
-version = "0.3.0"
+name = "pyo3-ffi"
+version = "0.19.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b25cefb416687b688d203ae622671a4b9328051f45fc2d22173afd163e3999b"
+checksum = "e53cee42e77ebe256066ba8aa77eff722b3bb91f3419177cf4cd0f304d3284d9"
 dependencies = [
- "chrono",
- "pyo3",
+ "libc",
+ "pyo3-build-config",
 ]
 
 [[package]]
 name = "pyo3-macros"
-version = "0.15.2"
+version = "0.19.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b247e8c664be87998d8628e86f282c25066165f1f8dda66100c48202fdb93a"
+checksum = "dfeb4c99597e136528c6dd7d5e3de5434d1ceaf487436a3f03b2d56b6fc9efd1"
 dependencies = [
+ "proc-macro2",
  "pyo3-macros-backend",
  "quote",
  "syn 1.0.109",
@@ -2020,12 +1956,11 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.15.2"
+version = "0.19.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a8c2812c412e00e641d99eeb79dd478317d981d938aa60325dfa7157b607095"
+checksum = "947dc12175c254889edc0c02e399476c2f652b4b9ebd123aa655c224de259536"
 dependencies = [
  "proc-macro2",
- "pyo3-build-config",
  "quote",
  "syn 1.0.109",
 ]
@@ -2039,7 +1974,6 @@ dependencies = [
  "chrono",
  "pyo3",
  "pyo3-asyncio",
- "pyo3-chrono",
  "serde_json",
  "tokio",
 ]
@@ -2068,9 +2002,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.29"
+version = "1.0.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "573015e8ab27661678357f27dc26460738fd2b6c86e46f386fde94cb5d913105"
+checksum = "50f3b39ccfb720540debaa0164757101c08ecb8d326b15358ce76a62c7e85965"
 dependencies = [
  "proc-macro2",
 ]
@@ -2183,7 +2117,7 @@ checksum = "b2eae68fc220f7cf2532e4494aded17545fce192d59cd996e0fe7887f4ceb575"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.3.3",
+ "regex-automata 0.3.4",
  "regex-syntax 0.7.4",
 ]
 
@@ -2198,9 +2132,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39354c10dd07468c2e73926b23bb9c2caca74c5501e38a35da70406f1d923310"
+checksum = "b7b6d6190b7594385f61bd3911cd1be99dfddcfc365a4160cc2ab5bff4aed294"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2350,9 +2284,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.101.1"
+version = "0.101.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15f36a6828982f422756984e47912a7a51dcbc2a197aa791158f8ca61cd8204e"
+checksum = "513722fd73ad80a71f72b61009ea1b584bcfa1483ca93949c8f290298837fa59"
 dependencies = [
  "ring",
  "untrusted",
@@ -2360,15 +2294,15 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.14"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe232bdf6be8c8de797b22184ee71118d63780ea42ac85b61d1baa6d3b782ae9"
+checksum = "1ad4cc8da4ef723ed60bced201181d83791ad433213d8c24efffda1eec85d741"
 
 [[package]]
 name = "scopeguard"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "sct"
@@ -2392,9 +2326,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bebd363326d05ec3e2f532ab7660680f3b02130d780c299bca73469d521bc0ed"
+checksum = "b0293b4b29daaf487284529cc2f5675b8e57c61f70167ba415a463651fd6a918"
 
 [[package]]
 name = "serde"
@@ -2474,7 +2408,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with_macros",
- "time 0.3.23",
+ "time 0.3.24",
 ]
 
 [[package]]
@@ -2633,7 +2567,7 @@ dependencies = [
  "md-5",
  "memchr",
  "once_cell",
- "paste 1.0.13",
+ "paste",
  "percent-encoding",
  "rand 0.8.5",
  "rustls 0.20.8",
@@ -2689,9 +2623,9 @@ dependencies = [
 
 [[package]]
 name = "stringprep"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ee348cb74b87454fff4b551cbf727025810a004f88aeacae7f85b87f4e9a1c1"
+checksum = "db3737bde7edce97102e0e2b15365bf7a20bfdb5f60f4f9e8d7004258a51a8da"
 dependencies = [
  "unicode-bidi",
  "unicode-normalization",
@@ -2730,6 +2664,12 @@ dependencies = [
  "quote",
  "unicode-ident",
 ]
+
+[[package]]
+name = "target-lexicon"
+version = "0.12.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d0e916b1148c8e263850e1ebcbd046f333e0683c724876bb0da63ea4373dc8a"
 
 [[package]]
 name = "thiserror"
@@ -2774,10 +2714,11 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.23"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59e399c068f43a5d116fedaf73b203fa4f9c519f17e2b34f63221d3792f81446"
+checksum = "b79eabcd964882a646b3584543ccabeae7869e9ac32a46f6f22b7a5bd405308b"
 dependencies = [
+ "deranged",
  "itoa",
  "serde",
  "time-core",
@@ -2792,9 +2733,9 @@ checksum = "7300fbefb4dadc1af235a9cef3737cea692a9d97e1b9cbcd4ebdae6f8868e6fb"
 
 [[package]]
 name = "time-macros"
-version = "0.2.10"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96ba15a897f3c86766b757e5ac7221554c6750054d74d5b28844fce5fb36a6c4"
+checksum = "eb71511c991639bb078fd5bf97757e03914361c48100d52878b8e52b46fb92cd"
 dependencies = [
  "time-core",
 ]
@@ -2953,7 +2894,7 @@ dependencies = [
  "log",
  "serde",
  "serde_json",
- "time 0.3.23",
+ "time 0.3.24",
  "tracing",
  "tracing-core",
  "tracing-log",
@@ -3035,9 +2976,9 @@ checksum = "92888ba5573ff080736b3648696b70cafad7d250551175acbaa4e0385b3e1460"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.10"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22049a19f4a68748a168c0fc439f9516686aa045927ff767eca0a85101fb6e73"
+checksum = "301abaae475aa91687eb82514b328ab47a211a533026cb25fc3e519b86adfc3c"
 
 [[package]]
 name = "unicode-normalization"
@@ -3400,18 +3341,18 @@ checksum = "2a0956f1ba7c7909bfb66c2e9e4124ab6f6482560f6628b5aaeba39207c9aad9"
 
 [[package]]
 name = "zstd"
-version = "0.12.3+zstd.1.5.2"
+version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76eea132fb024e0e13fd9c2f5d5d595d8a967aa72382ac2f9d39fcc95afd0806"
+checksum = "1a27595e173641171fc74a1232b7b1c7a7cb6e18222c11e9dfb9888fa424c53c"
 dependencies = [
  "zstd-safe",
 ]
 
 [[package]]
 name = "zstd-safe"
-version = "6.0.5+zstd.1.5.4"
+version = "6.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d56d9e60b4b1758206c238a10165fbcae3ca37b01744e394c463463f6529d23b"
+checksum = "ee98ffd0b48ee95e6c5168188e44a54550b1564d9d530ee21d5f0eaed1069581"
 dependencies = [
  "libc",
  "zstd-sys",

--- a/plugins/apel/src/auditor_apel_plugin/core.py
+++ b/plugins/apel/src/auditor_apel_plugin/core.py
@@ -7,7 +7,7 @@ import logging
 from pathlib import Path
 import sqlite3
 from sqlite3 import Error
-from datetime import datetime, timedelta, time
+from datetime import datetime, timedelta, time, timezone
 from time import sleep
 import pytz
 import json
@@ -325,8 +325,8 @@ def create_summary_db(config, records):
             )
             user_name = None
 
-        year = r.stop_time.replace(tzinfo=pytz.utc).year
-        month = r.stop_time.replace(tzinfo=pytz.utc).month
+        year = r.stop_time.replace(tzinfo=timezone.utc).year
+        month = r.stop_time.replace(tzinfo=timezone.utc).month
 
         component_dict = {}
         score_dict = {}
@@ -379,8 +379,8 @@ def create_summary_db(config, records):
             norm_runtime,
             cputime,
             norm_cputime,
-            r.start_time.replace(tzinfo=pytz.utc).timestamp(),
-            r.stop_time.replace(tzinfo=pytz.utc).timestamp(),
+            r.start_time.replace(tzinfo=timezone.utc).timestamp(),
+            r.stop_time.replace(tzinfo=timezone.utc).timestamp(),
             user_name,
             benchmark_type,
             benchmark_value,
@@ -450,8 +450,8 @@ def create_sync_db(config, records):
 
         submit_host = get_submit_host(r, config)
 
-        year = r.stop_time.replace(tzinfo=pytz.utc).year
-        month = r.stop_time.replace(tzinfo=pytz.utc).month
+        year = r.stop_time.replace(tzinfo=timezone.utc).year
+        month = r.stop_time.replace(tzinfo=timezone.utc).month
 
         data_tuple = (
             site_name,

--- a/plugins/apel/tests/test_auditor_apel_plugin.py
+++ b/plugins/apel/tests/test_auditor_apel_plugin.py
@@ -14,7 +14,7 @@ from auditor_apel_plugin.core import (
     get_records,
     get_site_id,
 )
-from datetime import datetime
+from datetime import datetime, timezone
 import pytz
 import sqlite3
 import os
@@ -381,8 +381,8 @@ class TestAuditorApelPlugin:
 
         rec_1_values = {
             "rec_id": "test_record_1",
-            "start_time": datetime(1984, 3, 3, 0, 0, 0),
-            "stop_time": datetime(1985, 3, 3, 0, 0, 0),
+            "start_time": datetime(1984, 3, 3, 0, 0, 0).astimezone(tz=timezone.utc),
+            "stop_time": datetime(1985, 3, 3, 0, 0, 0).astimezone(tz=timezone.utc),
             "n_cores": 8,
             "hepscore": 10.0,
             "tot_cpu": 15520000,
@@ -395,8 +395,8 @@ class TestAuditorApelPlugin:
 
         rec_2_values = {
             "rec_id": "test_record_2",
-            "start_time": datetime(2023, 1, 1, 14, 24, 11),
-            "stop_time": datetime(2023, 1, 2, 7, 11, 45),
+            "start_time": datetime(2023, 1, 1, 14, 24, 11).astimezone(tz=timezone.utc),
+            "stop_time": datetime(2023, 1, 2, 7, 11, 45).astimezone(tz=timezone.utc),
             "n_cores": 1,
             "hepscore": 23.0,
             "tot_cpu": 12234325,
@@ -453,11 +453,11 @@ class TestAuditorApelPlugin:
             assert content[idx][14] == rec_values["tot_cpu"] * rec_values["hepscore"]
             assert (
                 content[idx][15]
-                == rec_values["start_time"].replace(tzinfo=pytz.utc).timestamp()
+                == rec_values["start_time"].replace(tzinfo=timezone.utc).timestamp()
             )
             assert (
                 content[idx][16]
-                == rec_values["stop_time"].replace(tzinfo=pytz.utc).timestamp()
+                == rec_values["stop_time"].replace(tzinfo=timezone.utc).timestamp()
             )
             assert content[idx][17] == replace_record_string(rec_values["user_name"])
 
@@ -549,8 +549,8 @@ class TestAuditorApelPlugin:
 
         rec_1_values = {
             "rec_id": "test_record_1",
-            "start_time": datetime(1984, 3, 3, 0, 0, 0),
-            "stop_time": datetime(1985, 3, 3, 0, 0, 0),
+            "start_time": datetime(1984, 3, 3, 0, 0, 0).astimezone(tz=timezone.utc),
+            "stop_time": datetime(1985, 3, 3, 0, 0, 0).astimezone(tz=timezone.utc),
             "n_cores": 8,
             "hepscore": 10.0,
             "tot_cpu": 15520000,
@@ -563,8 +563,8 @@ class TestAuditorApelPlugin:
 
         rec_2_values = {
             "rec_id": "test_record_2",
-            "start_time": datetime(2023, 1, 1, 14, 24, 11),
-            "stop_time": datetime(2023, 1, 2, 7, 11, 45),
+            "start_time": datetime(2023, 1, 1, 14, 24, 11).astimezone(tz=timezone.utc),
+            "stop_time": datetime(2023, 1, 2, 7, 11, 45).astimezone(tz=timezone.utc),
             "n_cores": 1,
             "hepscore": 23.0,
             "tot_cpu": 12234325,
@@ -651,8 +651,8 @@ class TestAuditorApelPlugin:
 
         rec_1_values = {
             "rec_id": "test_record_1",
-            "start_time": datetime(1984, 3, 3, 0, 0, 0),
-            "stop_time": datetime(1985, 3, 3, 0, 0, 0),
+            "start_time": datetime(1984, 3, 3, 0, 0, 0).astimezone(tz=timezone.utc),
+            "stop_time": datetime(1985, 3, 3, 0, 0, 0).astimezone(tz=timezone.utc),
             "n_cores": 8,
             "hepscore": 10.0,
             "tot_cpu": 15520000,
@@ -665,8 +665,8 @@ class TestAuditorApelPlugin:
 
         rec_2_values = {
             "rec_id": "test_record_2",
-            "start_time": datetime(2023, 1, 1, 14, 24, 11),
-            "stop_time": datetime(2023, 1, 2, 7, 11, 45),
+            "start_time": datetime(2023, 1, 1, 14, 24, 11).astimezone(tz=timezone.utc),
+            "stop_time": datetime(2023, 1, 2, 7, 11, 45).astimezone(tz=timezone.utc),
             "n_cores": 1,
             "hepscore": 23.0,
             "tot_cpu": 12234325,
@@ -679,8 +679,8 @@ class TestAuditorApelPlugin:
 
         rec_3_values = {
             "rec_id": "test_record_3",
-            "start_time": datetime(2022, 1, 1, 14, 24, 11),
-            "stop_time": datetime(2023, 1, 2, 7, 11, 45),
+            "start_time": datetime(2022, 1, 1, 14, 24, 11).astimezone(tz=timezone.utc),
+            "stop_time": datetime(2023, 1, 2, 7, 11, 45).astimezone(tz=timezone.utc),
             "n_cores": 2,
             "hepscore": 3.0,
             "tot_cpu": 12265325,
@@ -743,8 +743,8 @@ class TestAuditorApelPlugin:
 
         rec_1_values = {
             "rec_id": "test_record_1",
-            "start_time": datetime(1984, 3, 3, 0, 0, 0),
-            "stop_time": datetime(1985, 3, 3, 0, 0, 0),
+            "start_time": datetime(1984, 3, 3, 0, 0, 0).astimezone(tz=timezone.utc),
+            "stop_time": datetime(1985, 3, 3, 0, 0, 0).astimezone(tz=timezone.utc),
             "n_cores": 8,
             "hepscore": 10.0,
             "tot_cpu": 15520000,
@@ -757,8 +757,8 @@ class TestAuditorApelPlugin:
 
         rec_2_values = {
             "rec_id": "test_record_2",
-            "start_time": datetime(2023, 1, 1, 14, 24, 11),
-            "stop_time": datetime(2023, 1, 2, 7, 11, 45),
+            "start_time": datetime(2023, 1, 1, 14, 24, 11).astimezone(tz=timezone.utc),
+            "stop_time": datetime(2023, 1, 2, 7, 11, 45).astimezone(tz=timezone.utc),
             "n_cores": 1,
             "hepscore": 23.0,
             "tot_cpu": 12234325,
@@ -771,8 +771,8 @@ class TestAuditorApelPlugin:
 
         rec_3_values = {
             "rec_id": "test_record_3",
-            "start_time": datetime(2022, 1, 1, 14, 24, 11),
-            "stop_time": datetime(2023, 1, 2, 7, 11, 45),
+            "start_time": datetime(2022, 1, 1, 14, 24, 11).astimezone(tz=timezone.utc),
+            "stop_time": datetime(2023, 1, 2, 7, 11, 45).astimezone(tz=timezone.utc),
             "n_cores": 2,
             "hepscore": 3.0,
             "tot_cpu": 12265325,
@@ -786,8 +786,8 @@ class TestAuditorApelPlugin:
 
         rec_4_values = {
             "rec_id": "test_record_4",
-            "start_time": datetime(2022, 1, 1, 14, 24, 11),
-            "stop_time": datetime(2023, 1, 2, 7, 11, 45),
+            "start_time": datetime(2022, 1, 1, 14, 24, 11).astimezone(tz=timezone.utc),
+            "stop_time": datetime(2023, 1, 2, 7, 11, 45).astimezone(tz=timezone.utc),
             "n_cores": 2,
             "hepscore": 3.0,
             "tot_cpu": 12265325,
@@ -801,8 +801,8 @@ class TestAuditorApelPlugin:
 
         rec_5_values = {
             "rec_id": "test_record_4",
-            "start_time": datetime(2022, 1, 1, 14, 24, 11),
-            "stop_time": datetime(2023, 1, 2, 7, 11, 45),
+            "start_time": datetime(2022, 1, 1, 14, 24, 11).astimezone(tz=timezone.utc),
+            "stop_time": datetime(2023, 1, 2, 7, 11, 45).astimezone(tz=timezone.utc),
             "n_cores": 2,
             "hepscore": 3.0,
             "tot_cpu": 12265325,
@@ -922,8 +922,8 @@ class TestAuditorApelPlugin:
 
         rec_1_values = {
             "rec_id": "test_record_1",
-            "start_time": datetime(1984, 3, 3, 0, 0, 0),
-            "stop_time": datetime(1985, 3, 3, 0, 0, 0),
+            "start_time": datetime(1984, 3, 3, 0, 0, 0).astimezone(tz=timezone.utc),
+            "stop_time": datetime(1985, 3, 3, 0, 0, 0).astimezone(tz=timezone.utc),
             "n_cores": 8,
             "hepscore": 10.0,
             "tot_cpu": 15520000,
@@ -936,8 +936,8 @@ class TestAuditorApelPlugin:
 
         rec_2_values = {
             "rec_id": "test_record_2",
-            "start_time": datetime(2023, 1, 1, 14, 24, 11),
-            "stop_time": datetime(2023, 1, 2, 7, 11, 45),
+            "start_time": datetime(2023, 1, 1, 14, 24, 11).astimezone(tz=timezone.utc),
+            "stop_time": datetime(2023, 1, 2, 7, 11, 45).astimezone(tz=timezone.utc),
             "n_cores": 1,
             "hepscore": 23.0,
             "tot_cpu": 12234325,
@@ -993,8 +993,8 @@ class TestAuditorApelPlugin:
 
         rec_1_values = {
             "rec_id": "test_record_1",
-            "start_time": datetime(1984, 3, 3, 0, 0, 0),
-            "stop_time": datetime(1985, 3, 3, 0, 0, 0),
+            "start_time": datetime(1984, 3, 3, 0, 0, 0).astimezone(tz=timezone.utc),
+            "stop_time": datetime(1985, 3, 3, 0, 0, 0).astimezone(tz=timezone.utc),
             "n_cores": 8,
             "hepscore": 10.0,
             "tot_cpu": 15520000,
@@ -1007,8 +1007,8 @@ class TestAuditorApelPlugin:
 
         rec_2_values = {
             "rec_id": "test_record_2",
-            "start_time": datetime(2023, 1, 1, 14, 24, 11),
-            "stop_time": datetime(2023, 1, 2, 7, 11, 45),
+            "start_time": datetime(2023, 1, 1, 14, 24, 11).astimezone(tz=timezone.utc),
+            "stop_time": datetime(2023, 1, 2, 7, 11, 45).astimezone(tz=timezone.utc),
             "n_cores": 1,
             "hepscore": 23.0,
             "tot_cpu": 12234325,

--- a/pyauditor/Cargo.toml
+++ b/pyauditor/Cargo.toml
@@ -27,9 +27,8 @@ crate-type = ["cdylib"]
 [dependencies]
 auditor = { path = "../auditor", version = "0.1.0", default-features = false, features = ["client"] }
 anyhow = "1"
-pyo3 = { version = "0.15.2", features = ["extension-module", "anyhow"] }
-pyo3-asyncio = { version = "0.15", features = ["attributes", "tokio-runtime"] }
+pyo3 = { version = "0.19", features = ["chrono", "extension-module", "anyhow"] }
+pyo3-asyncio = { version = "0.19", features = ["attributes", "tokio-runtime"] }
 tokio = "1"
 chrono = { version = "0.4.26", features = ["serde"] }
-pyo3-chrono = { version = "0.3.0", features = [] }
 serde_json = "1.0.104"

--- a/pyauditor/docs/examples.rst
+++ b/pyauditor/docs/examples.rst
@@ -168,33 +168,30 @@ When the timestamps you are using are already in UTC, they can be used without f
 Timestamp in local time
 -----------------------
 
-This requires the python modules ``pytz`` and ``tzlocal``.
+This requires the python modules ``tzlocal``.
 
 Assuming that you are creating the timestamp yourself (it is not obtained from an external source), you need to attach the local timezone to the timestamp and then convert it to UTC:
 
 .. code-block:: python
 
-   import pytz
    from tzlocal import get_localzone
    local_tz = get_localzone()
-   timestamp = datetime.datetime(2022, 8, 16, 12, 00, 43, 48942, tzinfo=local_tz).astimezone(pytz.utc)
+   timestamp = datetime.datetime(2022, 8, 16, 12, 00, 43, 48942, tzinfo=local_tz).astimezone(datetime.timezone.utc)
 
 If you have a ``datetime`` object from some external source, the timezone can be attached like this:
 
 
 .. code-block:: python
 
-   import pytz
    from tzlocal import get_localzone
    local_tz = get_localzone()
-   timestamp = datetime_from_somewhere_else.replace(tzinfo=local_tz).astimezone(pytz.utc)
+   timestamp = datetime_from_somewhere_else.replace(tzinfo=local_tz).astimezone(datetime.timezone.utc)
 
 
 When using ``datetime.now()`` the local timezone also has to be provided explicitly. However, the parameter is now called ``tz`` instead of ``tzinfo`` because who needs consistency anyways?
 
 .. code-block:: python
 
-   import pytz
    from tzlocal import get_localzone
    local_tz = get_localzone()
-   timestamp = datetime.now(tz=local_tz).astimezone(pytz.utc)
+   timestamp = datetime.now(tz=local_tz).astimezone(datetime.timezone.utc)

--- a/pyauditor/pyproject.toml
+++ b/pyauditor/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["maturin>=0.13,<0.14"]
+requires = ["maturin>=1.0,<2.0"]
 build-backend = "maturin"
 
 [project]

--- a/pyauditor/pyproject.toml
+++ b/pyauditor/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "python-auditor"
-requires-python = ">=3.6"
+requires-python = ">=3.7"
 authors = [
     { name = "Stefan Kroboth", email = "stefan.kroboth@gmail.com" }
 ]

--- a/pyauditor/scripts/test_add_update.py
+++ b/pyauditor/scripts/test_add_update.py
@@ -3,7 +3,6 @@
 import asyncio
 from pyauditor import AuditorClientBuilder, Record
 import datetime
-import pytz
 from tzlocal import get_localzone
 
 
@@ -27,7 +26,7 @@ async def main():
     # datetimes sent to auditor MUST BE in UTC.
     start = datetime.datetime(
         2021, 12, 6, 16, 29, 43, 79043, tzinfo=local_tz
-    ).astimezone(pytz.utc)
+    ).astimezone(datetime.timezone.utc)
     record = Record(record_id, start)
 
     await client.add(record)
@@ -37,10 +36,10 @@ async def main():
     assert len(records) == 1
     record = records[0]
     assert record.record_id == record_id
-    assert record.start_time.replace(tzinfo=pytz.utc) == start
+    assert record.start_time.replace(tzinfo=datetime.timezone.utc) == start
 
     print("Updating record: Adding stop time")
-    stop = datetime.datetime.now(tz=local_tz).astimezone(pytz.utc)
+    stop = datetime.datetime.now(tz=local_tz).astimezone(datetime.timezone.utc)
 
     record = record.with_stop_time(stop)
     await client.update(record)
@@ -50,8 +49,8 @@ async def main():
     assert len(records) == 1
     record = records[0]
     assert record.record_id == record_id
-    assert record.start_time.replace(tzinfo=pytz.utc) == start
-    assert record.stop_time.replace(tzinfo=pytz.utc) == stop
+    assert record.start_time.replace(tzinfo=datetime.timezone.utc) == start
+    assert record.stop_time.replace(tzinfo=datetime.timezone.utc) == stop
 
     print("Script test_add_update.py finished.")
 

--- a/pyauditor/scripts/test_add_update_blocking.py
+++ b/pyauditor/scripts/test_add_update_blocking.py
@@ -2,7 +2,6 @@
 
 from pyauditor import AuditorClientBuilder, Record
 import datetime
-import pytz
 from tzlocal import get_localzone
 
 
@@ -28,7 +27,8 @@ def main():
     # datetimes sent to auditor MUST BE in UTC.
     start = datetime.datetime(
         2021, 12, 6, 16, 29, 43, 79043, tzinfo=local_tz
-    ).astimezone(pytz.utc)
+    ).astimezone(datetime.timezone.utc)
+
     record = Record(record_id, start)
 
     client.add(record)
@@ -38,10 +38,10 @@ def main():
     assert len(records) == 1
     record = records[0]
     assert record.record_id == record_id
-    assert record.start_time.replace(tzinfo=pytz.utc) == start
+    assert record.start_time.replace(tzinfo=datetime.timezone.utc) == start
 
     print("Updating record: Adding stop time")
-    stop = datetime.datetime.now(tz=local_tz).astimezone(pytz.utc)
+    stop = datetime.datetime.now(tz=local_tz).astimezone(datetime.timezone.utc)
 
     record = record.with_stop_time(stop)
     client.update(record)
@@ -51,8 +51,8 @@ def main():
     assert len(records) == 1
     record = records[0]
     assert record.record_id == record_id
-    assert record.start_time.replace(tzinfo=pytz.utc) == start
-    assert record.stop_time.replace(tzinfo=pytz.utc) == stop
+    assert record.start_time.replace(tzinfo=datetime.timezone.utc) == start
+    assert record.stop_time.replace(tzinfo=datetime.timezone.utc) == stop
 
     print("Script test_add_update.py finished.")
 

--- a/pyauditor/scripts/test_components.py
+++ b/pyauditor/scripts/test_components.py
@@ -3,7 +3,6 @@
 import asyncio
 from pyauditor import AuditorClientBuilder, Record, Component, Score
 import datetime
-import pytz
 from tzlocal import get_localzone
 
 
@@ -27,8 +26,8 @@ async def main():
     # datetimes sent to auditor MUST BE in UTC.
     start = datetime.datetime(
         2021, 12, 6, 16, 29, 43, 79043, tzinfo=local_tz
-    ).astimezone(pytz.utc)
-    # stop = datetime.datetime(2022, 8, 9, 3, 0, 0, 0, tzinfo=pytz.utc)
+    ).astimezone(datetime.timezone.utc)
+    # stop = datetime.datetime(2022, 8, 9, 3, 0, 0, 0, tzinfo=datetime.timezone.utc)
     score1 = Score("HEPSPEC", 1.0)
     score2 = Score("OTHERSPEC", 4.0)
     component1 = Component("comp-1", 10).with_score(score1)
@@ -43,7 +42,7 @@ async def main():
     assert len(records) == 1
     record = records[0]
     assert record.record_id == record_id
-    assert record.start_time.replace(tzinfo=pytz.utc) == start
+    assert record.start_time.replace(tzinfo=datetime.timezone.utc) == start
     assert record.components[0].name == "comp-1"
     assert record.components[0].amount == 10
     assert record.components[0].scores[0].name == "HEPSPEC"

--- a/pyauditor/scripts/test_components_blocking.py
+++ b/pyauditor/scripts/test_components_blocking.py
@@ -2,7 +2,6 @@
 
 from pyauditor import AuditorClientBuilder, Record, Component, Score
 import datetime
-import pytz
 from tzlocal import get_localzone
 
 
@@ -28,8 +27,8 @@ def main():
     # datetimes sent to auditor MUST BE in UTC.
     start = datetime.datetime(
         2021, 12, 6, 16, 29, 43, 79043, tzinfo=local_tz
-    ).astimezone(pytz.utc)
-    # stop = datetime.datetime(2022, 8, 9, 3, 0, 0, 0, tzinfo=pytz.utc)
+    ).astimezone(datetime.timezone.utc)
+    # stop = datetime.datetime(2022, 8, 9, 3, 0, 0, 0, tzinfo=datetime.timezone.utc)
     score1 = Score("HEPSPEC", 1.0)
     score2 = Score("OTHERSPEC", 4.0)
     component1 = Component("comp-1", 10).with_score(score1)
@@ -44,7 +43,7 @@ def main():
     assert len(records) == 1
     record = records[0]
     assert record.record_id == record_id
-    assert record.start_time.replace(tzinfo=pytz.utc) == start
+    assert record.start_time.replace(tzinfo=datetime.timezone.utc) == start
     assert record.components[0].name == "comp-1"
     assert record.components[0].amount == 10
     assert record.components[0].scores[0].name == "HEPSPEC"

--- a/pyauditor/scripts/test_eq.py
+++ b/pyauditor/scripts/test_eq.py
@@ -2,7 +2,6 @@
 
 from pyauditor import Record, Component, Score
 import datetime
-import pytz
 from tzlocal import get_localzone
 
 
@@ -19,7 +18,7 @@ def main():
     # datetimes sent to auditor MUST BE in UTC.
     start = datetime.datetime(
         2021, 12, 6, 16, 29, 43, 79043, tzinfo=local_tz
-    ).astimezone(pytz.utc)
+    ).astimezone(datetime.timezone.utc)
 
     score1 = Score(score, value)
     score2 = Score(score, value)

--- a/pyauditor/scripts/test_get_since.py
+++ b/pyauditor/scripts/test_get_since.py
@@ -3,7 +3,6 @@
 import asyncio
 from pyauditor import AuditorClientBuilder, Record
 import datetime
-import pytz
 from tzlocal import get_localzone
 
 
@@ -27,8 +26,8 @@ async def main():
         record_id = f"record-{i:02d}"
 
         # datetimes sent to auditor MUST BE in UTC.
-        start = datetime.datetime(2022, 8, 8, i, 0, 0, 0, tzinfo=pytz.utc)
-        stop = datetime.datetime(2022, 8, 9, i, 0, 0, 0, tzinfo=pytz.utc)
+        start = datetime.datetime(2022, 8, 8, i, 0, 0, 0, tzinfo=datetime.timezone.utc)
+        stop = datetime.datetime(2022, 8, 9, i, 0, 0, 0, tzinfo=datetime.timezone.utc)
         record = Record(record_id, start).with_stop_time(stop)
 
         await client.add(record)
@@ -43,7 +42,9 @@ async def main():
     for i in range(0, 24):
         assert records[i].record_id == f"record-{i:02d}"
 
-    start_since = datetime.datetime(2022, 8, 8, 11, 30, 0, 0, tzinfo=pytz.utc)
+    start_since = datetime.datetime(
+        2022, 8, 8, 11, 30, 0, 0, tzinfo=datetime.timezone.utc
+    )
 
     records = await client.get_started_since(start_since)
     assert len(records) == 12
@@ -53,7 +54,9 @@ async def main():
     for i in range(12, 24):
         assert records[i - 12].record_id == f"record-{i:02d}"
 
-    stop_since = datetime.datetime(2022, 8, 9, 11, 30, 0, 0, tzinfo=pytz.utc)
+    stop_since = datetime.datetime(
+        2022, 8, 9, 11, 30, 0, 0, tzinfo=datetime.timezone.utc
+    )
 
     records = await client.get_stopped_since(stop_since)
     assert len(records) == 12

--- a/pyauditor/scripts/test_get_since_blocking.py
+++ b/pyauditor/scripts/test_get_since_blocking.py
@@ -2,7 +2,6 @@
 
 from pyauditor import AuditorClientBuilder, Record
 import datetime
-import pytz
 from tzlocal import get_localzone
 
 
@@ -28,8 +27,8 @@ def main():
         record_id = f"record-{i:02d}"
 
         # datetimes sent to auditor MUST BE in UTC.
-        start = datetime.datetime(2022, 8, 8, i, 0, 0, 0, tzinfo=pytz.utc)
-        stop = datetime.datetime(2022, 8, 9, i, 0, 0, 0, tzinfo=pytz.utc)
+        start = datetime.datetime(2022, 8, 8, i, 0, 0, 0, tzinfo=datetime.timezone.utc)
+        stop = datetime.datetime(2022, 8, 9, i, 0, 0, 0, tzinfo=datetime.timezone.utc)
         record = Record(record_id, start).with_stop_time(stop)
 
         client.add(record)
@@ -44,7 +43,9 @@ def main():
     for i in range(0, 24):
         assert records[i].record_id == f"record-{i:02d}"
 
-    start_since = datetime.datetime(2022, 8, 8, 11, 30, 0, 0, tzinfo=pytz.utc)
+    start_since = datetime.datetime(
+        2022, 8, 8, 11, 30, 0, 0, tzinfo=datetime.timezone.utc
+    )
 
     records = client.get_started_since(start_since)
     assert len(records) == 12
@@ -54,7 +55,9 @@ def main():
     for i in range(12, 24):
         assert records[i - 12].record_id == f"record-{i:02d}"
 
-    stop_since = datetime.datetime(2022, 8, 9, 11, 30, 0, 0, tzinfo=pytz.utc)
+    stop_since = datetime.datetime(
+        2022, 8, 9, 11, 30, 0, 0, tzinfo=datetime.timezone.utc
+    )
 
     records = client.get_stopped_since(stop_since)
     assert len(records) == 12

--- a/pyauditor/scripts/test_meta.py
+++ b/pyauditor/scripts/test_meta.py
@@ -3,7 +3,6 @@
 import asyncio
 from pyauditor import AuditorClientBuilder, Record, Component, Meta
 import datetime
-import pytz
 from tzlocal import get_localzone
 
 
@@ -27,8 +26,8 @@ async def main():
     # datetimes sent to auditor MUST BE in UTC.
     start = datetime.datetime(
         2021, 12, 6, 16, 29, 43, 79043, tzinfo=local_tz
-    ).astimezone(pytz.utc)
-    # stop = datetime.datetime(2022, 8, 9, 3, 0, 0, 0, tzinfo=pytz.utc)
+    ).astimezone(datetime.timezone.utc)
+    # stop = datetime.datetime(2022, 8, 9, 3, 0, 0, 0, tzinfo=datetime.timezone.utc)
     component1 = Component("comp-1", 10)
     meta = (
         Meta()
@@ -44,7 +43,7 @@ async def main():
     assert len(records) == 1
     record = records[0]
     assert record.record_id == record_id
-    assert record.start_time.replace(tzinfo=pytz.utc) == start
+    assert record.start_time.replace(tzinfo=datetime.timezone.utc) == start
     assert record.components[0].name == "comp-1"
     assert record.components[0].amount == 10
     assert record.meta.get("site_id") == ["site_A"]

--- a/pyauditor/scripts/test_meta_blocking.py
+++ b/pyauditor/scripts/test_meta_blocking.py
@@ -2,7 +2,6 @@
 
 from pyauditor import AuditorClientBuilder, Record, Component, Meta
 import datetime
-import pytz
 from tzlocal import get_localzone
 
 
@@ -28,8 +27,8 @@ def main():
     # datetimes sent to auditor MUST BE in UTC.
     start = datetime.datetime(
         2021, 12, 6, 16, 29, 43, 79043, tzinfo=local_tz
-    ).astimezone(pytz.utc)
-    # stop = datetime.datetime(2022, 8, 9, 3, 0, 0, 0, tzinfo=pytz.utc)
+    ).astimezone(datetime.timezone.utc)
+    # stop = datetime.datetime(2022, 8, 9, 3, 0, 0, 0, tzinfo=datetime.timezone.utc)
     component1 = Component("comp-1", 10)
     meta = (
         Meta()
@@ -45,7 +44,7 @@ def main():
     assert len(records) == 1
     record = records[0]
     assert record.record_id == record_id
-    assert record.start_time.replace(tzinfo=pytz.utc) == start
+    assert record.start_time.replace(tzinfo=datetime.timezone.utc) == start
     assert record.components[0].name == "comp-1"
     assert record.components[0].amount == 10
     assert record.meta.get("site_id") == ["site_A"]

--- a/pyauditor/src/blocking_client.rs
+++ b/pyauditor/src/blocking_client.rs
@@ -6,10 +6,9 @@
 // copied, modified, or distributed except according to those terms.
 
 use crate::domain::Record;
-use chrono::{offset::TimeZone, Utc};
+use chrono::{DateTime, Utc};
 use pyo3::prelude::*;
 use pyo3::types::PyDateTime;
-use pyo3_chrono::NaiveDateTime;
 
 /// The `AuditorClientBlocking` handles the interaction with the Auditor instances and allows one to add
 /// records to the database, update records in the database and retrieve the records from the
@@ -54,19 +53,17 @@ impl AuditorClientBlocking {
     /// .. code-block:: python
     ///
     ///     # If the date/time is already in UTC:
-    ///     import pytz
-    ///     start_since = datetime.datetime(2022, 8, 8, 11, 30, 0, 0, tzinfo=pytz.utc)
+    ///     start_since = datetime.datetime(2022, 8, 8, 11, 30, 0, 0, tzinfo=datetime.timezone.utc)
     ///
     ///     # If it is in local time:
     ///     from tzlocal import get_localzone
     ///     local_tz = get_localzone()
-    ///     start_since = datetime.datetime(2022, 8, 8, 11, 30, 0, 0, tzinfo=local_tz).astimezone(pytz.utc)
+    ///     start_since = datetime.datetime(2022, 8, 8, 11, 30, 0, 0, tzinfo=local_tz).astimezone(datetime.timezone.utc)
     ///
     ///     records = client.get_stopped_since(start_since)
     ///
     fn get_started_since(self_: PyRef<'_, Self>, timestamp: &PyDateTime) -> PyResult<Vec<Record>> {
-        let timestamp: NaiveDateTime = timestamp.extract()?;
-        let timestamp = Utc.from_utc_datetime(&timestamp.into());
+        let timestamp: DateTime<Utc> = timestamp.extract()?;
         Ok(self_
             .inner
             .get_started_since(&timestamp)
@@ -90,19 +87,17 @@ impl AuditorClientBlocking {
     /// .. code-block:: python
     ///
     ///     # If the date/time is already in UTC:
-    ///     import pytz
-    ///     stop_since = datetime.datetime(2022, 8, 8, 11, 30, 0, 0, tzinfo=pytz.utc)
+    ///     stop_since = datetime.datetime(2022, 8, 8, 11, 30, 0, 0, tzinfo=datetime.timezone.utc)
     ///
     ///     # If it is in local time:
     ///     from tzlocal import get_localzone
     ///     local_tz = get_localzone()
-    ///     stop_since = datetime.datetime(2022, 8, 8, 11, 30, 0, 0, tzinfo=local_tz).astimezone(pytz.utc)
+    ///     stop_since = datetime.datetime(2022, 8, 8, 11, 30, 0, 0, tzinfo=local_tz).astimezone(datetime.timezone.utc)
     ///
     ///     records = client.get_stopped_since(stop_since)
     ///
     fn get_stopped_since(self_: PyRef<'_, Self>, timestamp: &PyDateTime) -> PyResult<Vec<Record>> {
-        let timestamp: NaiveDateTime = timestamp.extract()?;
-        let timestamp = Utc.from_utc_datetime(&timestamp.into());
+        let timestamp: DateTime<Utc> = timestamp.extract()?;
         Ok(self_
             .inner
             .get_stopped_since(&timestamp)

--- a/pyauditor/src/client.rs
+++ b/pyauditor/src/client.rs
@@ -6,10 +6,9 @@
 // copied, modified, or distributed except according to those terms.
 
 use crate::domain::Record;
-use chrono::{offset::TimeZone, Utc};
+use chrono::{DateTime, Utc};
 use pyo3::prelude::*;
 use pyo3::types::PyDateTime;
-use pyo3_chrono::NaiveDateTime;
 
 /// The `AuditorClient` handles the interaction with the Auditor instances and allows one to add
 /// records to the database, update records in the database and retrieve the records from the
@@ -61,13 +60,12 @@ impl AuditorClient {
     /// .. code-block:: python
     ///
     ///     # If the date/time is already in UTC:
-    ///     import pytz
-    ///     start_since = datetime.datetime(2022, 8, 8, 11, 30, 0, 0, tzinfo=pytz.utc)
+    ///     start_since = datetime.datetime(2022, 8, 8, 11, 30, 0, 0, tzinfo=datetime.timezone.utc)
     ///
     ///     # If it is in local time:
     ///     from tzlocal import get_localzone
     ///     local_tz = get_localzone()
-    ///     start_since = datetime.datetime(2022, 8, 8, 11, 30, 0, 0, tzinfo=local_tz).astimezone(pytz.utc)
+    ///     start_since = datetime.datetime(2022, 8, 8, 11, 30, 0, 0, tzinfo=local_tz).astimezone(datetime.timezone.utc)
     ///
     ///     records = client.get_stopped_since(start_since)
     ///
@@ -76,8 +74,7 @@ impl AuditorClient {
         timestamp: &PyDateTime,
         py: Python<'a>,
     ) -> PyResult<&'a PyAny> {
-        let timestamp: NaiveDateTime = timestamp.extract()?;
-        let timestamp = Utc.from_utc_datetime(&timestamp.into());
+        let timestamp: DateTime<Utc> = timestamp.extract()?;
         let inner = self_.inner.clone();
         pyo3_asyncio::tokio::future_into_py(py, async move {
             Ok(inner
@@ -104,13 +101,12 @@ impl AuditorClient {
     /// .. code-block:: python
     ///
     ///     # If the date/time is already in UTC:
-    ///     import pytz
-    ///     stop_since = datetime.datetime(2022, 8, 8, 11, 30, 0, 0, tzinfo=pytz.utc)
+    ///     stop_since = datetime.datetime(2022, 8, 8, 11, 30, 0, 0, tzinfo=datetime.timezone.utc)
     ///
     ///     # If it is in local time:
     ///     from tzlocal import get_localzone
     ///     local_tz = get_localzone()
-    ///     stop_since = datetime.datetime(2022, 8, 8, 11, 30, 0, 0, tzinfo=local_tz).astimezone(pytz.utc)
+    ///     stop_since = datetime.datetime(2022, 8, 8, 11, 30, 0, 0, tzinfo=local_tz).astimezone(datetime.timezone.utc)
     ///
     ///     records = client.get_stopped_since(stop_since)
     ///
@@ -119,8 +115,7 @@ impl AuditorClient {
         timestamp: &PyDateTime,
         py: Python<'a>,
     ) -> PyResult<&'a PyAny> {
-        let timestamp: NaiveDateTime = timestamp.extract()?;
-        let timestamp = Utc.from_utc_datetime(&timestamp.into());
+        let timestamp: DateTime<Utc> = timestamp.extract()?;
         let inner = self_.inner.clone();
         pyo3_asyncio::tokio::future_into_py(py, async move {
             Ok(inner

--- a/pyauditor/src/domain/component.rs
+++ b/pyauditor/src/domain/component.rs
@@ -6,7 +6,7 @@
 // copied, modified, or distributed except according to those terms.
 
 use crate::domain::Score;
-use pyo3::class::basic::{CompareOp, PyObjectProtocol};
+use pyo3::class::basic::CompareOp;
 use pyo3::prelude::*;
 
 /// Component(name: str, amount: int)
@@ -61,10 +61,7 @@ impl Component {
     fn scores(&self) -> Vec<Score> {
         self.inner.scores.iter().cloned().map(Score::from).collect()
     }
-}
 
-#[pyproto]
-impl PyObjectProtocol for Component {
     fn __richcmp__(&self, other: PyRef<Component>, op: CompareOp) -> Py<PyAny> {
         let py = other.py();
         match op {

--- a/pyauditor/src/domain/meta.rs
+++ b/pyauditor/src/domain/meta.rs
@@ -5,7 +5,7 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use pyo3::class::basic::{CompareOp, PyObjectProtocol};
+use pyo3::class::basic::CompareOp;
 use pyo3::prelude::*;
 
 /// Meta()
@@ -49,10 +49,7 @@ impl Meta {
     fn get(&self, key: String) -> Option<Vec<String>> {
         self.inner.get(&key).cloned()
     }
-}
 
-#[pyproto]
-impl PyObjectProtocol for Meta {
     fn __richcmp__(&self, other: PyRef<Meta>, op: CompareOp) -> Py<PyAny> {
         let py = other.py();
         match op {

--- a/pyauditor/src/domain/score.rs
+++ b/pyauditor/src/domain/score.rs
@@ -5,7 +5,7 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use pyo3::class::basic::{CompareOp, PyObjectProtocol};
+use pyo3::class::basic::CompareOp;
 use pyo3::prelude::*;
 
 /// Score(name: str, value: float)
@@ -53,10 +53,7 @@ impl Score {
     fn value(&self) -> f64 {
         *self.inner.value.as_ref()
     }
-}
 
-#[pyproto]
-impl PyObjectProtocol for Score {
     fn __richcmp__(&self, other: PyRef<Score>, op: CompareOp) -> Py<PyAny> {
         let py = other.py();
         match op {

--- a/scripts/test_pyauditor.sh
+++ b/scripts/test_pyauditor.sh
@@ -17,7 +17,6 @@ function compile_pyauditor() {
 	python -m venv $ENV_DIR
 	source $ENV_DIR/bin/activate
   pip install maturin
-  pip install pytz
   pip install tzlocal
 	if [ "$RELEASE_MODE" = true ]; then
 		maturin develop --manifest-path pyauditor/Cargo.toml --release


### PR DESCRIPTION
This PR updates `pyo3` and `pyo3-asyncio` to version `0.19`. 

Remove pyo3-chrono, because it is deprecated and has been integrated into pyo3 with the `chrono` feature.

Support for Python 3.6 has to be dropped because it is not supported anymore by pyo3 v0.19.

This closes #110.