### PR TITLE
add workflow for publishing python packages

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -1,0 +1,63 @@
+name: python-publish
+
+on:
+  push:
+    tags:
+      - v*.*.*
+
+jobs:
+  publish-apel-plugin:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./plugins/apel
+    permissions:
+      id-token: write
+      contents: write
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
+      - name: Install build
+        run: |
+          pip install --upgrade pip
+          pip install .[build]
+      - name: Build binary wheel and source tarball
+        run: python3 -m build --sdist --wheel --outdir dist/
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+      - name: Publish to GitHub
+        uses: softprops/action-gh-release@v1
+        with:
+          files: dist/*
+          
+  publish-htcondor-collector:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./collectors/htcondor
+    permissions:
+      id-token: write
+      contents: write
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
+      - name: Install build
+        run: |
+          pip install --upgrade pip
+          pip install .[build]
+      - name: Build binary wheel and source tarball
+        run: python3 -m build --sdist --wheel --outdir dist/
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+      - name: Publish to GitHub
+        uses: softprops/action-gh-release@v1
+        with:
+          files: dist/*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Apel plugin: Migrate the Apel plugin from [ALU-Schumacher/AUDITOR-APEL-plugin](https://github.com/ALU-Schumacher/AUDITOR-APEL-plugin) to this repo ([@dirksammel](https://github.com/dirksammel))
 - Apel plugin: Docker image ([@QuantumDancer](https://github.com/QuantumDancer))
 - Apel plugin: Check if there are sites to report in the record list ([@dirksammel](https://github.com/dirksammel))
+- Apel plugin + HTCondor collector: Add GitHub workflow for publishing to PyPI and GitHub ([@dirksammel](https://github.com/dirksammel))
 - HTCondor collector ([@rfvc](https://github.com/rfvc))
 - Priority plugin: Add option for client timeout ([@QuantumDancer](https://github.com/QuantumDancer))
 - CI: Linting of python code with ruff and black ([@dirksammel](https://github.com/dirksammel))

--- a/collectors/htcondor/pyproject.toml
+++ b/collectors/htcondor/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools"]
+requires = ["setuptools==68.2.2"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools]
@@ -16,6 +16,12 @@ dependencies = [
     "python-auditor==0.1.0"
 ]
 readme = "README.md"
+
+[project.optional-dependencies]
+build = [
+      "build==1.0.3",
+      "setuptools==68.2.2",
+]
 
 [project.scripts]
 auditor-htcondor-collector = "auditor_htcondor_collector.main:main"

--- a/plugins/apel/pyproject.toml
+++ b/plugins/apel/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools"]
+requires = ["setuptools==68.2.2"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -20,12 +20,12 @@ style = [
       "flake8",
 ]
 tests = [
-      "pytest",
-      "pytest-cov",
+      "pytest==7.4.2",
+      "pytest-cov==4.1.0",
 ]
 build = [
-      "build",
-      "setuptools",
+      "build==1.0.3",
+      "setuptools==68.2.2",
 ]
 
 [project.scripts]


### PR DESCRIPTION
This PR adds a workflow to publish the APEL plugin and the HTCondor collector to PyPI and GitHub.
Adds dependencies for building to the HTCondor collector, and fixes several dependency versions for both the HTCondor collector and the APEL plugin.

Closes #312.