### PR TITLE
Priority plugin: Fix location of frequency option and update docs/migration guide

### DIFF
--- a/auditor/configuration/priority-plugin/base.yml
+++ b/auditor/configuration/priority-plugin/base.yml
@@ -17,11 +17,11 @@ group_mapping:
 commands:
   - "/usr/bin/scontrol update PartitionName={1} PriorityJobFactor={priority}"
   - "echo '{group}: {priority}'"
+frequency: 3600
 prometheus:
   enable: true
   addr: 0.0.0.0
   port: 9000
-  frequency: 3600
   metrics:
     - ResourceUsage
     - Priority

--- a/containers/docker-centos7-slurm/plugin_config_fullspread.yaml
+++ b/containers/docker-centos7-slurm/plugin_config_fullspread.yaml
@@ -21,11 +21,11 @@ group_mapping:
     - "part6"
 command:
   - "/usr/bin/scontrol update PartitionName={1} PriorityJobFactor={priority}"
+frequency: 3600
 prometheus:
   enable: true
   addr: 0.0.0.0
   port: 9000
-  frequency: 3600
   metrics:
     - ResourceUsage
     - Priority

--- a/containers/docker-centos7-slurm/plugin_config_scaledbysum.yaml
+++ b/containers/docker-centos7-slurm/plugin_config_scaledbysum.yaml
@@ -21,11 +21,11 @@ group_mapping:
     - "part6"
 command:
   - "/usr/bin/scontrol update PartitionName={1} PriorityJobFactor={priority}"
+frequency: 3600
 prometheus:
   enable: true
   addr: 0.0.0.0
   port: 9000
-  frequency: 3600
   metrics:
     - ResourceUsage
     - Priority

--- a/containers/docker-centos7-slurm/test_config_prometheus_exporter.yaml
+++ b/containers/docker-centos7-slurm/test_config_prometheus_exporter.yaml
@@ -17,11 +17,11 @@ group_mapping:
 commands:
   - "/usr/bin/scontrol update PartitionName={1} PriorityJobFactor={priority}"
   - "echo '{group}: {priority}'"
+frequency: 5
 prometheus:
   enable: true
   addr: "localhost"
   port: 9000
-  frequency: 5
   metrics:
     - ResourceUsage
     - Priority

--- a/plugins/priority/src/configuration.rs
+++ b/plugins/priority/src/configuration.rs
@@ -38,6 +38,9 @@ pub struct Settings {
     pub duration: Option<Duration>,
     #[serde(default = "default_computation_mode")]
     pub computation_mode: ComputationMode,
+    #[serde(default = "default_prometheus_frequency")]
+    #[serde_as(as = "serde_with::DurationSeconds<i64>")]
+    pub frequency: chrono::Duration,
     #[serde(default = "default_log_level")]
     #[serde(deserialize_with = "deserialize_log_level")]
     pub log_level: LevelFilter,
@@ -64,9 +67,6 @@ pub struct PrometheusSettings {
     #[serde(default = "default_prometheus_port")]
     #[serde(deserialize_with = "deserialize_number_from_string")]
     pub port: u16,
-    #[serde(default = "default_prometheus_frequency")]
-    #[serde_as(as = "serde_with::DurationSeconds<i64>")]
-    pub frequency: chrono::Duration,
     pub metrics: Vec<PrometheusMetricsOptions>,
 }
 

--- a/plugins/priority/src/main.rs
+++ b/plugins/priority/src/main.rs
@@ -260,7 +260,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let request_metrics = PrometheusExporterConfig::build()?;
 
     let cloned_request_metrics = request_metrics.clone();
-    let mut interval = tokio::time::interval(chrono::Duration::seconds(3600).to_std()?);
+    let mut interval = tokio::time::interval(config.frequency.to_std()?);
     let mut enable_prometheus = false;
     let mut prometheus_metrics = Vec::<PrometheusMetricsOptions>::new();
 
@@ -268,7 +268,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         Some(prometheus_settings) => {
             let prometheus_addr = prometheus_settings.addr.clone();
             let prometheus_port = prometheus_settings.port;
-            interval = tokio::time::interval(prometheus_settings.frequency.to_std()?);
             enable_prometheus = prometheus_settings.enable;
             let address = format!("{}:{}", prometheus_addr, prometheus_port);
             prometheus_metrics = prometheus_settings.metrics;
@@ -363,12 +362,12 @@ mod tests {
             commands: vec!["whatever".to_string()],
             duration: None,
             computation_mode: ComputationMode::FullSpread,
+            frequency: chrono::Duration::seconds(3600),
             log_level: LevelFilter::INFO,
             prometheus: Some(PrometheusSettings {
                 enable: true,
                 addr: "whatever".to_string(),
                 port: 1234,
-                frequency: chrono::Duration::seconds(3600),
                 metrics: vec![
                     PrometheusMetricsOptions::ResourceUsage,
                     PrometheusMetricsOptions::Priority,
@@ -403,12 +402,12 @@ mod tests {
             commands: vec!["whatever".to_string()],
             duration: None,
             computation_mode: ComputationMode::ScaledBySum,
+            frequency: chrono::Duration::seconds(3600),
             log_level: LevelFilter::INFO,
             prometheus: Some(PrometheusSettings {
                 enable: true,
                 addr: "whatever".to_string(),
                 port: 1234,
-                frequency: chrono::Duration::seconds(3600),
                 metrics: vec![
                     PrometheusMetricsOptions::ResourceUsage,
                     PrometheusMetricsOptions::Priority,


### PR DESCRIPTION
The frequency option for the priority plugin was introduced in #471. However, it should not be in the `prometheus` block but in the main section of the configuration.

In addition, this PR also updates the documentation for the priority plugin after introducing the Prometheus exporter and makes improvements to the existing documentation and migration guide for the Prometheus plugin.

The changelog has no update because this PR only improves on changes introduced after the latest release.