### PR TITLE
add APEL plugin installation and usage to documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Apel plugin: Migrate the Apel plugin from [ALU-Schumacher/AUDITOR-APEL-plugin](https://github.com/ALU-Schumacher/AUDITOR-APEL-plugin) to this repo ([@dirksammel](https://github.com/dirksammel))
 - Apel plugin: Docker image ([@QuantumDancer](https://github.com/QuantumDancer))
 - Apel plugin: Check if there are sites to report in the record list ([@dirksammel](https://github.com/dirksammel))
-- Apel plugin + HTCondor collector: Add GitHub workflow for publishing to PyPI and GitHub ([@dirksammel](https://github.com/dirksammel))
 - HTCondor collector ([@rfvc](https://github.com/rfvc))
 - Priority plugin: Add option for client timeout ([@QuantumDancer](https://github.com/QuantumDancer))
 - Set LogLevel using env variable for auditor, slurm and slurm-epilog collectors and priority plugin ([@raghuvar-vijay](https://github.com/raghuvar-vijay))
@@ -29,11 +28,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CI: Dependabot checks for python plugins/collectors and GitHub actions ([@dirksammel](https://github.com/dirksammel))
 - CI: Python unit tests ([@dirksammel](https://github.com/dirksammel))
 - CI: Check CHANGELOG.md for changes ([@dirksammel](https://github.com/dirksammel))
+- CI: Publish Apel plugin and HTCondor collector to PyPI and GitHub ([@dirksammel](https://github.com/dirksammel))
 - Docs: Document `Record`, `RecordAdd`, `RecordUpdate`, `Component`, `Score`, and `Meta` in Rust API ([@QuantumDancer](https://github.com/QuantumDancer))
 - Docs: Add tutorial for Rust client ([@QuantumDancer](https://github.com/QuantumDancer))
 - Docs: Common sections for collectors and plugins ([@QuantumDancer](https://github.com/QuantumDancer))
 - Docs: Dedicated docs for development ([@QuantumDancer](https://github.com/QuantumDancer))
 - Docs: Add documentation for the Slurm collector ([@QuantumDancer](https://github.com/QuantumDancer))
+- Docs: Add documentation for the Apel plugin ([@dirksammel](https://github.com/dirksammel))
 
 ### Changed
 - Apel plugin: Bugfix in catching empty record list ([@dirksammel](https://github.com/dirksammel))

--- a/media/website/content/_index.md
+++ b/media/website/content/_index.md
@@ -503,7 +503,35 @@ See below for all currently available collectors.
 
 ## APEL Plugin
 
-The APEL plugin creates job summary records and sends them to APEL.
+The APEL plugin creates job summary records and sends them to APEL. It is provided as a [pip package](https://pypi.org/project/auditor-apel-plugin/) and as a Docker container from [Docker Hub](https://hub.docker.com/r/aluschumacher/auditor-apel-plugin) or from the [GitHub Container Registry](https://github.com/ALU-Schumacher/AUDITOR/pkgs/container/auditor-apel-plugin).
+Two CLI commands are available after the installation: `auditor-apel-publish` and `auditor-apel-republish`.
+
+`auditor-apel-publish` runs periodically at a given report interval.
+
+```bash
+usage: auditor-apel-publish [-h] -c CONFIG
+
+options:
+  -h, --help            show this help message and exit
+  -c CONFIG, --config CONFIG
+                        Path to the config file
+```
+
+`auditor-apel-republish` runs once and submits a report for a given month, year, and site.
+
+```bash
+usage: auditor-apel-republish [-h] -y YEAR -m MONTH -s SITE -c CONFIG
+
+options:
+  -h, --help            show this help message and exit
+  -y YEAR, --year YEAR  Year: 2020, 2021, ...
+  -m MONTH, --month MONTH
+                        Month: 4, 8, 12, ...
+  -s SITE, --site SITE  Site (GOCDB): UNI-FREIBURG, ...
+  -c CONFIG, --config CONFIG
+                        Path to the config file
+```
+
 The following fields need to be present in the config file:
 
 | Parameter             | Description                                                                                                                                                               |


### PR DESCRIPTION
This PR adds information about the installation and usage of the APEL plugin to the documentation.