### PR TITLE
Apel plugin: Build pyauditor from source for docker image

### DIFF
--- a/containers/auditor-apel-plugin/Dockerfile
+++ b/containers/auditor-apel-plugin/Dockerfile
@@ -7,11 +7,16 @@ FROM python:3.8.17-slim-bookworm AS builder
 # install build dependencies and create python env
 RUN set -ex                                                          \
     && apt-get update                                                \
-    && apt-get -y install git                                        \
+    && apt-get -y install build-essential curl git                   \
     && python -m venv /env                                           \
     && /env/bin/pip install --upgrade pip                            \
     && apt-get -y autoremove && apt-get clean                        \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+# install rust toolchain
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+RUN curl https://sh.rustup.rs -sSf | bash -s -- -y
+ENV PATH="/root/.cargo/bin:${PATH}"
 
 # activate python env
 ENV VIRTUAL_ENV /env
@@ -20,9 +25,14 @@ ENV PATH /env/bin:$PATH
 # copy code
 COPY . /code
 
+# build pyauditor wheel
+WORKDIR /code/pyauditor
+RUN pip wheel .
+
 # install python package
 WORKDIR /code/plugins/apel
-RUN pip install --no-cache-dir .
+RUN    pip install --no-cache-dir /code/pyauditor/*.whl \
+    && pip install --no-cache-dir .
 
 
 ################


### PR DESCRIPTION
Instead of installing pyauditor from PyPI it is now built from the current version of the git repo

Closes #452 