### PR TITLE
replace pytz.utc with datetime.timezone.utc, remove pytz dependency

### DIFF
--- a/plugins/apel/pyproject.toml
+++ b/plugins/apel/pyproject.toml
@@ -8,7 +8,6 @@ version = "0.1.0"
 requires-python = ">=3.7"
 dependencies = [
 	     "python-auditor==0.1.0",
-	     "pytz==2023.3",
 	     "requests==2.31.0",
 	     "cryptography==41.0.3",
 ]
@@ -45,7 +44,6 @@ branch = true
 output = "lcov.info"
 
 [tool.black]
-line-length = 79
 include = '\.pyi?$'
 
 [tool.pytest.ini_options]

--- a/plugins/apel/src/auditor_apel_plugin/core.py
+++ b/plugins/apel/src/auditor_apel_plugin/core.py
@@ -9,7 +9,6 @@ import sqlite3
 from sqlite3 import Error
 from datetime import datetime, timedelta, time, timezone
 from time import sleep
-import pytz
 import json
 import sys
 import requests
@@ -49,7 +48,7 @@ def get_begin_previous_month(current_time):
     previous_month = first_current_month - timedelta(days=1)
     first_previous_month = previous_month.replace(day=1)
     begin_previous_month = datetime.combine(first_previous_month, time())
-    begin_previous_month_utc = begin_previous_month.replace(tzinfo=pytz.utc)
+    begin_previous_month_utc = begin_previous_month.replace(tzinfo=timezone.utc)
 
     return begin_previous_month_utc
 
@@ -87,7 +86,7 @@ def create_time_db(publish_since, time_db_path):
     initial_report_time = datetime(1970, 1, 1, 0, 0, 0)
     publish_since_datetime = datetime.strptime(publish_since, "%Y-%m-%d %H:%M:%S%z")
     data_tuple = (
-        publish_since_datetime.replace(tzinfo=pytz.utc).timestamp(),
+        publish_since_datetime.replace(tzinfo=timezone.utc).timestamp(),
         initial_report_time,
     )
 
@@ -113,7 +112,7 @@ def get_start_time(conn):
         cur.row_factory = lambda cursor, row: row[0]
         cur.execute("SELECT last_end_time FROM times")
         start_time_row = cur.fetchall()
-        start_time = datetime.fromtimestamp(start_time_row[0], tz=pytz.utc)
+        start_time = datetime.fromtimestamp(start_time_row[0], tz=timezone.utc)
         cur.close()
         return start_time
     except Error as e:

--- a/plugins/apel/src/auditor_apel_plugin/publish.py
+++ b/plugins/apel/src/auditor_apel_plugin/publish.py
@@ -5,8 +5,7 @@
 
 import logging
 from pyauditor import AuditorClientBuilder
-from datetime import datetime, timedelta
-import pytz
+from datetime import datetime, timedelta, timezone
 import configparser
 import argparse
 import base64
@@ -60,7 +59,9 @@ def run(config, client):
 
             records_summary = get_records(client, start_time, 30)
 
-            latest_stop_time = records_summary[-1].stop_time.replace(tzinfo=pytz.utc)
+            latest_stop_time = records_summary[-1].stop_time.replace(
+                tzinfo=timezone.utc
+            )
             logging.debug(f"Latest stop time is {latest_stop_time}")
             summary_db = create_summary_db(config, records_summary)
             grouped_summary_list = group_summary_db(summary_db)

--- a/plugins/apel/src/auditor_apel_plugin/republish.py
+++ b/plugins/apel/src/auditor_apel_plugin/republish.py
@@ -7,8 +7,7 @@ import logging
 from pyauditor import AuditorClientBuilder
 import configparser
 import argparse
-from datetime import datetime
-import pytz
+from datetime import datetime, timezone
 import base64
 from auditor_apel_plugin.core import (
     get_token,
@@ -30,7 +29,7 @@ def run(config, args, client):
     year = args.year
     site = args.site
 
-    begin_month = datetime(year, month, 1).replace(tzinfo=pytz.utc)
+    begin_month = datetime(year, month, 1).replace(tzinfo=timezone.utc)
 
     records = get_records(client, begin_month, 30)
     token = get_token(config)

--- a/plugins/apel/tests/test_auditor_apel_plugin.py
+++ b/plugins/apel/tests/test_auditor_apel_plugin.py
@@ -15,7 +15,6 @@ from auditor_apel_plugin.core import (
     get_site_id,
 )
 from datetime import datetime, timezone
-import pytz
 import sqlite3
 import os
 import subprocess
@@ -90,10 +89,10 @@ class TestAuditorApelPlugin:
         time_b = datetime(1970, 1, 1, 00, 00, 00)
 
         result = get_begin_previous_month(time_a)
-        assert result == datetime(2022, 9, 1, 00, 00, 00, tzinfo=pytz.utc)
+        assert result == datetime(2022, 9, 1, 00, 00, 00, tzinfo=timezone.utc)
 
         result = get_begin_previous_month(time_b)
-        assert result == datetime(1969, 12, 1, 00, 00, 00, tzinfo=pytz.utc)
+        assert result == datetime(1969, 12, 1, 00, 00, 00, tzinfo=timezone.utc)
 
     def test_create_time_db(self):
         path = ":memory:"
@@ -111,7 +110,7 @@ class TestAuditorApelPlugin:
             cur.close()
             time_db.close()
             time_dt = datetime.strptime(publish_since, "%Y-%m-%d %H:%M:%S%z")
-            time_stamp = time_dt.replace(tzinfo=pytz.utc).timestamp()
+            time_stamp = time_dt.replace(tzinfo=timezone.utc).timestamp()
 
             assert result == [(time_stamp, datetime(1970, 1, 1, 0, 0, 0))]
 
@@ -145,7 +144,7 @@ class TestAuditorApelPlugin:
             cur.close()
             time_db.close()
             time_dt = datetime.strptime(publish_since, "%Y-%m-%d %H:%M:%S%z")
-            time_stamp = time_dt.replace(tzinfo=pytz.utc).timestamp()
+            time_stamp = time_dt.replace(tzinfo=timezone.utc).timestamp()
             os.remove(path)
 
             assert result == [(time_stamp, datetime(1970, 1, 1, 0, 0, 0))]
@@ -160,7 +159,7 @@ class TestAuditorApelPlugin:
             cur.close()
             time_db.close()
             time_dt = datetime.strptime(publish_since, "%Y-%m-%d %H:%M:%S%z")
-            time_stamp = time_dt.replace(tzinfo=pytz.utc).timestamp()
+            time_stamp = time_dt.replace(tzinfo=timezone.utc).timestamp()
             os.remove(path)
 
             assert result == [(time_stamp, datetime(1970, 1, 1, 0, 0, 0))]
@@ -222,7 +221,7 @@ class TestAuditorApelPlugin:
             result = get_start_time(time_db)
             time_db.close()
             time_dt = datetime.strptime(publish_since, "%Y-%m-%d %H:%M:%S%z")
-            time_dt_utc = time_dt.replace(tzinfo=pytz.utc)
+            time_dt_utc = time_dt.replace(tzinfo=timezone.utc)
 
             assert result == time_dt_utc
 


### PR DESCRIPTION
This PR replaces `pytz.utc` with `datetime.timezone.utc`, therefore the `pytz` dependency is no longer needed.