### PR TITLE
Add semver tags and edge tag for docker containers

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -29,14 +29,14 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Log in to Docker Hub
-        if: ${{ github.repository == 'ALU-Schumacher/AUDITOR' && github.ref == 'refs/heads/main' }}
+        if: ${{ github.repository == 'ALU-Schumacher/AUDITOR' && github.event_name != 'pull_request' }}
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Log in to ghcr.io
-        if: ${{ github.repository == 'ALU-Schumacher/AUDITOR' && github.ref == 'refs/heads/main' }}
+        if: ${{ github.repository == 'ALU-Schumacher/AUDITOR' && github.event_name != 'pull_request' }}
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
@@ -50,6 +50,11 @@ jobs:
           images: |
             aluschumacher/${{ matrix.containers }}
             ghcr.io/ALU-Schumacher/${{ matrix.containers }}
+          tags: |
+            type=edge,branch=main
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}},enable=${{ !startsWith(github.ref, 'refs/tags/v0.') }}
 
       - name: Setup Docker buildx
         uses: docker/setup-buildx-action@v3
@@ -59,7 +64,7 @@ jobs:
         with:
           context: .
           file: containers/${{ matrix.containers }}/Dockerfile
-          push: ${{ github.repository == 'ALU-Schumacher/AUDITOR' && github.ref == 'refs/heads/main' }}
+          push: ${{ github.repository == 'ALU-Schumacher/AUDITOR' && github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha


### PR DESCRIPTION
When pushing a tag in the form of `vX.Y.Z` to GitHub, the following docker container tags are created:
- `X.Y.Z`
- `X.Y`
- `X` (only if `X >= 1`).

These tags follow the semantic versioning specifications, i.e. the tags `X.Y` and `X` will be updated if needed.

Furthermore, two additional tags are created for the docker containers:
- `latest`: This will point to the docker container with the latest tag
- `edge`: This will point to the docker container corresponding to the latest commit of the `main` branch`.

Closes #387 