### PR TITLE
add HTCondor collector to dependabot checks and coverage

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,11 @@ updates:
     directory: "/plugins/apel"
     schedule:
       interval: "daily"
+  # HTCondor collector
+  - package-ecosystem: "pip"
+    directory: "/collectors/htcondor"
+    schedule:
+      interval: "daily"
   # GitHub action
   - package-ecosystem: "github-actions"
     directory: "/"

--- a/codecov.yaml
+++ b/codecov.yaml
@@ -19,6 +19,10 @@ component_management:
       name: slurm_epilog_collector
       paths:
         - collectors/slurm-epilog/**
+    - component_id: module_htcondor_collector
+      name: htcondor_collector
+      paths:
+        - collectors/htcondor/**
     - component_id: module_priority_plugin
       name: priority_plugin
       paths:

--- a/collectors/htcondor/pyproject.toml
+++ b/collectors/htcondor/pyproject.toml
@@ -12,8 +12,8 @@ description = "AUDITOR collector for aggregating data from the HTCondor batch sy
 version = "0.1.0"
 requires-python = ">=3.6"
 dependencies = [
-    "pyyaml",
-    "python-auditor"
+    "pyyaml==6.0.1",
+    "python-auditor==0.1.0"
 ]
 readme = "README.md"
 


### PR DESCRIPTION
This PR adds the HTCondor collector to the dependabot update checks and to the coverage overview. Unit tests are missing.