### PR TITLE
remove remaining SQLX_OFFLINE

### DIFF
--- a/.github/workflows/pyauditor.yml
+++ b/.github/workflows/pyauditor.yml
@@ -20,14 +20,6 @@ jobs:
         with:
           prefix-key: cache-dependencies-linux
 
-      # We need to somehow get the SQLX_OFFLINE env variable into the container.
-      # Since `maturin-action` doesn't enable us to do that, we have to tell cargo
-      # via its configuration.
-      - name: Create fake .cargo/config.toml
-        run: |
-          mkdir -p .cargo
-          echo -e "[env]\nSQLX_OFFLINE = \"true\"" >> .cargo/config.toml
-
       - name: Maturin
         uses: messense/maturin-action@v1
         with:
@@ -59,21 +51,6 @@ jobs:
         with:
           prefix-key: cache-dependencies-windows
 
-      # We need to somehow get the SQLX_OFFLINE env variable into the container.
-      # Since `maturin-action` doesn't enable us to do that, we have to tell cargo
-      # via its configuration.
-      # I don't know how to script this on windows (and I don't care). Therefore
-      # I'll just copy the config.toml from the pyauditor directory. This may lead to 
-      # problems when there is a .cargo/config.toml, which will then be overwritten.
-      - name: Create fake .cargo\config.toml
-        run: |
-          copy pyauditor\.cargo\config.toml .cargo\config.toml
-          # echo "[env]" >> .cargo\config.toml
-          # Fails here, saying "echo." doesn't exist.
-          # echo. >> .cargo\config.toml
-          # echo "SQLX_OFFLINE = \"true\"" >> .cargo\config.toml
-          # type .cargo\config.toml
-
       - uses: messense/maturin-action@v1
         with:
           command: build
@@ -100,14 +77,6 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           prefix-key: cache-dependencies-macos
-
-      # We need to somehow get the SQLX_OFFLINE env variable into the container.
-      # Since `maturin-action` doesn't enable us to do that, we have to tell cargo
-      # via its configuration.
-      - name: Create fake .cargo/config.toml
-        run: |
-          mkdir -p .cargo
-          echo -e "[env]\nSQLX_OFFLINE = \"true\"" >> .cargo/config.toml
 
       - uses: messense/maturin-action@v1
         with:
@@ -216,8 +185,6 @@ jobs:
   docs:
     name: pyauditor docs
     runs-on: ubuntu-latest
-    env:
-      SQLX_OFFLINE: true
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/rpm-build.yml
+++ b/.github/workflows/rpm-build.yml
@@ -25,6 +25,7 @@ jobs:
           - auditor-priority-plugin
 
     env:
+      SQLX_OFFLINE: true
       CARGO_GET_VERSION: 0.3.3
     steps:
       - name: Checkout repository

--- a/.github/workflows/rpm-build.yml
+++ b/.github/workflows/rpm-build.yml
@@ -25,7 +25,6 @@ jobs:
           - auditor-priority-plugin
 
     env:
-      SQLX_OFFLINE: true 
       CARGO_GET_VERSION: 0.3.3
     steps:
       - name: Checkout repository

--- a/auditor/build.rs
+++ b/auditor/build.rs
@@ -5,6 +5,4 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-fn main() {
-
-}
+fn main() {}

--- a/auditor/build.rs
+++ b/auditor/build.rs
@@ -6,8 +6,5 @@
 // copied, modified, or distributed except according to those terms.
 
 fn main() {
-    // When building in docs.rs, we want to set SQLX_OFFLINE mode to true
-    if std::env::var_os("DOCS_RS").is_some() {
-        println!("cargo:rustc-env=SQLX_OFFLINE=true");
-    }
+
 }

--- a/containers/auditor/Dockerfile
+++ b/containers/auditor/Dockerfile
@@ -13,7 +13,6 @@ COPY --from=planner /auditor/recipe.json recipe.json
 RUN cargo chef cook --release --recipe-path recipe.json
 
 COPY . .
-ENV SQLX_OFFLINE true
 RUN cargo build --release --bin auditor
 
 # Runtime stage

--- a/containers/auditor/Dockerfile
+++ b/containers/auditor/Dockerfile
@@ -13,6 +13,7 @@ COPY --from=planner /auditor/recipe.json recipe.json
 RUN cargo chef cook --release --recipe-path recipe.json
 
 COPY . .
+ENV SQLX_OFFLINE true
 RUN cargo build --release --bin auditor
 
 # Runtime stage

--- a/media/website/content/development.md
+++ b/media/website/content/development.md
@@ -59,12 +59,7 @@ cargo run
 
 Calling `./scripts/db_init.sh` will start a temporary PostgreSQL database in a Docker container and will automatically migrate the database.
 If you plan to run Auditor like this in production, make sure to properly set up a database and instead of calling `db_init.sh` pass the correct settings to auditor via the configuration environment variables mentioned above.
-Building requires a running database, because database queries are checked against the database during runtime! This can be disabled with:
-
-```bash
-SQLX_OFFLINE=true cargo run
-```
-
+Building requires a running database, because database queries are checked against the database during runtime!
 For nicer logs pipe the output through `bunyan`:
 
 ```bash

--- a/pyauditor/.cargo/config.toml
+++ b/pyauditor/.cargo/config.toml
@@ -1,2 +1,0 @@
-[env]
-SQLX_OFFLINE = "true"

--- a/scripts/docs_pyauditor.sh
+++ b/scripts/docs_pyauditor.sh
@@ -12,7 +12,7 @@ function make_docs() {
   pip install sphinx
   pip install sphinx_rtd_theme
   pip install myst-parser
-  SQLX_OFFLINE=true maturin develop
+  maturin develop
   cd docs
   make html
 }


### PR DESCRIPTION
This PR removes the remaining occurrences of `SQLX_OFFLINE`. The offline mode is enabled by default in newer versions of `sqlx`.