### PR TITLE
Set log level for auditor, slurm and slurm-epilog

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -55,7 +55,7 @@ jobs:
         uses: docker/setup-buildx-action@v2
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v5
         with:
           context: .
           file: containers/${{ matrix.containers }}/Dockerfile

--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -52,7 +52,7 @@ jobs:
             ghcr.io/ALU-Schumacher/${{ matrix.containers }}
 
       - name: Setup Docker buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v5

--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -45,7 +45,7 @@ jobs:
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v5
         with:
           images: |
             aluschumacher/${{ matrix.containers }}

--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -30,14 +30,14 @@ jobs:
 
       - name: Log in to Docker Hub
         if: ${{ github.repository == 'ALU-Schumacher/AUDITOR' && github.ref == 'refs/heads/main' }}
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Log in to ghcr.io
         if: ${{ github.repository == 'ALU-Schumacher/AUDITOR' && github.ref == 'refs/heads/main' }}
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/htcondor-collector.yaml
+++ b/.github/workflows/htcondor-collector.yaml
@@ -41,7 +41,7 @@ jobs:
     - name: Submit test job
       run: |
         docker exec -u submituser -w /home/submituser htcondor-submit-1 \
-          bash -c "echo -e \"executable=/bin/sleep\narguments=2\n+VoName=testgroup\nqueue\" > job \
+          bash -c "echo -e \"executable=/bin/sleep\narguments=2\n+VoName=\\\"testgroup\\\"\nqueue\" > job \
             && condor_submit job"
     - name: Wait for job and collector
       run: |

--- a/.github/workflows/pyauditor.yml
+++ b/.github/workflows/pyauditor.yml
@@ -34,7 +34,7 @@ jobs:
           target: x86_64
           manylinux: auto
           command: build
-          args: --release --sdist -o dist --interpreter python3.7 python3.8 python3.9 python3.10 python3.11 --manifest-path pyauditor/Cargo.toml
+          args: --release --sdist -o dist --interpreter python3.8 python3.9 python3.10 python3.11 --manifest-path pyauditor/Cargo.toml
 
       - name: Upload wheels
         uses: actions/upload-artifact@v3
@@ -77,8 +77,7 @@ jobs:
       - uses: messense/maturin-action@v1
         with:
           command: build
-          # Note: No python3.6 on Windows!
-          args: --release -o dist --interpreter python3.7 python3.8 python3.9 python3.10 python3.11 --manifest-path pyauditor/Cargo.toml
+          args: --release -o dist --interpreter python3.8 python3.9 python3.10 python3.11 --manifest-path pyauditor/Cargo.toml
 
       - name: Upload wheels
         uses: actions/upload-artifact@v3
@@ -113,7 +112,7 @@ jobs:
       - uses: messense/maturin-action@v1
         with:
           command: build
-          args: --release -o dist --target universal2-apple-darwin --interpreter python3.7 python3.8 python3.9 python3.10 python3.11 --manifest-path pyauditor/Cargo.toml
+          args: --release -o dist --target universal2-apple-darwin --interpreter python3.8 python3.9 python3.10 python3.11 --manifest-path pyauditor/Cargo.toml
 
       - name: Upload wheels
         uses: actions/upload-artifact@v3

--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,6 @@ nohup.out
 dist/
 **/testdb.db
 **/target/
+**/lcov.info
 /venv
 *~

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Apel plugin: Bugfix in catching empty record list ([@dirksammel](https://github.com/dirksammel))
+- Apel plugin: Catch VOMS information that does not start with `/` ([@dirksammel](https://github.com/dirksammel))
 - Slurm collector: Fix parsing of ParsableType::Time for certain cases ([@QuantumDancer](https://github.com/QuantumDancer))
 - Dependencies: Updated docker/build-push-action from 4 to 5 ([@dirksammel](https://github.com/dirksammel))
 - Dependencies: Updated docker/login-action from 2 to 3 ([@dirksammel](https://github.com/dirksammel))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Breaking changes
+- pyauditor + Apel plugin + HTCondor collector: Support for Python 3.6 and 3.7 has been dropped ([@dirksammel](https://github.com/dirksammel) and [@QuantumDancer](https://github.com/QuantumDancer)).
 - Apel plugin: `cpu_time_unit` has to be present in the config file. See [Documentation](https://github.com/ALU-Schumacher/AUDITOR/blob/main/media/website/content/_index.md#apel-plugin) ([@dirksammel](https://github.com/dirksammel))
+
 ### Added
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Apel plugin: Bugfix in catching empty record list ([@dirksammel](https://github.com/dirksammel))
 - Slurm collector: Fix parsing of ParsableType::Time for certain cases ([@QuantumDancer](https://github.com/QuantumDancer))
+- Dependencies: Updated docker/build-push-action from 4 to 5 ([@dirksammel](https://github.com/dirksammel))
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Dependencies: Updated docker/build-push-action from 4 to 5 ([@dirksammel](https://github.com/dirksammel))
 - Dependencies: Updated docker/login-action from 2 to 3 ([@dirksammel](https://github.com/dirksammel))
 - Dependencies: Updated docker/setup-buildx-action from 2 to 3 ([@dirksammel](https://github.com/dirksammel))
+- Dependencies: Updated docker/metadata-action from 4 to 5 ([@dirksammel](https://github.com/dirksammel))
 - HTCondor collector: Handle `undefined` values from the batch system correctly ([@rfvc](https://github.com/rfvc))
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Slurm collector: Fix parsing of ParsableType::Time for certain cases ([@QuantumDancer](https://github.com/QuantumDancer))
 - Dependencies: Updated docker/build-push-action from 4 to 5 ([@dirksammel](https://github.com/dirksammel))
 - Dependencies: Updated docker/login-action from 2 to 3 ([@dirksammel](https://github.com/dirksammel))
+- Dependencies: Updated docker/setup-buildx-action from 2 to 3 ([@dirksammel](https://github.com/dirksammel))
 - HTCondor collector: Handle `undefined` values from the batch system correctly ([@rfvc](https://github.com/rfvc))
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Breaking changes
+- Apel plugin: `cpu_time_unit` has to be present in the config file. See [Documentation](https://github.com/ALU-Schumacher/AUDITOR/blob/main/media/website/content/_index.md#apel-plugin) ([@dirksammel](https://github.com/dirksammel))
 ### Added
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Apel plugin: Bugfix in catching empty record list ([@dirksammel](https://github.com/dirksammel))
+- Slurm collector: Fix parsing of ParsableType::Time for certain cases ([@QuantumDancer](https://github.com/QuantumDancer))
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Apel plugin: Bugfix in catching empty record list ([@dirksammel](https://github.com/dirksammel))
 - Slurm collector: Fix parsing of ParsableType::Time for certain cases ([@QuantumDancer](https://github.com/QuantumDancer))
 - Dependencies: Updated docker/build-push-action from 4 to 5 ([@dirksammel](https://github.com/dirksammel))
+- Dependencies: Updated docker/login-action from 2 to 3 ([@dirksammel](https://github.com/dirksammel))
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Slurm collector: Fix parsing of ParsableType::Time for certain cases ([@QuantumDancer](https://github.com/QuantumDancer))
 - Dependencies: Updated docker/build-push-action from 4 to 5 ([@dirksammel](https://github.com/dirksammel))
 - Dependencies: Updated docker/login-action from 2 to 3 ([@dirksammel](https://github.com/dirksammel))
+- HTCondor collector: Handle `undefined` values from the batch system correctly ([@rfvc](https://github.com/rfvc))
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+
+### Changed
+- Apel plugin: Bugfix in catching empty record list ([@dirksammel](https://github.com/dirksammel))
+
+### Removed
 
 ## [0.1.0] - 2023-04-19
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2385,9 +2385,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.105"
+version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "693151e1ac27563d6dbcec9dee9fbd5da8539b20fa14ad3752b2e6d363ace360"
+checksum = "2cc66a619ed80bf7a0f6b17dd063a84b88f6dea1813737cf469aef1d081142c2"
 dependencies = [
  "itoa",
  "ryu",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -552,9 +552,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.26"
+version = "0.4.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec837a71355b28f6556dbd569b37b3f363091c0bd4b2e735674521b4c5fd9bc5"
+checksum = "95ed24df0632f708f5f6d8082675bef2596f7084dee3dd55f632290bf35bfe0f"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
@@ -563,7 +563,7 @@ dependencies = [
  "serde",
  "time 0.1.45",
  "wasm-bindgen",
- "winapi",
+ "windows-targets",
 ]
 
 [[package]]

--- a/auditor/Cargo.toml
+++ b/auditor/Cargo.toml
@@ -42,7 +42,7 @@ serde-aux = "4"
 serde_with = { version = "3", features = ["chrono_0_4"] }
 config = "0.13"
 uuid = { version = "1.4", features = ["v4"] }
-chrono = { version = "0.4.26", default-features = false, features = ["serde"] }
+chrono = { version = "0.4.28", default-features = false, features = ["serde"] }
 tracing = { version = "0.1", features = ["log"] }
 tracing-subscriber = { version = "0.3", features = ["registry", "env-filter"] }
 tracing-bunyan-formatter = "0.3"

--- a/auditor/configuration/loglevel.yaml
+++ b/auditor/configuration/loglevel.yaml
@@ -1,0 +1,1 @@
+loglevel: "INFdrgdrO"

--- a/auditor/src/configuration.rs
+++ b/auditor/src/configuration.rs
@@ -16,6 +16,7 @@ pub struct Settings {
     pub application: AuditorSettings,
     #[serde(default = "default_metrics")]
     pub metrics: MetricsSettings,
+    pub loglevel: String,
 }
 
 #[derive(serde::Deserialize, Debug)]
@@ -114,7 +115,8 @@ pub fn get_configuration() -> Result<Settings, config::ConfigError> {
         .add_source(config::File::from(configuration_directory.join("base")).required(false))
         .add_source(
             config::File::from(configuration_directory.join(environment.as_str())).required(false),
-        );
+        )
+        .add_source(config::File::from(configuration_directory.join("loglevel")).required(false));
 
     let settings = match std::env::args().nth(1) {
         Some(file) => settings.add_source(

--- a/auditor/src/telemetry.rs
+++ b/auditor/src/telemetry.rs
@@ -5,6 +5,7 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
+use std::fmt;
 use tracing::{subscriber::set_global_default, Subscriber};
 use tracing_bunyan_formatter::{BunyanFormattingLayer, JsonStorageLayer};
 use tracing_log::LogTracer;
@@ -32,4 +33,56 @@ where
 pub fn init_subscriber(subscriber: impl Subscriber + Send + Sync) {
     LogTracer::init().expect("Failed to set logger");
     set_global_default(subscriber).expect("Failed to set subscriber");
+}
+
+/// Log level options for AUDITOR and collectors                                                                                                                                          
+
+#[derive(serde::Deserialize, Debug, Clone)]
+pub enum LogLevel {
+    TRACE,
+    DEBUG,
+    INFO,
+    WARN,
+    ERROR,
+}
+
+impl LogLevel {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            LogLevel::TRACE => "trace",
+            LogLevel::DEBUG => "debug",
+            LogLevel::INFO => "info",
+            LogLevel::WARN => "warn",
+            LogLevel::ERROR => "error",
+        }
+    }
+}
+
+impl TryFrom<String> for LogLevel {
+    type Error = String;
+    fn try_from(log_string: String) -> Result<Self, Self::Error> {
+        match log_string.to_lowercase().as_str() {
+            "trace" => Ok(Self::TRACE),
+            "debug" => Ok(Self::DEBUG),
+            "info" => Ok(Self::INFO),
+            "warn" => Ok(Self::WARN),
+            "error" => Ok(Self::ERROR),
+            _ => Err(format!(
+                "Not a supported log level. Please check your spelling. 
+                Setting INFO as default log level"
+            )),
+        }
+    }
+}
+
+impl fmt::Display for LogLevel {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            LogLevel::TRACE => write!(f, "trace"),
+            LogLevel::DEBUG => write!(f, "debug"),
+            LogLevel::INFO => write!(f, "info"),
+            LogLevel::WARN => write!(f, "warn"),
+            LogLevel::ERROR => write!(f, "error"),
+        }
+    }
 }

--- a/auditor/src/telemetry.rs
+++ b/auditor/src/telemetry.rs
@@ -67,10 +67,9 @@ impl TryFrom<String> for LogLevel {
             "info" => Ok(Self::INFO),
             "warn" => Ok(Self::WARN),
             "error" => Ok(Self::ERROR),
-            _ => Err(format!(
-                "Not a supported log level. Please check your spelling. 
-                Setting INFO as default log level"
-            )),
+            _ => Err("Not a supported log level. Please check your spelling. 
+					Setting INFO as default log level"
+                .to_string()),
         }
     }
 }

--- a/collectors/htcondor/pyproject.toml
+++ b/collectors/htcondor/pyproject.toml
@@ -10,7 +10,7 @@ packages = ["auditor_htcondor_collector"]
 name = "auditor-htcondor-collector"
 description = "AUDITOR collector for aggregating data from the HTCondor batch system"
 version = "0.1.0"
-requires-python = ">=3.6"
+requires-python = ">=3.8"
 dependencies = [
     "pyyaml==6.0.1",
     "python-auditor==0.1.0"

--- a/collectors/htcondor/src/auditor_htcondor_collector/collector.py
+++ b/collectors/htcondor/src/auditor_htcondor_collector/collector.py
@@ -188,6 +188,9 @@ class CondorHistoryCollector(object):
         components = []
         for component in self.config.components:
             amount = get_value(component, job)
+            self.logger.debug(
+                f"Got amount {amount!r} ({type(amount)}) for component {component!r}."
+            )
             if amount is not None:
                 try:
                     # AUDITOR expects int-values for components
@@ -207,7 +210,7 @@ class CondorHistoryCollector(object):
             else:
                 self.logger.warning(
                     f"Could not get value for component {component['name']!r} "
-                    f"for job {job['GlobalJobId']!r}."
+                    f"({component!r}) for job {job['GlobalJobId']!r}."
                 )
                 raise ValueError
         return components

--- a/collectors/htcondor/src/auditor_htcondor_collector/utils.py
+++ b/collectors/htcondor/src/auditor_htcondor_collector/utils.py
@@ -76,6 +76,8 @@ def get_value(config_entry: T_Config, job: dict):
     if "key" in config_entry:
         try:
             val = job[config_entry["key"]]
+            if val == "undefined":
+                return None
         except KeyError:
             return None
     elif "factor" in config_entry:

--- a/collectors/slurm-epilog/Cargo.toml
+++ b/collectors/slurm-epilog/Cargo.toml
@@ -31,7 +31,7 @@ strip = true
 
 [dependencies]
 auditor = { path = "../../auditor", version = "0.1.0" }
-chrono = { version = "0.4.26", default-features = false, features = ["serde"] }
+chrono = { version = "0.4.28", default-features = false, features = ["serde"] }
 anyhow = "1"
 regex = "1"
 tracing = { version = "0.1", features = ["log"] }

--- a/collectors/slurm-epilog/src/configuration.rs
+++ b/collectors/slurm-epilog/src/configuration.rs
@@ -20,6 +20,8 @@ pub struct Settings {
     pub site_id: String,
     #[serde(default = "default_components")]
     pub components: Vec<ComponentConfig>,
+    #[serde(default = "default_log_level")]
+    pub loglevel: String,
 }
 
 #[derive(serde::Deserialize, Debug, Clone)]
@@ -73,6 +75,10 @@ fn default_components() -> Vec<ComponentConfig> {
     }]
 }
 
+fn default_log_level() -> String {
+    "info".to_string()
+}
+
 /// Loads the configuration from a file `configuration.{yaml,json,toml,...}`
 #[tracing::instrument(name = "Loading configuration")]
 pub fn get_configuration() -> Result<Settings, config::ConfigError> {
@@ -82,7 +88,9 @@ pub fn get_configuration() -> Result<Settings, config::ConfigError> {
         .join("slurm-epilog-collector");
 
     let settings = config::Config::builder()
-        .add_source(config::File::from(configuration_directory.join("base")).required(false));
+        .add_source(config::File::from(configuration_directory.join("base")).required(false))
+        .add_source(config::File::from(configuration_directory.join("loglevel")).required(false));
+
     let settings = match std::env::args().nth(1) {
         Some(file) => settings.add_source(
             config::File::from(file.as_ref())

--- a/collectors/slurm-epilog/src/main.rs
+++ b/collectors/slurm-epilog/src/main.rs
@@ -55,10 +55,11 @@ fn parse_slurm_timestamp<T: AsRef<str> + std::fmt::Debug>(
     timestamp: T,
 ) -> Result<DateTime<Utc>, Error> {
     let local_offset = Local::now().offset().local_minus_utc();
-    Ok(DateTime::<Utc>::from(DateTime::<Local>::from_local(
-        NaiveDateTime::parse_from_str(timestamp.as_ref(), "%Y-%m-%dT%H:%M:%S")?,
-        FixedOffset::east_opt(local_offset).unwrap(),
-    )))
+    Ok(DateTime::<Utc>::from(
+        NaiveDateTime::parse_from_str(timestamp.as_ref(), "%Y-%m-%dT%H:%M:%S")?
+            .and_local_timezone(FixedOffset::east_opt(local_offset).unwrap())
+            .unwrap(),
+    ))
 }
 
 #[tracing::instrument(name = "Remove forbidden characters from string", level = "debug")]

--- a/collectors/slurm/Cargo.toml
+++ b/collectors/slurm/Cargo.toml
@@ -45,7 +45,7 @@ regex = "1.9.5"
 chrono = { version = "0.4.26", default-features = false }
 once_cell = "1.18.0"
 serde_with = { version = "3.3.0", features = ["chrono_0_4"] }
-serde_json = "1.0.105"
+serde_json = "1.0.106"
 
 [dependencies.sqlx]
 version = "0.6.3"

--- a/collectors/slurm/Cargo.toml
+++ b/collectors/slurm/Cargo.toml
@@ -42,7 +42,7 @@ serde = { version = "1.0.188", features = ["derive"] }
 serde-aux = "4.2.0"
 itertools = "0.11.0"
 regex = "1.9.5"
-chrono = { version = "0.4.26", default-features = false }
+chrono = { version = "0.4.28", default-features = false }
 once_cell = "1.18.0"
 serde_with = { version = "3.3.0", features = ["chrono_0_4"] }
 serde_json = "1.0.106"

--- a/collectors/slurm/src/configuration.rs
+++ b/collectors/slurm/src/configuration.rs
@@ -48,6 +48,8 @@ pub struct Settings {
     /// Potentially interesting: completed, failed, node_fail
     #[serde(default = "default_job_status")]
     pub job_status: Vec<String>,
+    #[serde(default = "default_log_level")]
+    pub loglevel: String,
 }
 
 #[derive(serde::Deserialize, Debug, Clone)]
@@ -201,6 +203,10 @@ fn default_database_path() -> String {
 
 fn default_job_status() -> Vec<String> {
     vec!["completed".into()]
+}
+
+fn default_log_level() -> String {
+    "into".to_string()
 }
 
 fn default_components() -> Vec<ComponentConfig> {
@@ -452,7 +458,8 @@ pub fn get_configuration() -> Result<Settings, config::ConfigError> {
     let configuration_directory = base_path.join("configuration").join("slurm-collector");
 
     let settings = config::Config::builder()
-        .add_source(config::File::from(configuration_directory.join("base")).required(false));
+        .add_source(config::File::from(configuration_directory.join("base")).required(false))
+        .add_source(config::File::from(configuration_directory.join("loglevel")).required(false));
     let settings = match std::env::args().nth(1) {
         Some(file) => settings.add_source(
             config::File::from(file.as_ref())

--- a/collectors/slurm/src/configuration.rs
+++ b/collectors/slurm/src/configuration.rs
@@ -391,10 +391,11 @@ impl ParsableType {
             ParsableType::String => AllowedTypes::String(input.to_owned()),
             ParsableType::DateTime => {
                 let local_offset = Local::now().offset().local_minus_utc();
-                AllowedTypes::DateTime(DateTime::<Utc>::from(DateTime::<Local>::from_local(
-                    NaiveDateTime::parse_from_str(input, "%Y-%m-%dT%H:%M:%S")?,
-                    FixedOffset::east_opt(local_offset).unwrap(),
-                )))
+                AllowedTypes::DateTime(DateTime::<Utc>::from(
+                    NaiveDateTime::parse_from_str(input, "%Y-%m-%dT%H:%M:%S")?
+                        .and_local_timezone(FixedOffset::east_opt(local_offset).unwrap())
+                        .unwrap(),
+                ))
             }
             ParsableType::Id => {
                 AllowedTypes::String(input.split('(').take(1).collect::<Vec<_>>()[0].to_owned())

--- a/collectors/slurm/src/sacctcaller.rs
+++ b/collectors/slurm/src/sacctcaller.rs
@@ -238,7 +238,7 @@ async fn get_job_info(database: &Database) -> Result<Vec<RecordAdd>> {
             },
         );
         (
-            DateTime::<Local>::from_utc(
+            DateTime::<Local>::from_naive_utc_and_offset(
                 ts.naive_utc(),
                 FixedOffset::east_opt(local_offset).unwrap(),
             ),

--- a/media/website/content/_index.md
+++ b/media/website/content/_index.md
@@ -407,74 +407,35 @@ See below for all currently available collectors.
 The APEL plugin creates job summary records and sends them to APEL.
 The following fields need to be present in the config file:
 
-```
-[logging]
-log_level =
-
-[paths]
-time_db_path =
-
-[intervals]
-report_interval =
-
-[site]
-publish_since =
-sites_to_report =
-site_name_mapping =
-default_submit_host =
-infrastructure_type =
-benchmark_type =
-
-[auditor]
-auditor_ip =
-auditor_port =
-auditor_timeout =
-benchmark_name =
-cores_name =
-cpu_time_name =
-nnodes_name =
-meta_key_site =
-meta_key_submithost =
-meta_key_voms =
-meta_key_username =
-
-[authentication]
-auth_url =
-ams_url =
-client_cert =
-client_key =
-ca_path =
-verify_ca =
-```
-
 | Parameter             | Description                                                                                                                                                               |
-| --------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `log_level`      	| Can be set to `DEBUG`, `INFO`, `WARNING`, `ERROR`, or `CRITICAL` (with decreasing verbosity).                                                                             |
+|-----------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `log_level`           | Can be set to `DEBUG`, `INFO`, `WARNING`, `ERROR`, or `CRITICAL` (with decreasing verbosity).                                                                             |
 | `time_db_path`        | Path of the `time.db`. The database should be located at a persistent path and stores the end time of the latest reported job, and the time of the latest report to APEL. |
-| `report_interval` 	| Time in seconds between reports to APEL.   		     		     	 	    	     	    	   	    	     	      	     	    	      	    |
-| `publish_since`     	| Date and time (UTC) after which jobs will be published. Only relevant for first run when no `time.db` is present yet. 						    |
-| `sites_to_report` 	| List of sites that will be reported. Uses the site name as stored in the AUDITOR records.										    |
-| `site_name_mapping` 	| Maps the site name as stored in the AUDITOR record to the name of the site in the GOCDB. 										    |
-| `default_submit_host` | Default submit host if this information is missing in the AUDITOR record.												    |
-| `infrastructure_type` | Origin of the job, can be set to `grid` or `local`. 	    	    													    |
-| `benchmark_type` 	| Name of the benchmark that will be reported to APEL. 															    |
-| `auditor_ip` 	     	| IP of the AUDITOR instance. 	     	      	 															    |
-| `auditor_port`       	| Port of the AUDITOR instance. 																	    |
-| `auditor_timeout` 	| Time in seconds after which the connection to the AUDITOR instance times out. 											    |
-| `benchmark_name`      | Name of the `benchmark` field in the AUDITOR records.     	     	   												    |
-| `cores_name`          | Name of the `cores` field in the AUDITOR records. 															    |
-| `cpu_time_name`       | Name of the field that stores the total CPU time in the AUDITOR records. 												    |
-| `nnodes_name`         | Name of the field that stores the number of nodes in the AUDITOR records. 												    |
-| `meta_key_site`       | Name of the field that stores the name of the site in the AUDITOR records. 												    |
-| `meta_key_submithost` | Name of the field that stores the submithost in the AUDITOR records. 													    |
-| `meta_key_voms` 	| Name of the field that stores the VOMS information in the AUDITOR records. 												    |
-| `meta_key_user` 	| Name of the field that stores the GlobalUserName in the AUDITOR records. 												    |
-| `auth_url` 		| URL from which the APEL authentication token is received. 	  													    |
-| `ams_url` 		| URL to which the reports are sent. 	       	  															    |
-| `client_cert` 	| Path of the host certificate. 																	    |
-| `client_key` 		| Path of the host key. 																		    |
-| `ca_path` 		| Path of the local certificate folder. 																    |
-| `verify_ca` 		| Controls the verification of the certificate of the APEL server. Can be set to `True` or `False` (the latter might be necessary for local test setups). 		    |
+| `report_interval`     | Time in seconds between reports to APEL.                                                                                                                                  |
+| `publish_since`       | Date and time (UTC) after which jobs will be published. Only relevant for first run when no `time.db` is present yet.                                                     |
+| `sites_to_report`     | List of sites that will be reported. Uses the site name as stored in the AUDITOR records.                                                                                 |
+| `site_name_mapping`   | Maps the site name as stored in the AUDITOR record to the name of the site in the GOCDB.                                                                                  |
+| `default_submit_host` | Default submit host if this information is missing in the AUDITOR record.                                                                                                 |
+| `infrastructure_type` | Origin of the job, can be set to `grid` or `local`.                                                                                                                       |
+| `benchmark_type`      | Name of the benchmark that will be reported to APEL.                                                                                                                      |
+| `auditor_ip`          | IP of the AUDITOR instance.                                                                                                                                               |
+| `auditor_port`        | Port of the AUDITOR instance.                                                                                                                                             |
+| `auditor_timeout`     | Time in seconds after which the connection to the AUDITOR instance times out.                                                                                             |
+| `benchmark_name`      | Name of the `benchmark` field in the AUDITOR records.                                                                                                                     |
+| `cores_name`          | Name of the `cores` field in the AUDITOR records.                                                                                                                         |
+| `cpu_time_name`       | Name of the field that stores the total CPU time in the AUDITOR records.                                                                                                  |
+| `cpu_time_unit`       | Unit of total CPU time in the AUDITOR records, can be `seconds` or `milliseconds`.                                                                                        |
+| `nnodes_name`         | Name of the field that stores the number of nodes in the AUDITOR records.                                                                                                 |
+| `meta_key_site`       | Name of the field that stores the name of the site in the AUDITOR records.                                                                                                |
+| `meta_key_submithost` | Name of the field that stores the submithost in the AUDITOR records.                                                                                                      |
+| `meta_key_voms`       | Name of the field that stores the VOMS information in the AUDITOR records.                                                                                                |
+| `meta_key_user`       | Name of the field that stores the GlobalUserName in the AUDITOR records.                                                                                                  |
+| `auth_url`            | URL from which the APEL authentication token is received.                                                                                                                 |
+| `ams_url`             | URL to which the reports are sent.                                                                                                                                        |
+| `client_cert`         | Path of the host certificate.                                                                                                                                             |
+| `client_key`          | Path of the host key.                                                                                                                                                     |
+| `ca_path`             | Path of the local certificate folder.                                                                                                                                     |
+| `verify_ca`           | Controls the verification of the certificate of the APEL server. Can be set to `True` or `False` (the latter might be necessary for local test setups).                   |
 
 
 Example config:
@@ -504,6 +465,7 @@ auditor_timeout = 60
 benchmark_name = hepscore23
 cores_name = Cores
 cpu_time_name = TotalCPU
+cpu_time_unit = milliseconds
 nnodes_name = NNodes
 meta_key_site = site_id
 meta_key_submithost = headnode

--- a/plugins/apel/pyproject.toml
+++ b/plugins/apel/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "auditor_apel_plugin"
 version = "0.1.0"
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 dependencies = [
 	     "python-auditor==0.1.0",
 	     "requests==2.31.0",

--- a/plugins/apel/src/auditor_apel_plugin/core.py
+++ b/plugins/apel/src/auditor_apel_plugin/core.py
@@ -339,6 +339,8 @@ def create_summary_db(config, records):
             logging.critical(f"no {cpu_time_name} in components")
             raise
 
+        cputime = convert_to_seconds(cputime, config)
+
         try:
             nodecount = component_dict[nnodes_name].amount
         except KeyError:
@@ -650,6 +652,7 @@ def build_payload(msg):
 def send_payload(config, token, payload):
     ams_url = config["authentication"].get("ams_url")
     verify_ca = config["authentication"].getboolean("verify_ca")
+
     if verify_ca:
         ca_path = config["authentication"].get("ca_path")
     else:
@@ -664,3 +667,19 @@ def send_payload(config, token, payload):
     )
 
     return post
+
+
+def convert_to_seconds(cpu_time, config):
+    cpu_time_name = config["auditor"].get("cpu_time_name")
+    cpu_time_unit = config["auditor"].get("cpu_time_unit")
+
+    if cpu_time_unit == "seconds":
+        return cpu_time
+    elif cpu_time_unit == "milliseconds":
+        return round(cpu_time / 1000)
+    else:
+        logging.critical(
+            f"Unknown unit for {cpu_time_name}: {cpu_time_unit}. "
+            "Possible values are seconds or milliseconds."
+        )
+        raise ValueError

--- a/plugins/apel/src/auditor_apel_plugin/core.py
+++ b/plugins/apel/src/auditor_apel_plugin/core.py
@@ -192,34 +192,50 @@ def get_voms_info(record, config):
 
     try:
         voms_string = replace_record_string(record.meta.get(meta_key_voms)[0])
-        voms_list = voms_string.split("/")
-        voms_dict["vo"] = voms_list[1]
-
-        if "Role" not in voms_string:
-            logging.warning(
-                f"No Role found in VOMS of {record.record_id}: {voms_string}, "
-                "not sending VORole"
-            )
-            voms_dict["vorole"] = None
-
-            if len(voms_list) == 2:
-                voms_dict["vogroup"] = "/" + voms_list[1]
-            else:
-                voms_dict["vogroup"] = "/" + voms_list[1] + "/" + voms_list[2]
-        elif len(voms_list) == 3:
-            voms_dict["vogroup"] = "/" + voms_list[1]
-            voms_dict["vorole"] = voms_list[2]
-        else:
-            voms_dict["vogroup"] = "/" + voms_list[1] + "/" + voms_list[2]
-            voms_dict["vorole"] = voms_list[3]
     except TypeError:
         logging.warning(
             f"No VOMS information found in {record.record_id}, "
             "not sending VO, VOGroup, and VORole"
         )
+
         voms_dict["vo"] = None
         voms_dict["vogroup"] = None
         voms_dict["vorole"] = None
+
+        return voms_dict
+
+    if not voms_string.startswith("/"):
+        logging.warning(
+            f"VOMS information found in {record.record_id} has unknown "
+            f"format: {voms_string}. Not sending VO, VOGroup, and VORole"
+        )
+
+        voms_dict["vo"] = None
+        voms_dict["vogroup"] = None
+        voms_dict["vorole"] = None
+
+        return voms_dict
+
+    voms_list = voms_string.split("/")
+    voms_dict["vo"] = voms_list[1]
+
+    if "Role" not in voms_string:
+        logging.warning(
+            f"No Role found in VOMS of {record.record_id}: {voms_string}, "
+            "not sending VORole"
+        )
+        voms_dict["vorole"] = None
+
+        if len(voms_list) == 2:
+            voms_dict["vogroup"] = "/" + voms_list[1]
+        else:
+            voms_dict["vogroup"] = "/" + voms_list[1] + "/" + voms_list[2]
+    elif len(voms_list) == 3:
+        voms_dict["vogroup"] = "/" + voms_list[1]
+        voms_dict["vorole"] = voms_list[2]
+    else:
+        voms_dict["vogroup"] = "/" + voms_list[1] + "/" + voms_list[2]
+        voms_dict["vorole"] = voms_list[3]
 
     return voms_dict
 

--- a/plugins/apel/src/auditor_apel_plugin/publish.py
+++ b/plugins/apel/src/auditor_apel_plugin/publish.py
@@ -57,11 +57,8 @@ def run(config, client):
         logging.info(f"Getting records since {start_time}")
 
         records_summary = get_records(client, start_time, 30)
-        try:
-            latest_stop_time = records_summary[-1].stop_time.replace(
-                tzinfo=timezone.utc
-            )
-        except IndexError:
+
+        if len(records_summary) == 0:
             logging.info("No new records, do nothing for now")
             time_db_conn.close()
             logging.info(
@@ -70,6 +67,8 @@ def run(config, client):
             )
             sleep(report_interval)
             continue
+
+        latest_stop_time = records_summary[-1].stop_time.replace(tzinfo=timezone.utc)
 
         logging.debug(f"Latest stop time is {latest_stop_time}")
         summary_db = create_summary_db(config, records_summary)

--- a/plugins/apel/tests/test_auditor_apel_plugin.py
+++ b/plugins/apel/tests/test_auditor_apel_plugin.py
@@ -13,6 +13,7 @@ from auditor_apel_plugin.core import (
     replace_record_string,
     get_records,
     get_site_id,
+    convert_to_seconds,
 )
 from datetime import datetime, timezone
 import sqlite3
@@ -350,6 +351,7 @@ class TestAuditorApelPlugin:
         benchmark_name = "hepscore"
         cores_name = "Cores"
         cpu_time_name = "TotalCPU"
+        cpu_time_unit = "seconds"
         nnodes_name = "NNodes"
         meta_key_site = "site_id"
         meta_key_submithost = "headnode"
@@ -369,6 +371,7 @@ class TestAuditorApelPlugin:
             "benchmark_name": benchmark_name,
             "cores_name": cores_name,
             "cpu_time_name": cpu_time_name,
+            "cpu_time_unit": cpu_time_unit,
             "nnodes_name": nnodes_name,
             "meta_key_site": meta_key_site,
             "meta_key_submithost": meta_key_submithost,
@@ -518,6 +521,7 @@ class TestAuditorApelPlugin:
         benchmark_name = "hepscore"
         cores_name = "Cores"
         cpu_time_name = "TotalCPU"
+        cpu_time_unit = "seconds"
         nnodes_name = "NNodes"
         meta_key_site = "site_id"
         meta_key_submithost = "headnode"
@@ -537,6 +541,7 @@ class TestAuditorApelPlugin:
             "benchmark_name": benchmark_name,
             "cores_name": cores_name,
             "cpu_time_name": cpu_time_name,
+            "cpu_time_unit": cpu_time_unit,
             "nnodes_name": nnodes_name,
             "meta_key_site": meta_key_site,
             "meta_key_submithost": meta_key_submithost,
@@ -1028,3 +1033,41 @@ class TestAuditorApelPlugin:
         with pytest.raises(Exception) as pytest_error:
             get_site_id(rec_2, conf)
         assert pytest_error.type == AttributeError
+
+    def test_convert_to_seconds(self):
+        cpu_time_name = "TotalCPU"
+        cpu_time_unit = "seconds"
+
+        conf = configparser.ConfigParser()
+        conf["auditor"] = {
+            "cpu_time_name": cpu_time_name,
+            "cpu_time_unit": cpu_time_unit,
+        }
+
+        result = convert_to_seconds(1100, conf)
+        assert result == 1100
+
+        result = convert_to_seconds(1500, conf)
+        assert result == 1500
+
+        conf["auditor"]["cpu_time_unit"] = "milliseconds"
+
+        result = convert_to_seconds(1100, conf)
+        assert result == 1
+
+        result = convert_to_seconds(1500, conf)
+        assert result == 2
+
+    def test_convert_to_seconds_fail(self):
+        cpu_time_name = "TotalCPU"
+        cpu_time_unit = "hours"
+
+        conf = configparser.ConfigParser()
+        conf["auditor"] = {
+            "cpu_time_name": cpu_time_name,
+            "cpu_time_unit": cpu_time_unit,
+        }
+
+        with pytest.raises(Exception) as pytest_error:
+            convert_to_seconds(1100, conf)
+        assert pytest_error.type == ValueError

--- a/plugins/apel/tests/test_auditor_apel_plugin.py
+++ b/plugins/apel/tests/test_auditor_apel_plugin.py
@@ -818,12 +818,28 @@ class TestAuditorApelPlugin:
             "voms": None,
         }
 
+        rec_6_values = {
+            "rec_id": "test_record_4",
+            "start_time": datetime(2022, 1, 1, 14, 24, 11).astimezone(tz=timezone.utc),
+            "stop_time": datetime(2023, 1, 2, 7, 11, 45).astimezone(tz=timezone.utc),
+            "n_cores": 2,
+            "hepscore": 3.0,
+            "tot_cpu": 12265325,
+            "n_nodes": 1,
+            "site": "test-site-2",
+            "user": "second_user",
+            "submit_host": None,
+            "user_name": "%2FDC=ch%2FDC=cern%2FOU=Users%2FCN=test2: test2",
+            "voms": "atlas",
+        }
+
         rec_value_list = [
             rec_1_values,
             rec_2_values,
             rec_3_values,
             rec_4_values,
             rec_5_values,
+            rec_6_values,
         ]
         records = []
 
@@ -857,6 +873,11 @@ class TestAuditorApelPlugin:
         assert result["vorole"] is None
 
         result = get_voms_info(records[4], conf)
+        assert result["vo"] is None
+        assert result["vogroup"] is None
+        assert result["vorole"] is None
+
+        result = get_voms_info(records[5], conf)
         assert result["vo"] is None
         assert result["vogroup"] is None
         assert result["vorole"] is None

--- a/plugins/priority/Cargo.toml
+++ b/plugins/priority/Cargo.toml
@@ -37,7 +37,7 @@ serde = { version = "1", features = ["derive"] }
 serde_with = { version = "3", features = ["chrono_0_4"] }
 serde-aux = "4"
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "time"] }
-chrono = { version = "0.4.26", default-features = false, features = ["serde"] }
+chrono = { version = "0.4.28", default-features = false, features = ["serde"] }
 uuid = { version = "1.4", features = ["v4"] }
 num-traits = "^0.2"
 anyhow = "1"

--- a/pyauditor/Cargo.toml
+++ b/pyauditor/Cargo.toml
@@ -31,4 +31,4 @@ pyo3 = { version = "0.19", features = ["chrono", "extension-module", "anyhow"] }
 pyo3-asyncio = { version = "0.19", features = ["attributes", "tokio-runtime"] }
 tokio = "1"
 chrono = { version = "0.4.26", features = ["serde"] }
-serde_json = "1.0.105"
+serde_json = "1.0.106"

--- a/pyauditor/Cargo.toml
+++ b/pyauditor/Cargo.toml
@@ -30,5 +30,5 @@ anyhow = "1"
 pyo3 = { version = "0.19", features = ["chrono", "extension-module", "anyhow"] }
 pyo3-asyncio = { version = "0.19", features = ["attributes", "tokio-runtime"] }
 tokio = "1"
-chrono = { version = "0.4.26", features = ["serde"] }
+chrono = { version = "0.4.28", features = ["serde"] }
 serde_json = "1.0.106"

--- a/pyauditor/docs/index.rst
+++ b/pyauditor/docs/index.rst
@@ -14,7 +14,7 @@ It provides functionality to create records and send records to and receive reco
 Installation
 ============
 
-pyauditor requires a Python version >= 3.6.
+pyauditor requires a Python version >= 3.8.
 
 .. code-block::
 

--- a/pyauditor/pyproject.toml
+++ b/pyauditor/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "python-auditor"
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 authors = [
     { name = "Stefan Kroboth", email = "stefan.kroboth@gmail.com" }
 ]


### PR DESCRIPTION
feat- To set log level by users for auditor, slurm and slurm-epilog

- In auditor, log level value is set using loglevel.yaml file.
- LogLevel enum is specifed in telemetry.rs to check the user input and verify if it corresponds to the 5 filter levels.
- Log level is set to INFO as default if the user doesn't specify.
