### PR TITLE
move check for empty record list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,6 @@ nohup.out
 dist/
 **/testdb.db
 **/target/
+**/lcov.info
 /venv
 *~

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+
+### Changed
+- Apel plugin: Bugfix in catching empty record list ([@dirksammel](https://github.com/dirksammel))
+
+### Removed
 
 ## [0.1.0] - 2023-04-19
 ### Added

--- a/plugins/apel/src/auditor_apel_plugin/publish.py
+++ b/plugins/apel/src/auditor_apel_plugin/publish.py
@@ -57,11 +57,8 @@ def run(config, client):
         logging.info(f"Getting records since {start_time}")
 
         records_summary = get_records(client, start_time, 30)
-        try:
-            latest_stop_time = records_summary[-1].stop_time.replace(
-                tzinfo=timezone.utc
-            )
-        except IndexError:
+
+        if len(records_summary) == 0:
             logging.info("No new records, do nothing for now")
             time_db_conn.close()
             logging.info(
@@ -70,6 +67,8 @@ def run(config, client):
             )
             sleep(report_interval)
             continue
+
+        latest_stop_time = records_summary[-1].stop_time.replace(tzinfo=timezone.utc)
 
         logging.debug(f"Latest stop time is {latest_stop_time}")
         summary_db = create_summary_db(config, records_summary)


### PR DESCRIPTION
This PR moves the check if the record list is empty and ensures that the resulting `IndexError` can only come from that.
Closes #422.