### PR TITLE
pyauditor and auditor Docker image from source for HTCondor collector workflow

### DIFF
--- a/.github/workflows/htcondor-collector.yaml
+++ b/.github/workflows/htcondor-collector.yaml
@@ -17,6 +17,17 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: 3.9
+    - name: Create fake .cargo/config.toml
+      run: |
+        mkdir -p .cargo
+        echo -e "[env]\nSQLX_OFFLINE = \"true\"" >> .cargo/config.toml
+    - name: Build pyauditor
+      uses: messense/maturin-action@v1
+      with:
+        target: x86_64
+        manylinux: auto
+        command: build
+        args: --release --sdist -o dist --interpreter python3.9 --manifest-path pyauditor/Cargo.toml
     - name: Build collector package
       run: |
         python3.9 -m venv pvenv
@@ -28,9 +39,15 @@ jobs:
       run: |
         docker compose -f docker-compose.yaml up -d --build
         sleep 5
+    - name: Install pyauditor in container
+      run: |
+        docker cp dist/python_auditor-*whl htcondor-auditor-collector-1:/tmp/
+        docker exec -u submituser htcondor-auditor-collector-1 \
+          bash -c "pip install --upgrade pip && \
+            pip install --no-cache-dir --no-index /tmp/python_auditor-*.whl"
     - name: Install collector in container
       run: |
-        docker cp dist/*whl htcondor-auditor-collector-1:/tmp/
+        docker cp dist/auditor_htcondor_collector-*whl htcondor-auditor-collector-1:/tmp/
         docker exec -u submituser htcondor-auditor-collector-1 \
           bash -c "pip install --upgrade pip && \
             pip install --no-cache-dir --no-index /tmp/auditor_htcondor_collector-*.whl"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Dependencies: Update tokio from 1.32.0 to 1.33.0 ([@QuantumDancer](https://github.com/QuantumDancer))
 - Dependencies: Update tracing from 0.1.37 to 0.1.39 ([@QuantumDancer](https://github.com/QuantumDancer))
 - Dependencies: Update tracing-actix-web from 0.7.6 to 0.7.7 ([@QuantumDancer](https://github.com/QuantumDancer))
+- CI: Build pyauditor and Auditor Docker image from source for HTCondor collector test ([@dirksammel](https://github.com/dirksammel))
 
 ### Removed
 

--- a/containers/htcondor/collector.Dockerfile
+++ b/containers/htcondor/collector.Dockerfile
@@ -6,7 +6,6 @@ RUN yum update -y && \
     rm -rf /var/cache/yum/*
 
 RUN python3.9 -m pip install --upgrade pip pyyaml
-RUN python3.9 -m pip install python-auditor
 
 COPY ./condor_passwords /etc/condor/passwords-orig.d/
 COPY ./condor_passwords/POOL /home/submituser/POOL

--- a/containers/htcondor/docker-compose.yaml
+++ b/containers/htcondor/docker-compose.yaml
@@ -1,6 +1,8 @@
 services:
   auditor:
-    image: aluschumacher/auditor:edge
+    build:
+      context: ../../
+      dockerfile: containers/auditor/Dockerfile
     environment:
       - AUDITOR_DATABASE__REQUIRE_SSL=false
       - AUDITOR_DATABASE__HOST=postgres


### PR DESCRIPTION
This PR builds `pyauditor` and the `auditor` Docker image from source for use in the HTCondor collector workflow.
Closes #474.