### PR TITLE
catch VOMS information in unknown format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Apel plugin: Bugfix in catching empty record list ([@dirksammel](https://github.com/dirksammel))
+- Apel plugin: Catch VOMS information that does not start with `/` ([@dirksammel](https://github.com/dirksammel))
 - Slurm collector: Fix parsing of ParsableType::Time for certain cases ([@QuantumDancer](https://github.com/QuantumDancer))
 - Dependencies: Updated docker/build-push-action from 4 to 5 ([@dirksammel](https://github.com/dirksammel))
 - Dependencies: Updated docker/login-action from 2 to 3 ([@dirksammel](https://github.com/dirksammel))

--- a/plugins/apel/src/auditor_apel_plugin/core.py
+++ b/plugins/apel/src/auditor_apel_plugin/core.py
@@ -192,34 +192,50 @@ def get_voms_info(record, config):
 
     try:
         voms_string = replace_record_string(record.meta.get(meta_key_voms)[0])
-        voms_list = voms_string.split("/")
-        voms_dict["vo"] = voms_list[1]
-
-        if "Role" not in voms_string:
-            logging.warning(
-                f"No Role found in VOMS of {record.record_id}: {voms_string}, "
-                "not sending VORole"
-            )
-            voms_dict["vorole"] = None
-
-            if len(voms_list) == 2:
-                voms_dict["vogroup"] = "/" + voms_list[1]
-            else:
-                voms_dict["vogroup"] = "/" + voms_list[1] + "/" + voms_list[2]
-        elif len(voms_list) == 3:
-            voms_dict["vogroup"] = "/" + voms_list[1]
-            voms_dict["vorole"] = voms_list[2]
-        else:
-            voms_dict["vogroup"] = "/" + voms_list[1] + "/" + voms_list[2]
-            voms_dict["vorole"] = voms_list[3]
     except TypeError:
         logging.warning(
             f"No VOMS information found in {record.record_id}, "
             "not sending VO, VOGroup, and VORole"
         )
+
         voms_dict["vo"] = None
         voms_dict["vogroup"] = None
         voms_dict["vorole"] = None
+
+        return voms_dict
+
+    if not voms_string.startswith("/"):
+        logging.warning(
+            f"VOMS information found in {record.record_id} has unknown "
+            f"format: {voms_string}. Not sending VO, VOGroup, and VORole"
+        )
+
+        voms_dict["vo"] = None
+        voms_dict["vogroup"] = None
+        voms_dict["vorole"] = None
+
+        return voms_dict
+
+    voms_list = voms_string.split("/")
+    voms_dict["vo"] = voms_list[1]
+
+    if "Role" not in voms_string:
+        logging.warning(
+            f"No Role found in VOMS of {record.record_id}: {voms_string}, "
+            "not sending VORole"
+        )
+        voms_dict["vorole"] = None
+
+        if len(voms_list) == 2:
+            voms_dict["vogroup"] = "/" + voms_list[1]
+        else:
+            voms_dict["vogroup"] = "/" + voms_list[1] + "/" + voms_list[2]
+    elif len(voms_list) == 3:
+        voms_dict["vogroup"] = "/" + voms_list[1]
+        voms_dict["vorole"] = voms_list[2]
+    else:
+        voms_dict["vogroup"] = "/" + voms_list[1] + "/" + voms_list[2]
+        voms_dict["vorole"] = voms_list[3]
 
     return voms_dict
 

--- a/plugins/apel/tests/test_auditor_apel_plugin.py
+++ b/plugins/apel/tests/test_auditor_apel_plugin.py
@@ -818,12 +818,28 @@ class TestAuditorApelPlugin:
             "voms": None,
         }
 
+        rec_6_values = {
+            "rec_id": "test_record_4",
+            "start_time": datetime(2022, 1, 1, 14, 24, 11).astimezone(tz=timezone.utc),
+            "stop_time": datetime(2023, 1, 2, 7, 11, 45).astimezone(tz=timezone.utc),
+            "n_cores": 2,
+            "hepscore": 3.0,
+            "tot_cpu": 12265325,
+            "n_nodes": 1,
+            "site": "test-site-2",
+            "user": "second_user",
+            "submit_host": None,
+            "user_name": "%2FDC=ch%2FDC=cern%2FOU=Users%2FCN=test2: test2",
+            "voms": "atlas",
+        }
+
         rec_value_list = [
             rec_1_values,
             rec_2_values,
             rec_3_values,
             rec_4_values,
             rec_5_values,
+            rec_6_values,
         ]
         records = []
 
@@ -857,6 +873,11 @@ class TestAuditorApelPlugin:
         assert result["vorole"] is None
 
         result = get_voms_info(records[4], conf)
+        assert result["vo"] is None
+        assert result["vogroup"] is None
+        assert result["vorole"] is None
+
+        result = get_voms_info(records[5], conf)
         assert result["vo"] is None
         assert result["vogroup"] is None
         assert result["vorole"] is None


### PR DESCRIPTION
This PR catches VOMS information with an unknown format, i.e. that doesn't start with `/`. Nothing is sent to APEL in this case.
Closes #421.