### PR TITLE
remove encoding from logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Apel plugin: Catch VOMS information that does not start with `/` ([@dirksammel](https://github.com/dirksammel))
 - Apel plugin: Remove `pytz` dependency ([@dirksammel](https://github.com/dirksammel))
 - Apel plugin: Refactor code ([@dirksammel](https://github.com/dirksammel))
+- Apel plugin: Remove encoding from logging ([@dirksammel](https://github.com/dirksammel))
 - Auditor: Fix default address in AuditorClientBuilder ([@QuantumDancer](https://github.com/QuantumDancer))
 - HTCondor collector: Handle `undefined` values from the batch system correctly ([@rfvc](https://github.com/rfvc))
 - HTCondor collector: Replace `datetime.utcfromtimestamp` with `datetime.fromtimestamp` ([@dirksammel](https://github.com/dirksammel))

--- a/plugins/apel/src/auditor_apel_plugin/publish.py
+++ b/plugins/apel/src/auditor_apel_plugin/publish.py
@@ -135,7 +135,6 @@ def main():
     )
     logging.basicConfig(
         # filename="apel_plugin.log",
-        encoding="utf-8",
         level=log_level,
         format=log_format,
         datefmt="%Y-%m-%d %H:%M:%S",

--- a/plugins/apel/src/auditor_apel_plugin/republish.py
+++ b/plugins/apel/src/auditor_apel_plugin/republish.py
@@ -66,7 +66,6 @@ def main():
     log_level = config["logging"].get("log_level")
     log_format = "[%(asctime)s] %(levelname)-8s %(message)s"
     logging.basicConfig(
-        encoding="utf-8",
         level=log_level,
         format=log_format,
         datefmt="%Y-%m-%d %H:%M:%S",


### PR DESCRIPTION
This PR removes the encoding from logging. This feature was only introduced with Python 3.9, and it's not that important.