### PR TITLE
Fix path to overview image

### DIFF
--- a/media/website/templates/index.html
+++ b/media/website/templates/index.html
@@ -29,7 +29,7 @@
         {% block hero %}
         <script async defer src="https://buttons.github.io/buttons.js"></script>
         <section class="text-center">
-            <img src="../../auditor_overview.png" alt="AUDITOR"  style="width: 100%">
+            <img src="auditor_overview.png" alt="AUDITOR"  style="width: 100%">
             <h1 class="heading-text" style="color : white;font-size: 80px">
               <b>AUDITOR</b>
             </h1>


### PR DESCRIPTION
Currently, the overview image is not displayed (see https://alu-schumacher.github.io/AUDITOR/), because we cannot use relative filepaths like this for the index page. This fixes the file path to use a valid one.