### PR TITLE
[Apel plugin] check if record list contains any site to report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Auditor + Apel plugin: Add semver tags and edge tag for docker container ([@QuantumDancer](https://github.com/QuantumDancer))
 - Apel plugin: Migrate the Apel plugin from [ALU-Schumacher/AUDITOR-APEL-plugin](https://github.com/ALU-Schumacher/AUDITOR-APEL-plugin) to this repo ([@dirksammel](https://github.com/dirksammel))
 - Apel plugin: Docker image ([@QuantumDancer](https://github.com/QuantumDancer))
+- Apel plugin: Check if there are sites to report in the record list ([@dirksammel](https://github.com/dirksammel))
 - HTCondor collector ([@rfvc](https://github.com/rfvc))
 - Priority plugin: Add option for client timeout ([@QuantumDancer](https://github.com/QuantumDancer))
 - CI: Linting of python code with ruff and black ([@dirksammel](https://github.com/dirksammel))

--- a/plugins/apel/src/auditor_apel_plugin/core.py
+++ b/plugins/apel/src/auditor_apel_plugin/core.py
@@ -307,7 +307,7 @@ def create_summary_db(config, records):
         raise
 
     site_name_mapping = json.loads(config["site"].get("site_name_mapping"))
-    sites_to_report = json.loads(config["site"].get("sites_to_report"))
+    sites_to_report = set(json.loads(config["site"].get("sites_to_report")))
     infrastructure = config["site"].get("infrastructure_type")
     benchmark_type = config["site"].get("benchmark_type")
     benchmark_name = config["auditor"].get("benchmark_name")
@@ -451,7 +451,7 @@ def create_sync_db(config, records):
         raise
 
     site_name_mapping = json.loads(config["site"].get("site_name_mapping"))
-    sites_to_report = json.loads(config["site"].get("sites_to_report"))
+    sites_to_report = set(json.loads(config["site"].get("sites_to_report")))
 
     for r in records:
         site_id = get_site_id(r, config)
@@ -699,3 +699,14 @@ def convert_to_seconds(cpu_time, config):
             "Possible values are seconds or milliseconds."
         )
         raise ValueError
+
+
+def check_sites_in_records(config, records):
+    sites_to_report = set(json.loads(config["site"].get("sites_to_report")))
+
+    logging.debug(f"Sites to report from config: {sites_to_report}")
+
+    sites_in_records = {get_site_id(r, config) for r in records}
+    logging.debug(f"Sites found in records: {sites_in_records}")
+
+    return sites_to_report.intersection(sites_in_records)

--- a/plugins/apel/src/auditor_apel_plugin/publish.py
+++ b/plugins/apel/src/auditor_apel_plugin/publish.py
@@ -27,6 +27,7 @@ from auditor_apel_plugin.core import (
     group_sync_db,
     create_sync,
     get_records,
+    check_sites_in_records,
 )
 
 
@@ -67,6 +68,20 @@ def run(config, client):
             )
             sleep(report_interval)
             continue
+
+        sites_to_report = check_sites_in_records(config, records_summary)
+
+        if not sites_to_report:
+            logging.info("No sites to report in the records, do nothing for now")
+            time_db_conn.close()
+            logging.info(
+                "Next report scheduled for "
+                f"{datetime.now() + timedelta(seconds=report_interval)}"
+            )
+            sleep(report_interval)
+            continue
+        else:
+            logging.info(f"Create reports for {sites_to_report}")
 
         latest_stop_time = records_summary[-1].stop_time.replace(tzinfo=timezone.utc)
 


### PR DESCRIPTION
This PR adds a check if there is a match between the sites in the record list and the sites that should be reported (as defined in the config).
Also adds conversion of sites to report from `list` to `set`, since we don't expect/want duplicates.
If there is no match, nothing is done until the next reporting interval.
Closes #423.