### PR TITLE
update cargo-get

### DIFF
--- a/.github/workflows/rpm-build.yml
+++ b/.github/workflows/rpm-build.yml
@@ -26,7 +26,7 @@ jobs:
 
     env:
       SQLX_OFFLINE: true 
-      CARGO_GET_VERSION: 0.3.3
+      CARGO_GET_VERSION: 1
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -50,7 +50,7 @@ jobs:
             ~/.cargo/bin/cargo-get
 
       - name: Install cargo-get
-        run: cargo install cargo-get --version=${{ env.CARGO_GET_VERSION }} --locked
+        run: cargo install cargo-get --version ~${{ env.CARGO_GET_VERSION }} --locked
 
       - name: Install musl and rpm
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Dependencies: Add urlencoding 2.1.3 (to parse datetime while querying records)  (#465) ([@raghuvar-vijay](https://github.com/raghuvar-vijay))
 
 ### Changed
+- Dependencies: Update cargo-get from 0.3.3 to 1.0.0 ([@dirksammel](https://github.com/dirksammel))
 - Dependencies: Update num-traits from 0.2.16 to 0.2.27 ([@QuantumDancer](https://github.com/QuantumDancer))
 - Dependencies: Update regex from 1.9.5 to 1.10.0 ([@QuantumDancer](https://github.com/QuantumDancer))
 - Dependencies: Update reqwest from 0.11.20 to 0.11.22 ([@QuantumDancer](https://github.com/QuantumDancer))

--- a/scripts/build_rpm.sh
+++ b/scripts/build_rpm.sh
@@ -3,7 +3,7 @@ set -x
 set -eo pipefail
 
 BINARY=${BINARY:="auditor-slurm-epilog-collector"}
-CRATE_VERSION=$(cargo get --root auditor version)
+CRATE_VERSION=$(cargo get package.version --entry auditor)
 
 
 mkdir -p target/rpm/${BINARY}/rpmbuild


### PR DESCRIPTION
This PR updates `cargo-get` to v1.0.0 and ensures a version >=1.0.0 and <2.0.0.