### PR TITLE
create cache for pyauditor linux build

### DIFF
--- a/.github/workflows/build_pyauditor.yml
+++ b/.github/workflows/build_pyauditor.yml
@@ -38,13 +38,19 @@ jobs:
           manylinux: auto
           command: build
           args: --release --sdist -o dist --interpreter python${{ matrix.python-version }} --manifest-path pyauditor/Cargo.toml
-
+          
+      - name: Cache wheel
+        uses: actions/cache@v3
+        with:
+          path: dist
+          key: pyauditor-linux-wheel-${{ matrix.python-version }}-${{ github.run_id }}
+          
       - name: Upload wheel
         uses: actions/upload-artifact@v3
         with:
-          name: linux-wheel-${{ matrix.python-version }}
           path: dist
-
+          name: linux-wheel-${{ matrix.python-version }}
+          
   windows:
     runs-on: windows-latest
     strategy:


### PR DESCRIPTION
This PR creates a cache for the pyauditor linux build in `main`. This is needed since workflows in a PR don't seem to be able to access caches created in the PR.