### PR TITLE
Fix: Slurm collector handles ambiguous local time after switching from CEST to CET

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Dependencies: Add urlencoding 2.1.3 (to parse datetime while querying records)  (#465) ([@raghuvar-vijay](https://github.com/raghuvar-vijay))
 
 ### Changed
+- Slurm collector: Fix ambiguous local time in database.rs after switching from CEST to CET (#518) ([@raghuvar-vijay](https://github.com/raghuvar-vijay))
 - Dependencies: Update cargo-get from 0.3.3 to 1.0.0 ([@dirksammel](https://github.com/dirksammel))
 - Dependencies: Update fake from 2.8.0 to 2.9.1 ([@QuantumDancer](https://github.com/QuantumDancer))
 - Dependencies: Update num-traits from 0.2.16 to 0.2.27 ([@QuantumDancer](https://github.com/QuantumDancer))


### PR DESCRIPTION
This fixes #518.

Slurm collector crashes when daylight savings ends ( switches from CEST to CET). Due to this change, the timestamp stored in the db differs in timezone compared to the local time. This raises ambiguity while comparing the queried timezone (CEST) and the current local timezone (CET). 

The issue is fixed by choosing the timezone in which the queried timestamp was already saved in the db, which in this case would be CEST. 