### PR TITLE
Catch "undefined" value from HTCondor.

### DIFF
--- a/.github/workflows/htcondor-collector.yaml
+++ b/.github/workflows/htcondor-collector.yaml
@@ -41,7 +41,7 @@ jobs:
     - name: Submit test job
       run: |
         docker exec -u submituser -w /home/submituser htcondor-submit-1 \
-          bash -c "echo -e \"executable=/bin/sleep\narguments=2\n+VoName=testgroup\nqueue\" > job \
+          bash -c "echo -e \"executable=/bin/sleep\narguments=2\n+VoName=\\\"testgroup\\\"\nqueue\" > job \
             && condor_submit job"
     - name: Wait for job and collector
       run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Slurm collector: Fix parsing of ParsableType::Time for certain cases ([@QuantumDancer](https://github.com/QuantumDancer))
 - Dependencies: Updated docker/build-push-action from 4 to 5 ([@dirksammel](https://github.com/dirksammel))
 - Dependencies: Updated docker/login-action from 2 to 3 ([@dirksammel](https://github.com/dirksammel))
+- HTCondor collector: Handle `undefined` values from the batch system correctly ([@rfvc](https://github.com/rfvc))
 
 ### Removed
 

--- a/collectors/htcondor/src/auditor_htcondor_collector/collector.py
+++ b/collectors/htcondor/src/auditor_htcondor_collector/collector.py
@@ -188,6 +188,9 @@ class CondorHistoryCollector(object):
         components = []
         for component in self.config.components:
             amount = get_value(component, job)
+            self.logger.debug(
+                f"Got amount {amount!r} ({type(amount)}) for component {component!r}."
+            )
             if amount is not None:
                 try:
                     # AUDITOR expects int-values for components
@@ -207,7 +210,7 @@ class CondorHistoryCollector(object):
             else:
                 self.logger.warning(
                     f"Could not get value for component {component['name']!r} "
-                    f"for job {job['GlobalJobId']!r}."
+                    f"({component!r}) for job {job['GlobalJobId']!r}."
                 )
                 raise ValueError
         return components

--- a/collectors/htcondor/src/auditor_htcondor_collector/utils.py
+++ b/collectors/htcondor/src/auditor_htcondor_collector/utils.py
@@ -76,6 +76,8 @@ def get_value(config_entry: T_Config, job: dict):
     if "key" in config_entry:
         try:
             val = job[config_entry["key"]]
+            if val == "undefined":
+                return None
         except KeyError:
             return None
     elif "factor" in config_entry:


### PR DESCRIPTION
If a certain ClassAd is not set on a job, HTCondor returns the string `undefined`. This PR implements skipping the value, when generating the meta data or components of a record.