### PR TITLE
[HTCondor-collector] Clean meta values from special characters.

### DIFF
--- a/collectors/htcondor/src/auditor_htcondor_collector/collector.py
+++ b/collectors/htcondor/src/auditor_htcondor_collector/collector.py
@@ -213,7 +213,7 @@ class CondorHistoryCollector(object):
             for item in entry if isinstance(entry, list) else [entry]:
                 value = get_value(item, job)
                 if value is not None:
-                    values.append(value)
+                    values.append(quote(value, safe=""))
                     if key == "site":  # site is a special case
                         break
             if not values:


### PR DESCRIPTION
If meta values contain [special characters](https://alu-schumacher.github.io/AUDITOR/pyauditor/api.html#pyauditor.Meta), the record generation fails. This PR fixes that by quoting the values, as already done for record id. 