### PR TITLE
remove sdist from htcondor workflow

### DIFF
--- a/.github/workflows/htcondor-collector.yaml
+++ b/.github/workflows/htcondor-collector.yaml
@@ -27,7 +27,7 @@ jobs:
         target: x86_64
         manylinux: auto
         command: build
-        args: --release --sdist -o dist --interpreter python3.9 --manifest-path pyauditor/Cargo.toml
+        args: --release -o dist --interpreter python3.9 --manifest-path pyauditor/Cargo.toml
     - name: Build collector package
       run: |
         python3.9 -m venv pvenv


### PR DESCRIPTION
This PR removes the `-- sdist` argument from `maturin` when building `pyauditor.` We only need the `.whl` file, not the source.