### PR TITLE
GitHub workflow for python unit tests

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -73,6 +73,5 @@ jobs:
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3
         with:
-          token: ${{ secrets.CODECOV_TOKEN }} # not required for public repos
           files: lcov.info
           fail_ci_if_error: true

--- a/.github/workflows/python-unit-tests.yml
+++ b/.github/workflows/python-unit-tests.yml
@@ -1,0 +1,40 @@
+name: python-unit-tests
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  unit-tests-apel-plugin:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./plugins/apel
+    strategy:
+      matrix:
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install pyauditor from repo
+        working-directory: ./pyauditor
+        run: |
+          pip install --upgrade pip
+          pip install .
+      - name: Install dependencies
+        run: |
+          pip install -e .[tests]
+      - name: Run pytest
+        run: pytest
+      - name: Upload coverage
+        uses: codecov/codecov-action@v3
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          working-directory: ./plugins/apel
+          files: lcov.info
+          fail_ci_if_error: true

--- a/.github/workflows/python-unit-tests.yml
+++ b/.github/workflows/python-unit-tests.yml
@@ -34,7 +34,6 @@ jobs:
       - name: Upload coverage
         uses: codecov/codecov-action@v3
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
           working-directory: ./plugins/apel
           files: lcov.info
           fail_ci_if_error: true

--- a/.github/workflows/python-unit-tests.yml
+++ b/.github/workflows/python-unit-tests.yml
@@ -6,8 +6,35 @@ on:
     branches: [main]
 
 jobs:
+  build-pyauditor:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./pyauditor
+    strategy:
+      matrix:
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Build pyauditor wheel from repo
+        run: |
+          pip install --upgrade pip
+          pip wheel .
+      - name: Upload pyauditor wheel
+        uses: actions/upload-artifact@v3
+        with:
+          name: pyauditor-wheel-${{ matrix.python-version }}
+          path: pyauditor/*.whl
+          retention-days: 7
+
   unit-tests-apel-plugin:
     runs-on: ubuntu-latest
+    needs: build-pyauditor
     defaults:
       run:
         working-directory: ./plugins/apel
@@ -21,19 +48,40 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Install pyauditor from repo
-        working-directory: ./pyauditor
-        run: |
-          pip install --upgrade pip
-          pip install .
+      - name: Download pyauditor wheel
+        uses: actions/download-artifact@v3
+        with:
+          name: pyauditor-wheel-${{ matrix.python-version }}
+          path: ./plugins/apel
       - name: Install dependencies
         run: |
+          pip install --upgrade pip
+          pip install *.whl
           pip install -e .[tests]
       - name: Run pytest
         run: pytest
+      - name: Upload coverage as artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: lcov-${{ matrix.python-version }}.info
+          path: ./plugins/apel/lcov.info
+          retention-days: 7
+
+  upload-coverage:
+    runs-on: ubuntu-latest
+    needs: unit-tests-apel-plugin
+    strategy:
+      matrix:
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@v3
+      - name: Download coverage artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: lcov-${{ matrix.python-version }}.info
       - name: Upload coverage
         uses: codecov/codecov-action@v3
         with:
-          working-directory: ./plugins/apel
           files: lcov.info
           fail_ci_if_error: true

--- a/codecov.yaml
+++ b/codecov.yaml
@@ -11,3 +11,6 @@ component_management:
       name: auditor
       paths:
         - auditor/**
+
+codecov:
+  token: ef0e698e-e1de-4603-88fa-b3d7c10fb0e1

--- a/codecov.yaml
+++ b/codecov.yaml
@@ -1,0 +1,13 @@
+comment:
+  layout: "header, diff, components"
+  
+component_management:
+  individual_components:
+    - component_id: module_apel_plugin
+      name: apel_plugin
+      paths:
+        - plugins/apel/**
+    - component_id: module_auditor
+      name: auditor
+      paths:
+        - auditor/**

--- a/codecov.yaml
+++ b/codecov.yaml
@@ -11,6 +11,18 @@ component_management:
       name: auditor
       paths:
         - auditor/**
+    - component_id: module_slurm_collector
+      name: slurm_collector
+      paths:
+        - collectors/slurm/**
+    - component_id: module_slurm_epilog_collector
+      name: slurm_epilog_collector
+      paths:
+        - collectors/slurm-epilog/**
+    - component_id: module_priority_plugin
+      name: priority_plugin
+      paths:
+        - plugins/priority/**
 
 codecov:
   token: ef0e698e-e1de-4603-88fa-b3d7c10fb0e1

--- a/plugins/apel/pyproject.toml
+++ b/plugins/apel/pyproject.toml
@@ -36,22 +36,25 @@ auditor-apel-republish = "auditor_apel_plugin.republish:main"
 
 [tool.setuptools_scm]
 local_scheme = "no-local-version"
-write_to = "src/auditor_apel_plugin/_version.py"
+root = "../.."
 
 [tool.setuptools.packages.find]
 where = ["src"]
 
 [tool.coverage.run]
 source = ["src"]
-omit = ["*__init__.py","*publish.py","*_version.py"]
+omit = ["*__init__.py", "*publish.py", "*_version.py"]
 branch = true
+
+[tool.coverage.lcov]
+output = "lcov.info"
 
 [tool.black]
 line-length = 79
 include = '\.pyi?$'
 
 [tool.pytest.ini_options]
-addopts = "-s -v --cov"
+addopts = "-s -v --cov --cov-report lcov"
 testpaths = [
 	  "tests",
 ]

--- a/plugins/apel/tests/test_auditor_apel_plugin.py
+++ b/plugins/apel/tests/test_auditor_apel_plugin.py
@@ -23,6 +23,9 @@ import configparser
 import pyauditor
 from unittest.mock import patch, PropertyMock
 import ast
+from pathlib import Path, PurePath
+
+test_dir = PurePath(__file__).parent
 
 
 class FakeAuditorClient:
@@ -163,7 +166,11 @@ class TestAuditorApelPlugin:
             assert result == [(time_stamp, datetime(1970, 1, 1, 0, 0, 0))]
 
     def test_sign_msg(self):
-        result = sign_msg("tests/test_cert.cert", "tests/test_key.key", "test")
+        result = sign_msg(
+            Path.joinpath(test_dir, "test_cert.cert"),
+            Path.joinpath(test_dir, "test_key.key"),
+            "test",
+        )
 
         with open("/tmp/signed_msg.txt", "wb") as msg_file:
             msg_file.write(result)
@@ -179,13 +186,17 @@ class TestAuditorApelPlugin:
     def test_sign_msg_fail(self):
         with pytest.raises(Exception) as pytest_error:
             sign_msg(
-                "tests/nofolder/test_cert.cert",
-                "tests/no/folder/test_key.key",
+                "tests/nodir/test_cert.cert",
+                "tests/no/dir/test_key.key",
                 "test",
             )
         assert pytest_error.type == FileNotFoundError
 
-        result = sign_msg("tests/test_cert.cert", "tests/test_key.key", "test")
+        result = sign_msg(
+            Path.joinpath(test_dir, "test_cert.cert"),
+            Path.joinpath(test_dir, "test_key.key"),
+            "test",
+        )
 
         with open("/tmp/signed_msg.txt", "wb") as msg_file:
             msg_file.write(result.replace(b"test", b"TEST"))


### PR DESCRIPTION
This PR adds a workflow to run unit tests for the python code in the repo and upload the coverage. The idea is to do this separately for all python packages in the repo such that the respective pyproject.toml file is used.
Closes #338.