### PR TITLE
Slurm collector: Fix parsing of ParsableType::Time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Apel plugin: Bugfix in catching empty record list ([@dirksammel](https://github.com/dirksammel))
+- Slurm collector: Fix parsing of ParsableType::Time for certain cases ([@QuantumDancer](https://github.com/QuantumDancer))
 
 ### Removed
 

--- a/collectors/slurm/src/configuration.rs
+++ b/collectors/slurm/src/configuration.rs
@@ -318,8 +318,9 @@ impl ParsableType {
             ParsableType::Time => {
                 let set = Lazy::new(|| {
                     RegexSet::new([
-                        r"(?P<min>\d{2}):(?P<sec>\d{2})\.(?P<milli>\d+)",
-                        r"(?P<hour>\d{2}):(?P<min>\d{2}):(?P<sec>\d{2})",
+                        r"^(?P<min>\d{2}):(?P<sec>\d{2})\.(?P<milli>\d+)$",
+                        r"^(?P<hour>\d{2}):(?P<min>\d{2}):(?P<sec>\d{2})$",
+                        r"^(?P<day>\d{1,2})-(?P<hour>\d{2}):(?P<min>\d{2}):(?P<sec>\d{2})$",
                     ])
                     .unwrap()
                 });
@@ -377,9 +378,10 @@ impl ParsableType {
 
                 AllowedTypes::Integer(
                     pm("milli", &cap)?
-                        + pm("sec", &cap)? * 1000
+                        + pm("sec", &cap)? * 1_000
                         + pm("min", &cap)? * 60_000
-                        + pm("hour", &cap)? * 1_440_000,
+                        + pm("hour", &cap)? * 3_600_000
+                        + pm("day", &cap)? * 86_400_000,
                 )
             }
             ParsableType::String => AllowedTypes::String(input.to_owned()),
@@ -477,6 +479,21 @@ pub fn get_configuration() -> Result<Settings, config::ConfigError> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn correct_time_parsed() {
+        let parsed = ParsableType::Time.parse("43:28.686").unwrap();
+        let expected = AllowedTypes::Integer(2608686);
+        assert_eq!(parsed, expected);
+
+        let parsed = ParsableType::Time.parse("10:07:24").unwrap();
+        let expected = AllowedTypes::Integer(36444000);
+        assert_eq!(parsed, expected);
+
+        let parsed = ParsableType::Time.parse("2-08:19:41").unwrap();
+        let expected = AllowedTypes::Integer(202781000);
+        assert_eq!(parsed, expected);
+    }
 
     #[test]
     fn correct_json_parsed() {


### PR DESCRIPTION
This fixes multiple issues with the parsing of `ParsableType::Time`:

- Expressions of D-HH:MM:SS were not parsed correctly because this is matched by the `(?P<hour>\d{2}):(?P<min>\d{2}):(?P<sec>\d{2}` regex. But this does not match the days. Solution: Introduce a new regex expression that also matches the days and in addition make sure (by using `^` and `$`) that the whole string is matched.
- The conversion factor between hours and milliseconds was wrong. The correct factor is `60*60*1000` = `3_600_000`.

In addition, unit tests have been added to confirm the correctness of the parsing.

This fixes #427 