### PR TITLE
Advanced query: Time filters, Meta filters and component, sort_by, limit, record_id filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Security
 
 ### Added
+- Auditor+pyauditor: Added advanced filtering when querying records (#466) ([@raghuvar-vijay](https://github.com/raghuvar-vijay))
 
 ### Changed
-
+- Auditor+pyauditor: Deprecate `get_started_since()` and `get_stopped_since()` functions ([@raghuvar-vijay](https://github.com/raghuvar-vijay))
 - Dependencies: Update sqlx from 0.7.2 to 0.7.3 ([@QuantumDancer](https://github.com/QuantumDancer))
 
 ### Removed
@@ -54,6 +55,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Priority plugin: Add prometheus data exporter (#456) ([@raghuvar-vijay](https://github.com/raghuvar-vijay))
 - Slurm collector: Add `default_value` option for component configuration (#510) ([@QuantumDancer](https://github.com/QuantumDancer))
 - Dependencies: Add urlencoding 2.1.3 (to parse datetime while querying records)  (#465) ([@raghuvar-vijay](https://github.com/raghuvar-vijay))
+
 
 ### Changed
 - Slurm collector: Fix ambiguous local time in database.rs after switching from CEST to CET (#518) ([@raghuvar-vijay](https://github.com/raghuvar-vijay))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -365,6 +365,7 @@ dependencies = [
  "secrecy",
  "serde",
  "serde-aux",
+ "serde_qs 0.11.0",
  "serde_with",
  "sqlx",
  "thiserror",
@@ -1340,7 +1341,7 @@ dependencies = [
  "rand 0.7.3",
  "serde",
  "serde_json",
- "serde_qs",
+ "serde_qs 0.8.5",
  "serde_urlencoded",
  "url",
 ]
@@ -2216,6 +2217,7 @@ dependencies = [
  "chrono",
  "pyo3",
  "pyo3-asyncio",
+ "serde",
  "serde_json",
  "tokio",
 ]
@@ -2621,6 +2623,19 @@ version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7715380eec75f029a4ef7de39a9200e0a63823176b759d055b613f5a87df6a6"
 dependencies = [
+ "percent-encoding",
+ "serde",
+ "thiserror",
+]
+
+[[package]]
+name = "serde_qs"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c679fa27b429f2bb57fd4710257e643e86c966e716037259f8baa33de594a1b6"
+dependencies = [
+ "actix-web",
+ "futures",
  "percent-encoding",
  "serde",
  "thiserror",

--- a/auditor/.sqlx/query-e6c7e05a8f9aac8353000db25e8ac0bc54f7ff067ab70715b8659cb835f45af6.json
+++ b/auditor/.sqlx/query-e6c7e05a8f9aac8353000db25e8ac0bc54f7ff067ab70715b8659cb835f45af6.json
@@ -1,0 +1,102 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT a.record_id,\n                          m.meta as \"meta: Vec<(String, Vec<String>)>\",\n                          css.components as \"components: Vec<Component>\",\n                          a.start_time as \"start_time?\",\n                          a.stop_time,\n                          a.runtime\n                   FROM accounting a\n                   LEFT JOIN (\n                       WITH subquery AS (\n                           SELECT m.record_id as record_id, m.key as key, array_agg(m.value) as values\n                           FROM meta as m\n                           GROUP BY m.record_id, m.key\n                       )\n                       SELECT s.record_id as record_id, array_agg(row(s.key, s.values)) as meta\n                       FROM subquery as s\n                       GROUP BY s.record_id\n                       ) m ON m.record_id = a.record_id\n                   LEFT JOIN (\n                       WITH subquery AS (\n                          SELECT \n                              c.id as cid,\n                              COALESCE(array_agg(row(s.name, s.value)::score) FILTER (WHERE s.name IS NOT NULL AND s.value IS NOT NULL), '{}'::score[]) as scores\n                          FROM components as c\n                          LEFT JOIN components_scores as cs\n                          ON c.id = cs.component_id\n                          LEFT JOIN scores as s\n                          ON cs.score_id = s.id\n                          GROUP BY c.id\n                       )\n                       SELECT rc.record_id as id, array_agg(row(c.name, c.amount, sq.scores)::component) as components\n                       FROM records_components AS rc\n                       LEFT JOIN components as c\n                       ON rc.component_id = c.id\n                       LEFT JOIN subquery AS sq\n                       ON sq.cid = rc.component_id\n                       GROUP BY rc.record_id\n                   ) css ON css.id = a.id\n                   WHERE a.record_id = $1\n               ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "record_id",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 1,
+        "name": "meta: Vec<(String, Vec<String>)>",
+        "type_info": "RecordArray"
+      },
+      {
+        "ordinal": 2,
+        "name": "components: Vec<Component>",
+        "type_info": {
+          "Custom": {
+            "name": "_component",
+            "kind": {
+              "Array": {
+                "Custom": {
+                  "name": "component",
+                  "kind": {
+                    "Composite": [
+                      [
+                        "name",
+                        "Text"
+                      ],
+                      [
+                        "amount",
+                        "Int8"
+                      ],
+                      [
+                        "scores",
+                        {
+                          "Custom": {
+                            "name": "_score",
+                            "kind": {
+                              "Array": {
+                                "Custom": {
+                                  "name": "score",
+                                  "kind": {
+                                    "Composite": [
+                                      [
+                                        "name",
+                                        "Text"
+                                      ],
+                                      [
+                                        "value",
+                                        "Float8"
+                                      ]
+                                    ]
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      ]
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "ordinal": 3,
+        "name": "start_time?",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 4,
+        "name": "stop_time",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 5,
+        "name": "runtime",
+        "type_info": "Int8"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      null,
+      null,
+      false,
+      true,
+      true
+    ]
+  },
+  "hash": "e6c7e05a8f9aac8353000db25e8ac0bc54f7ff067ab70715b8659cb835f45af6"
+}

--- a/auditor/Cargo.toml
+++ b/auditor/Cargo.toml
@@ -65,6 +65,7 @@ thiserror = "1"
 prometheus = "0.13"
 itertools = "0.12.0"
 urlencoding = "2.1.3"
+serde_qs = { version = "0.11.0", features = ["actix4"] }
 
 [dependencies.sqlx]
 version = "0.7.3"

--- a/auditor/src/client/mod.rs
+++ b/auditor/src/client/mod.rs
@@ -13,6 +13,8 @@ use crate::{
 };
 use chrono::{DateTime, Duration, Utc};
 use reqwest;
+use serde::Serialize;
+use std::collections::HashMap;
 use urlencoding::encode;
 
 static APP_USER_AGENT: &str = concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION"),);
@@ -174,6 +176,439 @@ impl Default for AuditorClientBuilder {
     }
 }
 
+/// `DateTimeUtcWrapper` helps to implement custom serialization to serialize `DateTime<Utc>`
+/// to rfc3339, so that it can be used to correctly encode the query string.
+#[derive(serde::Deserialize, Debug, Default, Clone)]
+pub struct DateTimeUtcWrapper(pub DateTime<Utc>);
+
+/// Implementation of the `Serialize` trait for DateTimeUtcWrapper.
+impl Serialize for DateTimeUtcWrapper {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str(&self.0.to_rfc3339())
+    }
+}
+
+/// The `QueryParameters` is used to build query parameters which allows to query records from
+/// the database using advanced_query function.
+#[derive(serde::Deserialize, serde::Serialize, Debug, Default, Clone)]
+pub struct QueryParameters {
+    /// Specifies the record id to query the exact record from the database
+    pub record_id: Option<String>,
+    /// Specifies the start time for querying records. It uses the `Operator` enum to
+    /// define time-based operations.
+    pub start_time: Option<Operator>,
+    /// Specifies the stop time for querying records. It uses the `Operator` enum to
+    /// define time-based operations.
+    pub stop_time: Option<Operator>,
+    /// Specifies the runtime for querying records. It uses the `Operator` enum to
+    /// define time-based operations.
+    pub runtime: Option<Operator>,
+    /// Specifies the meta values for querying records. It uses the `MetaOperator` enum to
+    /// define meta operations.
+    pub meta: Option<MetaQuery>,
+    /// Specifies the start time for querying records. It uses the `Operator` enum to
+    /// define component-based operations.
+    pub component: Option<ComponentQuery>,
+    // Specifies either to sort the query by ascending or descending order
+    pub sort_by: Option<SortBy>,
+    /// Specifies the number of query records to be returned
+    pub limit: Option<u64>,
+}
+
+impl Default for QueryBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Enum representing different types of values that can be used in query parameters
+/// Enum is used instead of generics to specify the type because pyo3 bindings does not contain the equivalent
+/// generics implementation.
+#[derive(serde::Deserialize, Debug, Clone)]
+pub enum Value {
+    /// Represents a datetime value
+    Datetime(DateTimeUtcWrapper),
+    /// Represents a runtime value
+    Runtime(u64),
+    /// Represents a count value
+    Count(u8),
+}
+
+/// Implementation of the `Serialize` trait for the `Value` enum.
+impl Serialize for Value {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Value::Datetime(datetime) => datetime.serialize(serializer),
+            Value::Runtime(runtime) => runtime.serialize(serializer),
+            Value::Count(count) => count.serialize(serializer),
+        }
+    }
+}
+
+/// The `Operator` struct is used to specify the operators on the query parameters.
+#[derive(serde::Deserialize, serde::Serialize, Debug, Default, Clone)]
+pub struct Operator {
+    /// Greater than operator.
+    pub gt: Option<Value>,
+    /// Lesser than operator.
+    pub lt: Option<Value>,
+    /// Greater than or equals operator.
+    pub gte: Option<Value>,
+    /// Lesser than or equals operator.
+    pub lte: Option<Value>,
+    /// Equals operator.
+    pub equals: Option<Value>,
+}
+
+/// Implementation of methods for the `Operator` struct to set various operators.
+impl Operator {
+    pub fn gt(mut self, value: Value) -> Self {
+        self.gt = Some(value);
+        self
+    }
+
+    pub fn lt(mut self, value: Value) -> Self {
+        self.lt = Some(value);
+        self
+    }
+
+    pub fn gte(mut self, value: Value) -> Self {
+        self.gte = Some(value);
+        self
+    }
+
+    pub fn lte(mut self, value: Value) -> Self {
+        self.lte = Some(value);
+        self
+    }
+
+    pub fn equals(mut self, value: Value) -> Self {
+        if !matches!(value, Value::Datetime(_)) {
+            self.equals = Some(value);
+            self
+        } else {
+            self
+        }
+    }
+}
+
+/// Implementations of conversion traits for the `Value` enum.
+
+/// Conversion from chrono DateTime to Value::Datetime.
+impl From<chrono::DateTime<Utc>> for Value {
+    fn from(item: chrono::DateTime<Utc>) -> Self {
+        Value::Datetime(DateTimeUtcWrapper(item))
+    }
+}
+
+/// Conversion from u64 to Value::Runtime.
+impl From<u64> for Value {
+    fn from(item: u64) -> Self {
+        Value::Runtime(item)
+    }
+}
+
+/// Conversion from u8 to Value::Count.
+impl From<u8> for Value {
+    fn from(item: u8) -> Self {
+        Value::Count(item)
+    }
+}
+
+/// The `QueryBuilder` is used to construct `QueryParameters` using the builder pattern.
+/// It is used to fetch records using query parameters such as start_time, stop_time etc.
+///
+/// # Examples
+///
+/// ```
+/// use auditor::client::{QueryBuilder, Operator, MetaQuery, ComponentQuery, SortBy};
+///
+/// // Create a new QueryBuilder instance.
+/// let query_builder = QueryBuilder::new()
+///     .with_start_time(Operator::default()) // Set start time operator.
+///     .with_stop_time(Operator::default())  // Set stop time operator.
+///     .with_runtime(Operator::default())    // Set runtime operator.
+///     .with_meta_query(MetaQuery::new())    // Set meta query.
+///     .with_component_query(ComponentQuery::new())  // Set component query.
+///     .sort_by(SortBy::new()) // Set sort by options
+///     .limit(1000); // Limit the number of queries
+///
+/// // For querying all records, just create an empty QueryBuilder instance without operators
+/// let query_builder = QueryBuilder::new();
+///
+/// // Build the query string.
+/// let query_string = query_builder.build();
+/// println!("Generated query string: {}", query_string);
+/// ```
+///
+#[derive(Debug, Clone)]
+pub struct QueryBuilder {
+    /// Query parameters to be built.
+    pub query_params: QueryParameters,
+}
+
+impl QueryBuilder {
+    /// Creates a new instance of the QueryBuilder with default parameters.
+    pub fn new() -> Self {
+        QueryBuilder {
+            query_params: QueryParameters {
+                record_id: None,
+                start_time: None,
+                stop_time: None,
+                runtime: None,
+                meta: None,
+                component: None,
+                sort_by: None,
+                limit: None,
+            },
+        }
+    }
+
+    /// Sets the exact record to be queried from the database using record id
+    pub fn with_record_id(mut self, record_id: String) -> Self {
+        self.query_params.record_id = Some(record_id);
+        self
+    }
+
+    /// Sets the start time in the query parameters.
+    pub fn with_start_time(mut self, time_operator: Operator) -> Self {
+        self.query_params.start_time = Some(time_operator);
+        self
+    }
+
+    /// Sets the stop time in the query parameters.
+    pub fn with_stop_time(mut self, time_operator: Operator) -> Self {
+        self.query_params.stop_time = Some(time_operator);
+        self
+    }
+
+    /// Sets the runtime in the query parameters.
+    pub fn with_runtime(mut self, time_operator: Operator) -> Self {
+        self.query_params.runtime = Some(time_operator);
+        self
+    }
+
+    /// Sets the meta query in the query parameters.
+    pub fn with_meta_query(mut self, meta: MetaQuery) -> Self {
+        self.query_params.meta = Some(meta);
+        self
+    }
+
+    /// Sets the component query in the query parameters.
+    pub fn with_component_query(mut self, component: ComponentQuery) -> Self {
+        self.query_params.component = Some(component);
+        self
+    }
+
+    /// Sets the sort_by option for the resulting query
+    pub fn sort_by(mut self, sort: SortBy) -> Self {
+        self.query_params.sort_by = Some(sort);
+        self
+    }
+
+    pub fn limit(mut self, number: u64) -> Self {
+        self.query_params.limit = Some(number);
+        self
+    }
+
+    // Executes an asynchronous query using the built parameters.
+    ///
+    /// # Arguments
+    ///
+    /// * `client` - An instance of the `AuditorClient` used to perform the query.
+    ///
+    /// # Returns
+    ///
+    /// A `Result` containing the vector of records if successful, or a `ClientError` if an error occurs.
+    ///
+    pub async fn get(&self, client: AuditorClient) -> Result<Vec<Record>, ClientError> {
+        let query_string = self.build();
+        client.advanced_query(query_string).await
+    }
+
+    /// Builds and returns the serialized query string
+    pub fn build(&self) -> String {
+        serde_qs::to_string(&self.query_params).expect("Failed to serialize query parameters")
+    }
+}
+
+/// The `MetaQuery` struct represents a set of metadata queries associated with specific query IDs
+/// It is used to filter records based on metadata conditions.
+#[derive(serde::Deserialize, Debug, Default, Clone)]
+pub struct MetaQuery {
+    /// HashMap containing query IDs and corresponding metadata operators.
+    pub meta_query: HashMap<String, Option<MetaOperator>>,
+}
+
+impl MetaQuery {
+    /// Creates a new instance of `MetaQuery` with an empty HashMap.
+    pub fn new() -> Self {
+        MetaQuery {
+            meta_query: HashMap::new(),
+        }
+    }
+
+    /// Adds a new metadata operator to the `MetaQuery` instance for a specific query ID.
+    ///
+    /// # Arguments
+    ///
+    /// * `query_id` - A unique identifier for the metadata query.
+    /// * `operator` - The metadata operator containing conditions for the query.
+    ///
+    /// # Returns
+    ///
+    /// A new `MetaQuery` instance with the added metadata operator.
+    pub fn meta_operator(mut self, query_id: String, operator: MetaOperator) -> Self {
+        self.meta_query.insert(query_id.to_string(), Some(operator));
+        self
+    }
+}
+
+/// Implementation of the `Serialize` trait for the `MetaQuery` struct.
+/// It allows the serialization of `MetaQuery` instances for building query string.
+impl Serialize for MetaQuery {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        self.meta_query.serialize(serializer)
+    }
+}
+
+/// The `MetaOperator` struct represents operators for metadata queries, specifying conditions for filtering.
+#[derive(serde::Deserialize, serde::Serialize, Debug, Default, Clone)]
+pub struct MetaOperator {
+    /// `contains` - Specifies if the meta key contains the value.
+    pub c: Option<String>,
+    /// `does not contains` - Specifies if the meta key does not contains the value.
+    pub dnc: Option<String>,
+}
+
+impl MetaOperator {
+    /// Specifies that the metadata query should contain a specific value.
+    ///
+    /// # Arguments
+    ///
+    /// * `c` - The value to be contained in the metadata query.
+    ///
+    /// # Returns
+    ///
+    /// A new `MetaOperator` instance with the specified condition.
+    pub fn contains(mut self, c: String) -> Self {
+        self.c = Some(c);
+        self
+    }
+
+    /// Specifies that the metadata query should not contain a specific value.
+    ///
+    /// # Arguments
+    ///
+    /// * `dnc` - The value that the metadata query should not contain.
+    ///
+    /// # Returns
+    ///
+    /// A new `MetaOperator` instance with the specified condition.
+    pub fn does_not_contains(mut self, dnc: String) -> Self {
+        self.dnc = Some(dnc);
+        self
+    }
+}
+
+/// The `ComponentQuery` struct represents a set of component queries associated with specific query IDs.
+/// It is used to filter records based on component-related conditions.
+#[derive(serde::Deserialize, Debug, Default, Clone)]
+pub struct ComponentQuery {
+    /// HashMap containing query IDs and corresponding component operators.
+    pub component_query: HashMap<String, Option<Operator>>,
+}
+
+impl ComponentQuery {
+    /// Creates a new instance of `ComponentQuery` with an empty HashMap.
+    pub fn new() -> Self {
+        ComponentQuery {
+            component_query: HashMap::new(),
+        }
+    }
+
+    /// Adds a new component operator to the `ComponentQuery` instance for a specific query ID.
+    ///
+    /// # Arguments
+    ///
+    /// * `query_id` - A unique identifier for the component query.
+    /// * `operator` - The component operator containing conditions for the query.
+    ///
+    /// # Returns
+    ///
+    /// A new `ComponentQuery` instance with the added component operator.
+    pub fn component_operator(mut self, query_id: String, operator: Operator) -> Self {
+        self.component_query
+            .insert(query_id.to_string(), Some(operator));
+        self
+    }
+}
+
+/// Implementation of the `Serialize` trait for the `ComponentQuery` struct.
+/// It allows the serialization of `ComponentQuery` instances for building query string.
+impl Serialize for ComponentQuery {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        self.component_query.serialize(serializer)
+    }
+}
+
+/// SortBy provides options on sorting the query records
+#[derive(serde::Deserialize, serde::Serialize, Debug, Default, Clone)]
+pub struct SortBy {
+    pub asc: Option<String>,
+    pub desc: Option<String>,
+}
+
+impl SortBy {
+    /// Creates a new instance of `SortBy`
+    pub fn new() -> Self {
+        Self {
+            asc: None,
+            desc: None,
+        }
+    }
+
+    /// Specify the column by which the query records must be sorted in ascending order
+    ///
+    /// # Arguments
+    ///
+    /// * `column` - One of four values (`start_time`, `stop_time`, `runtime`, `record_id`)
+    ///
+    /// # Returns
+    ///
+    /// A new `SortBy` instance with column name.
+    pub fn ascending(mut self, column: String) -> Self {
+        self.asc = Some(column);
+        self
+    }
+
+    /// Specify the column by which the query records must be sorted in descending order
+    ///
+    /// # Arguments
+    ///
+    /// * `column` - One of three values (`start_time`, `stop_time`, `runtime`, `record_id`)
+    ///
+    /// # Returns
+    ///
+    /// A new `SortBy` instance with column name.
+    pub fn descending(mut self, column: String) -> Self {
+        self.desc = Some(column);
+        self
+    }
+}
+
 /// The `AuditorClient` handles the interaction with the Auditor instances and allows one to add
 /// records to the database, update records in the database and retrieve the records from the
 /// database.
@@ -229,6 +664,7 @@ impl AuditorClient {
 
     /// Update an existing record in the Auditor instance.
     ///
+    ///
     /// # Errors
     ///
     /// * [`ClientError::ReqwestError`] - If there was an error sending the HTTP request.
@@ -275,6 +711,7 @@ impl AuditorClient {
         skip(self),
         fields(started_since = %since)
     )]
+    #[deprecated(since = "0.4.0", note = "please use `advanced_query` instead")]
     pub async fn get_started_since(
         &self,
         since: &DateTime<Utc>,
@@ -285,7 +722,7 @@ impl AuditorClient {
         Ok(self
             .client
             .get(&format!(
-                "{}/record?state=started&since={}",
+                "{}/record?start_time[gte]={}",
                 &self.address, encoded_since
             ))
             .send()
@@ -305,6 +742,7 @@ impl AuditorClient {
         skip(self),
         fields(started_since = %since)
     )]
+    #[deprecated(since = "0.4.0", note = "please use `advanced_query` instead")]
     pub async fn get_stopped_since(
         &self,
         since: &DateTime<Utc>,
@@ -314,9 +752,49 @@ impl AuditorClient {
         Ok(self
             .client
             .get(&format!(
-                "{}/record?state=stopped&since={}",
+                "{}/record?stop_time[gte]={}",
                 &self.address, encoded_since
             ))
+            .send()
+            .await?
+            .error_for_status()?
+            .json()
+            .await?)
+    }
+
+    /// Get records from AUDITOR server using custom query.
+    ///
+    /// # Errors
+    ///
+    /// * [`ClientError::ReqwestError`] - If there was an error sending the HTTP request.
+    #[tracing::instrument(
+        name = "Getting records from AUDITOR server using custom query",
+        skip(self)
+    )]
+    pub async fn advanced_query(&self, query_string: String) -> Result<Vec<Record>, ClientError> {
+        Ok(self
+            .client
+            .get(&format!("{}/record?{}", &self.address, query_string))
+            .send()
+            .await?
+            .error_for_status()?
+            .json()
+            .await?)
+    }
+
+    /// Get single record from AUDITOR server using record_id.
+    ///
+    /// # Errors
+    ///
+    /// * [`ClientError::ReqwestError`] - If there was an error sending the HTTP request.
+    #[tracing::instrument(
+        name = "Getting a single record from AUDITOR server using record_id",
+        skip(self)
+    )]
+    pub async fn get_single_record(&self, record_id: String) -> Result<Record, ClientError> {
+        Ok(self
+            .client
+            .get(&format!("{}/record/{}", &self.address, record_id))
             .send()
             .await?
             .error_for_status()?
@@ -421,6 +899,7 @@ impl AuditorClientBlocking {
         skip(self),
         fields(started_since = %since)
     )]
+    #[deprecated(since = "0.4.0", note = "please use `advanced_query` instead")]
     pub fn get_started_since(&self, since: &DateTime<Utc>) -> Result<Vec<Record>, ClientError> {
         dbg!(since.to_rfc3339());
         let since_str = since.to_rfc3339();
@@ -428,7 +907,7 @@ impl AuditorClientBlocking {
         Ok(self
             .client
             .get(format!(
-                "{}/record?state=started&since={}",
+                "{}/record?start_time[gte]={}",
                 &self.address, encoded_since
             ))
             .send()?
@@ -446,15 +925,48 @@ impl AuditorClientBlocking {
         skip(self),
         fields(started_since = %since)
     )]
+    #[deprecated(since = "0.4.0", note = "please use `advanced_query` instead")]
     pub fn get_stopped_since(&self, since: &DateTime<Utc>) -> Result<Vec<Record>, ClientError> {
         let since_str = since.to_rfc3339();
         let encoded_since = encode(&since_str);
         Ok(self
             .client
             .get(format!(
-                "{}/record?state=stopped&since={}",
+                "{}/record?stop_time[gte]={}",
                 &self.address, encoded_since
             ))
+            .send()?
+            .error_for_status()?
+            .json()?)
+    }
+
+    /// Get records from AUDITOR server using custom filters.
+    ///
+    /// # Errors
+    ///
+    /// * [`ClientError::ReqwestError`] - If there was an error sending the HTTP request.
+    pub fn advanced_query(&self, query_params: String) -> Result<Vec<Record>, ClientError> {
+        Ok(self
+            .client
+            .get(format!("{}/record?{}", &self.address, query_params))
+            .send()?
+            .error_for_status()?
+            .json()?)
+    }
+
+    /// Get single record from AUDITOR server using record_id.
+    ///
+    /// # Errors
+    ///
+    /// * [`ClientError::ReqwestError`] - If there was an error sending the HTTP request.
+    #[tracing::instrument(
+        name = "Getting a single record from AUDITOR server using record_id",
+        skip(self)
+    )]
+    pub fn get_single_record(&self, record_id: &str) -> Result<Record, ClientError> {
+        Ok(self
+            .client
+            .get(format!("{}/record/{}", &self.address, record_id))
             .send()?
             .error_for_status()?
             .json()?)
@@ -875,7 +1387,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn get_started_since_succeeds() {
+    async fn get_advanced_queries_succeeds() {
         let mock_server = MockServer::start().await;
         let client = AuditorClientBuilder::new()
             .connection_string(&mock_server.uri())
@@ -886,16 +1398,16 @@ mod tests {
 
         Mock::given(method("GET"))
             .and(path("/record"))
-            .and(query_param("state", "started"))
-            .and(query_param("since", "2022-08-03T09:47:00+00:00"))
-            // .and(query_param("since", "2022-08-03T09:47:00+00:00"))
+            .and(query_param("start_time[gte]", "2022-08-03T09:47:00+00:00"))
             .respond_with(ResponseTemplate::new(200).set_body_json(&body))
             .expect(1)
             .mount(&mock_server)
             .await;
 
-        let response = client
-            .get_started_since(&Utc.with_ymd_and_hms(2022, 8, 3, 9, 47, 0).unwrap())
+        let datetime_utc = Utc.with_ymd_and_hms(2022, 8, 3, 9, 47, 0).unwrap();
+        let response = QueryBuilder::new()
+            .with_start_time(Operator::default().gte(datetime_utc.into()))
+            .get(client)
             .await
             .unwrap();
 
@@ -907,94 +1419,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn blocking_get_started_since_succeeds() {
-        let mock_server = MockServer::start().await;
-        let uri = mock_server.uri();
-        let client = tokio::task::spawn_blocking(move || {
-            AuditorClientBuilder::new()
-                .connection_string(&uri)
-                .build_blocking()
-                .unwrap()
-        })
-        .await
-        .unwrap();
-
-        let body: Vec<Record> = vec![record()];
-
-        Mock::given(method("GET"))
-            .and(path("/record"))
-            .and(query_param("state", "started"))
-            .and(query_param("since", "2022-08-03T09:47:00+00:00"))
-            .respond_with(ResponseTemplate::new(200).set_body_json(&body))
-            .expect(1)
-            .mount(&mock_server)
-            .await;
-
-        let response = tokio::task::spawn_blocking(move || {
-            client.get_started_since(&Utc.with_ymd_and_hms(2022, 8, 3, 9, 47, 0).unwrap())
-        })
-        .await
-        .unwrap()
-        .unwrap();
-
-        response
-            .into_iter()
-            .zip(body)
-            .map(|(rr, br)| assert_eq!(rr, br))
-            .count();
-    }
-
-    #[tokio::test]
-    async fn get_started_since_fails_on_500() {
-        let mock_server = MockServer::start().await;
-        let client = AuditorClientBuilder::new()
-            .connection_string(&mock_server.uri())
-            .build()
-            .unwrap();
-
-        Mock::given(any())
-            .respond_with(ResponseTemplate::new(500))
-            .expect(1)
-            .mount(&mock_server)
-            .await;
-
-        let response = client
-            .get_started_since(&Utc.with_ymd_and_hms(2022, 8, 3, 9, 47, 0).unwrap())
-            .await;
-
-        assert_err!(response);
-    }
-
-    #[tokio::test]
-    async fn blocking_get_started_since_fails_on_500() {
-        let mock_server = MockServer::start().await;
-        let uri = mock_server.uri();
-        let client = tokio::task::spawn_blocking(move || {
-            AuditorClientBuilder::new()
-                .connection_string(&uri)
-                .build_blocking()
-                .unwrap()
-        })
-        .await
-        .unwrap();
-
-        Mock::given(any())
-            .respond_with(ResponseTemplate::new(500))
-            .expect(1)
-            .mount(&mock_server)
-            .await;
-
-        let response = tokio::task::spawn_blocking(move || {
-            client.get_started_since(&Utc.with_ymd_and_hms(2022, 8, 3, 9, 47, 0).unwrap())
-        })
-        .await
-        .unwrap();
-
-        assert_err!(response);
-    }
-
-    #[tokio::test]
-    async fn get_stopped_since_succeeds() {
+    async fn get_record_query_with_start_time_and_stop_time_succeeds() {
         let mock_server = MockServer::start().await;
         let client = AuditorClientBuilder::new()
             .connection_string(&mock_server.uri())
@@ -1005,15 +1430,18 @@ mod tests {
 
         Mock::given(method("GET"))
             .and(path("/record"))
-            .and(query_param("state", "stopped"))
-            .and(query_param("since", "2022-08-03T09:47:00+00:00"))
+            .and(query_param("start_time[gte]", "2022-08-03T09:47:00+00:00"))
+            .and(query_param("stop_time[gte]", "2022-08-03T09:47:00+00:00"))
             .respond_with(ResponseTemplate::new(200).set_body_json(&body))
             .expect(1)
             .mount(&mock_server)
             .await;
 
-        let response = client
-            .get_stopped_since(&Utc.with_ymd_and_hms(2022, 8, 3, 9, 47, 0).unwrap())
+        let datetime_utc = Utc.with_ymd_and_hms(2022, 8, 3, 9, 47, 0).unwrap();
+        let response = QueryBuilder::new()
+            .with_start_time(Operator::default().gte(datetime_utc.into()))
+            .with_stop_time(Operator::default().gte(datetime_utc.into()))
+            .get(client)
             .await
             .unwrap();
 
@@ -1025,35 +1453,35 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn blocking_get_stopped_since_succeeds() {
+    async fn get_record_query_with_start_time_gte_and_start_time_lte_succeeds() {
         let mock_server = MockServer::start().await;
-        let uri = mock_server.uri();
-        let client = tokio::task::spawn_blocking(move || {
-            AuditorClientBuilder::new()
-                .connection_string(&uri)
-                .build_blocking()
-                .unwrap()
-        })
-        .await
-        .unwrap();
+        let client = AuditorClientBuilder::new()
+            .connection_string(&mock_server.uri())
+            .build()
+            .unwrap();
 
         let body: Vec<Record> = vec![record()];
 
         Mock::given(method("GET"))
             .and(path("/record"))
-            .and(query_param("state", "stopped"))
-            .and(query_param("since", "2022-08-03T09:47:00+00:00"))
+            .and(query_param("start_time[gte]", "2022-08-03T09:47:00+00:00"))
+            .and(query_param("start_time[lte]", "2022-08-04T09:47:00+00:00"))
             .respond_with(ResponseTemplate::new(200).set_body_json(&body))
             .expect(1)
             .mount(&mock_server)
             .await;
 
-        let response = tokio::task::spawn_blocking(move || {
-            client.get_stopped_since(&Utc.with_ymd_and_hms(2022, 8, 3, 9, 47, 0).unwrap())
-        })
-        .await
-        .unwrap()
-        .unwrap();
+        let datetime_utc_gte = Utc.with_ymd_and_hms(2022, 8, 3, 9, 47, 0).unwrap();
+        let datetime_utc_lte = Utc.with_ymd_and_hms(2022, 8, 4, 9, 47, 0).unwrap();
+        let response = QueryBuilder::new()
+            .with_start_time(
+                Operator::default()
+                    .gte(datetime_utc_gte.into())
+                    .lte(datetime_utc_lte.into()),
+            )
+            .get(client)
+            .await
+            .unwrap();
 
         response
             .into_iter()
@@ -1063,7 +1491,99 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn get_stopped_since_fails_on_500() {
+    async fn get_record_query_with_start_time_gte_and_start_time_lte_runtime_succeeds() {
+        let mock_server = MockServer::start().await;
+        let client = AuditorClientBuilder::new()
+            .connection_string(&mock_server.uri())
+            .build()
+            .unwrap();
+
+        let body: Vec<Record> = vec![record()];
+
+        Mock::given(method("GET"))
+            .and(path("/record"))
+            .and(query_param("start_time[gte]", "2022-08-03T09:47:00+00:00"))
+            .and(query_param("start_time[lte]", "2022-08-04T09:47:00+00:00"))
+            .and(query_param("runtime[gte]", "100000"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(&body))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        let datetime_utc_gte = Utc.with_ymd_and_hms(2022, 8, 3, 9, 47, 0).unwrap();
+        let datetime_utc_lte = Utc.with_ymd_and_hms(2022, 8, 4, 9, 47, 0).unwrap();
+        let runtime: u64 = 100000;
+        let response = QueryBuilder::new()
+            .with_start_time(
+                Operator::default()
+                    .gte(datetime_utc_gte.into())
+                    .lte(datetime_utc_lte.into()),
+            )
+            .with_runtime(Operator::default().gte(runtime.into()))
+            .get(client)
+            .await
+            .unwrap();
+
+        response
+            .into_iter()
+            .zip(body)
+            .map(|(rr, br)| assert_eq!(rr, br))
+            .count();
+    }
+
+    #[tokio::test]
+    async fn get_record_query_with_start_time_stop_time_and_runtime_succeeds() {
+        let mock_server = MockServer::start().await;
+        let client = AuditorClientBuilder::new()
+            .connection_string(&mock_server.uri())
+            .build()
+            .unwrap();
+
+        let body: Vec<Record> = vec![record()];
+
+        Mock::given(method("GET"))
+            .and(path("/record"))
+            .and(query_param("start_time[gte]", "2022-08-03T09:47:00+00:00"))
+            .and(query_param("start_time[lte]", "2022-08-04T09:47:00+00:00"))
+            .and(query_param("runtime[gte]", "100000"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(&body))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        let datetime_utc_gte = Utc.with_ymd_and_hms(2022, 8, 3, 9, 47, 0).unwrap();
+        let datetime_utc_lte = Utc.with_ymd_and_hms(2022, 8, 4, 9, 47, 0).unwrap();
+        let runtime_gte: u64 = 100000;
+        let runtime_lte: u64 = 200000;
+        let response = QueryBuilder::new()
+            .with_start_time(
+                Operator::default()
+                    .gte(datetime_utc_gte.into())
+                    .lte(datetime_utc_lte.into()),
+            )
+            .with_stop_time(
+                Operator::default()
+                    .gte(datetime_utc_gte.into())
+                    .lte(datetime_utc_lte.into()),
+            )
+            .with_runtime(
+                Operator::default()
+                    .gte(runtime_gte.into())
+                    .lte(runtime_lte.into()),
+            )
+            .get(client)
+            .await
+            .unwrap();
+
+        response
+            .into_iter()
+            .zip(body)
+            .map(|(rr, br)| assert_eq!(rr, br))
+            .count();
+    }
+
+    #[tokio::test]
+    async fn get_advanced_queries_fails_on_500() {
         let mock_server = MockServer::start().await;
         let client = AuditorClientBuilder::new()
             .connection_string(&mock_server.uri())
@@ -1075,16 +1595,126 @@ mod tests {
             .expect(1)
             .mount(&mock_server)
             .await;
+
+        let datetime_utc_gte = Utc.with_ymd_and_hms(2022, 8, 3, 9, 47, 0).unwrap();
 
         assert_err!(
-            client
-                .get_stopped_since(&Utc.with_ymd_and_hms(2022, 8, 3, 9, 47, 0).unwrap())
+            QueryBuilder::new()
+                .with_stop_time(Operator::default().gte(datetime_utc_gte.into()))
+                .get(client)
                 .await
         );
     }
 
     #[tokio::test]
-    async fn blocking_get_stopped_since_fails_on_500() {
+    async fn get_meta_queries_succeeds() {
+        let mock_server = MockServer::start().await;
+        let client = AuditorClientBuilder::new()
+            .connection_string(&mock_server.uri())
+            .build()
+            .unwrap();
+
+        let body: Vec<Record> = vec![record()];
+
+        Mock::given(method("GET"))
+            .and(path("/record"))
+            .and(query_param("meta[site_id][c]", "group_1"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(&body))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        let response = QueryBuilder::new()
+            .with_meta_query(MetaQuery::new().meta_operator(
+                "site_id".to_string(),
+                MetaOperator::default().contains("group_1".to_string()),
+            ))
+            .get(client)
+            .await
+            .unwrap();
+
+        response
+            .into_iter()
+            .zip(body)
+            .map(|(rr, br)| assert_eq!(rr, br))
+            .count();
+    }
+
+    #[tokio::test]
+    async fn get_meta_queries_and_start_time_succeeds() {
+        let mock_server = MockServer::start().await;
+        let client = AuditorClientBuilder::new()
+            .connection_string(&mock_server.uri())
+            .build()
+            .unwrap();
+
+        let body: Vec<Record> = vec![record()];
+
+        Mock::given(method("GET"))
+            .and(path("/record"))
+            .and(query_param("meta[site_id][c]", "group_1"))
+            .and(query_param("start_time[lte]", "2022-08-04T09:47:00+00:00"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(&body))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        let datetime_utc_lte = Utc.with_ymd_and_hms(2022, 8, 4, 9, 47, 0).unwrap();
+        let response = QueryBuilder::new()
+            .with_meta_query(MetaQuery::new().meta_operator(
+                "site_id".to_string(),
+                MetaOperator::default().contains("group_1".to_string()),
+            ))
+            .with_start_time(Operator::default().lte(datetime_utc_lte.into()))
+            .get(client)
+            .await
+            .unwrap();
+
+        response
+            .into_iter()
+            .zip(body)
+            .map(|(rr, br)| assert_eq!(rr, br))
+            .count();
+    }
+
+    #[tokio::test]
+    async fn get_component_queries_succeeds() {
+        let mock_server = MockServer::start().await;
+        let client = AuditorClientBuilder::new()
+            .connection_string(&mock_server.uri())
+            .build()
+            .unwrap();
+
+        let body: Vec<Record> = vec![record()];
+
+        Mock::given(method("GET"))
+            .and(path("/record"))
+            .and(query_param("component[cpu][equals]", "4"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(&body))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        let count: u8 = 4;
+        let response =
+            QueryBuilder::new()
+                .with_component_query(ComponentQuery::new().component_operator(
+                    "cpu".to_string(),
+                    Operator::default().equals(count.into()),
+                ))
+                .get(client)
+                .await
+                .unwrap();
+
+        response
+            .into_iter()
+            .zip(body)
+            .map(|(rr, br)| assert_eq!(rr, br))
+            .count();
+    }
+
+    #[tokio::test]
+    async fn blocking_advanced_queries_succeeds() {
         let mock_server = MockServer::start().await;
         let uri = mock_server.uri();
         let client = tokio::task::spawn_blocking(move || {
@@ -1096,18 +1726,231 @@ mod tests {
         .await
         .unwrap();
 
+        let body: Vec<Record> = vec![record()];
+
+        Mock::given(method("GET"))
+            .and(path("/record"))
+            .and(query_param("stop_time[gte]", "2022-08-03T09:47:00+00:00"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(&body))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        let datetime_utc = Utc.with_ymd_and_hms(2022, 8, 3, 9, 47, 0).unwrap();
+        let query_string = QueryBuilder::new()
+            .with_stop_time(Operator::default().gte(datetime_utc.into()))
+            .build();
+
+        let response = tokio::task::spawn_blocking(move || client.advanced_query(query_string))
+            .await
+            .unwrap()
+            .unwrap();
+
+        println!("{:?}", &response);
+        response
+            .into_iter()
+            .zip(body)
+            .map(|(rr, br)| assert_eq!(rr, br))
+            .count();
+    }
+
+    #[tokio::test]
+    async fn get_sort_by_query_succeeds() {
+        let mock_server = MockServer::start().await;
+        let client = AuditorClientBuilder::new()
+            .connection_string(&mock_server.uri())
+            .build()
+            .unwrap();
+
+        let body: Vec<Record> = vec![record()];
+
+        Mock::given(method("GET"))
+            .and(path("/record"))
+            .and(query_param("sort_by[asc]", "start_time"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(&body))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        let response = QueryBuilder::new()
+            .sort_by(SortBy::new().ascending("start_time".to_string()))
+            .get(client)
+            .await
+            .unwrap();
+
+        response
+            .into_iter()
+            .zip(body)
+            .map(|(rr, br)| assert_eq!(rr, br))
+            .count();
+    }
+
+    #[tokio::test]
+    async fn limit_get_query_records_succeeds() {
+        let mock_server = MockServer::start().await;
+        let client = AuditorClientBuilder::new()
+            .connection_string(&mock_server.uri())
+            .build()
+            .unwrap();
+
+        let body: Vec<Record> = vec![record()];
+
+        Mock::given(method("GET"))
+            .and(path("/record"))
+            .and(query_param("limit", "500"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(&body))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        let number: u64 = 500;
+        let response = QueryBuilder::new()
+            .sort_by(SortBy::new().ascending("start_time".to_string()))
+            .limit(number)
+            .get(client)
+            .await
+            .unwrap();
+
+        response
+            .into_iter()
+            .zip(body)
+            .map(|(rr, br)| assert_eq!(rr, br))
+            .count();
+    }
+
+    #[tokio::test]
+    async fn get_exact_record_using_record_id_succeeds() {
+        let mock_server = MockServer::start().await;
+        let client = AuditorClientBuilder::new()
+            .connection_string(&mock_server.uri())
+            .build()
+            .unwrap();
+
+        let body: Vec<Record> = vec![record()];
+
+        Mock::given(method("GET"))
+            .and(path("/record"))
+            .and(query_param("record_id", "r1"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(&body))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        let response = QueryBuilder::new()
+            .with_record_id("r1".to_string())
+            .get(client)
+            .await
+            .unwrap();
+
+        response
+            .into_iter()
+            .zip(body)
+            .map(|(rr, br)| assert_eq!(rr, br))
+            .count();
+    }
+
+    #[tokio::test]
+    async fn get_single_record_succeeds() {
+        let mock_server = MockServer::start().await;
+        let client = AuditorClientBuilder::new()
+            .connection_string(&mock_server.uri())
+            .build()
+            .unwrap();
+
+        let record_id: &str = "r3";
+
+        let body: Record = record();
+
+        Mock::given(method("GET"))
+            .and(path("/record/r3"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(&body))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        let response = client
+            .get_single_record(record_id.to_string())
+            .await
+            .unwrap();
+
+        assert_eq!(body, response)
+    }
+
+    #[tokio::test]
+    async fn blocking_get_single_record_succeeds() {
+        let mock_server = MockServer::start().await;
+        let uri = mock_server.uri();
+        let client = tokio::task::spawn_blocking(move || {
+            AuditorClientBuilder::new()
+                .connection_string(&uri)
+                .build_blocking()
+                .unwrap()
+        })
+        .await
+        .unwrap();
+
+        let record_id: &str = "r3";
+
+        let body: Record = record();
+
+        Mock::given(method("GET"))
+            .and(path("/record/r3"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(&body))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        let response =
+            tokio::task::spawn_blocking(move || client.get_single_record(record_id).unwrap())
+                .await
+                .unwrap();
+
+        assert_eq!(body, response)
+    }
+
+    #[tokio::test]
+    async fn get_single_record_fails_on_500() {
+        let mock_server = MockServer::start().await;
+        let client = AuditorClientBuilder::new()
+            .connection_string(&mock_server.uri())
+            .build()
+            .unwrap();
+
+        let record_id: &str = "r3";
+
         Mock::given(any())
             .respond_with(ResponseTemplate::new(500))
             .expect(1)
             .mount(&mock_server)
             .await;
 
-        let response = tokio::task::spawn_blocking(move || {
-            client.get_stopped_since(&Utc.with_ymd_and_hms(2022, 8, 3, 9, 47, 0).unwrap())
+        assert_err!(client.get_single_record(record_id.to_string()).await);
+    }
+
+    #[tokio::test]
+    async fn blocking_get_single_record_fails_on_500() {
+        let mock_server = MockServer::start().await;
+        let uri = mock_server.uri();
+        let client = tokio::task::spawn_blocking(move || {
+            AuditorClientBuilder::new()
+                .connection_string(&uri)
+                .build_blocking()
+                .unwrap()
         })
         .await
         .unwrap();
 
-        assert_err!(response);
+        let record_id: &str = "r3";
+
+        Mock::given(any())
+            .respond_with(ResponseTemplate::new(500))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        let res = tokio::task::spawn_blocking(move || client.get_single_record(record_id))
+            .await
+            .unwrap();
+        assert_err!(res);
     }
 }

--- a/auditor/src/domain/meta.rs
+++ b/auditor/src/domain/meta.rs
@@ -11,6 +11,8 @@ use serde::{Deserialize, Serialize};
 
 use super::ValidName;
 
+use sqlx;
+
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Default)]
 pub struct ValidMeta(pub HashMap<ValidName, Vec<ValidName>>);
 
@@ -101,7 +103,7 @@ impl TryFrom<Meta> for ValidMeta {
 /// meta.insert("site_id".to_string(), vec!["site1".to_string()]);
 /// meta.insert("features".to_string(), vec!["ssd".to_string(), "gpu".to_string()]);
 /// ```
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Default)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Default, sqlx::FromRow)]
 pub struct Meta(pub HashMap<String, Vec<String>>);
 
 impl Meta {

--- a/auditor/src/domain/record.rs
+++ b/auditor/src/domain/record.rs
@@ -17,6 +17,7 @@ use fake::{Dummy, Fake, Faker, StringFaker};
 use quickcheck;
 use rand::Rng;
 use serde::{Deserialize, Serialize};
+use sqlx;
 
 /// `RecordAdd` represents a single accountable unit that is added to Auditor.
 ///
@@ -225,7 +226,7 @@ pub struct Record {
 }
 
 #[doc(hidden)]
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, sqlx::FromRow)]
 pub struct RecordDatabase {
     pub record_id: String,
     pub meta: Option<Vec<(String, Vec<String>)>>,

--- a/auditor/src/routes/advanced_record_filters.rs
+++ b/auditor/src/routes/advanced_record_filters.rs
@@ -1,0 +1,360 @@
+// Copyright 2021-2022 AUDITOR developers
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+use crate::domain::{Component, Record, RecordDatabase, ValidName};
+use chrono::{DateTime, Utc};
+use core::fmt::Debug;
+use serde_qs::actix::QsQuery;
+use sqlx;
+use sqlx::{PgPool, QueryBuilder, Row};
+use std::collections::HashMap;
+
+#[derive(thiserror::Error)]
+pub enum GetFilterError {
+    #[error(transparent)]
+    UnexpectedError(#[from] anyhow::Error),
+}
+
+debug_for_error!(GetFilterError);
+responseerror_for_error!(GetFilterError, UnexpectedError => INTERNAL_SERVER_ERROR;);
+
+#[derive(serde::Deserialize, Debug, Clone)]
+pub struct Filters {
+    pub record_id: Option<String>,
+    pub start_time: Option<Operator<DateTime<Utc>>>,
+    pub stop_time: Option<Operator<DateTime<Utc>>>,
+    pub runtime: Option<Operator<String>>,
+    pub meta: Option<HashMap<String, MetaOperator>>,
+    pub component: Option<HashMap<String, Operator<u8>>>,
+    pub sort_by: Option<SortOption>,
+    pub limit: Option<u64>,
+}
+
+#[derive(serde::Deserialize, Debug, Clone)]
+pub struct Operator<T> {
+    pub gt: Option<T>,
+    pub lt: Option<T>,
+    pub gte: Option<T>,
+    pub lte: Option<T>,
+    pub equals: Option<T>,
+}
+
+#[derive(serde::Deserialize, Debug, Clone)]
+pub struct MetaOperator {
+    pub c: Option<String>,
+    pub dnc: Option<String>,
+}
+
+#[derive(serde::Deserialize, Debug, Clone)]
+#[serde(rename_all = "lowercase")]
+pub enum SortOption {
+    ASC(SortField),
+    DESC(SortField),
+}
+
+#[derive(serde::Deserialize, Debug, PartialEq, Eq, Clone)]
+#[serde(rename_all = "lowercase")]
+pub enum SortField {
+    #[serde(rename = "start_time")]
+    StartTime,
+    #[serde(rename = "stop_time")]
+    StopTime,
+    #[serde(rename = "runtime")]
+    Runtime,
+    #[serde(rename = "record_id")]
+    RecordId,
+}
+
+impl ToString for SortField {
+    fn to_string(&self) -> String {
+        match self {
+            SortField::StartTime => String::from("start_time"),
+            SortField::StopTime => String::from("stop_time"),
+            SortField::Runtime => String::from("runtime"),
+            SortField::RecordId => String::from("record_id"),
+        }
+    }
+}
+
+#[tracing::instrument(name = "Getting records using custom query", skip(filters, pool))]
+pub async fn advanced_record_filtering(
+    filters: Option<&QsQuery<Filters>>,
+    pool: &PgPool,
+) -> Result<Vec<Record>, anyhow::Error> {
+    let mut query = QueryBuilder::new("SELECT a.record_id,
+                          m.meta,
+                          css.components,
+                          a.start_time,
+                          a.stop_time,
+                          a.runtime
+                   FROM accounting a
+                   LEFT JOIN (
+                       WITH subquery AS (
+                           SELECT m.record_id as record_id, m.key as key, array_agg(m.value) as values
+                           FROM meta as m
+                           GROUP BY m.record_id, m.key
+                       )
+                       SELECT s.record_id as record_id, array_agg(row(s.key, s.values)) as meta
+                       FROM subquery as s
+                       GROUP BY s.record_id
+                       ) m ON m.record_id = a.record_id
+                   LEFT JOIN (
+                       WITH subquery AS (
+                          SELECT 
+                              c.id as cid,
+                              COALESCE(array_agg(row(s.name, s.value)::score) FILTER (WHERE s.name IS NOT NULL AND s.value IS NOT NULL), '{}'::score[]) as scores
+                          FROM components as c
+                          LEFT JOIN components_scores as cs
+                          ON c.id = cs.component_id
+                          LEFT JOIN scores as s
+                          ON cs.score_id = s.id
+                          GROUP BY c.id
+                       )
+                       SELECT rc.record_id as id, array_agg(row(c.name, c.amount, sq.scores)::component) as components
+                       FROM records_components AS rc
+                       LEFT JOIN components as c
+                       ON rc.component_id = c.id
+                       LEFT JOIN subquery AS sq
+                       ON sq.cid = rc.component_id
+                       GROUP BY rc.record_id
+                   ) css ON css.id = a.id
+               ");
+
+    if let Some(filters) = &filters {
+        if filters.start_time.is_some()
+            || filters.stop_time.is_some()
+            || filters.runtime.is_some()
+            || filters.record_id.is_some()
+        {
+            query.push(" WHERE ".to_string());
+            if let Some(record_id) = &filters.record_id {
+                let is_valid_record_id = ValidName::parse(record_id.clone().to_string());
+                if is_valid_record_id.is_ok() {
+                    query.push(format!("a.record_id = '{}' and ", &record_id));
+                }
+            }
+
+            if let Some(start_time_filters) = &filters.start_time {
+                if let Some(operators) = get_operator(start_time_filters) {
+                    for operator in operators {
+                        let formatted_datetime = operator.1.format("%Y-%m-%d %H:%M:%S").to_string();
+                        query.push(format!(
+                            "a.start_time {} '{}' and ",
+                            operator.0, &formatted_datetime
+                        ));
+                    }
+                }
+            }
+
+            if let Some(stop_time_filters) = &filters.stop_time {
+                if let Some(operators) = get_operator(stop_time_filters) {
+                    for operator in operators {
+                        let formatted_datetime = operator.1.format("%Y-%m-%d %H:%M:%S").to_string();
+                        query.push(format!(
+                            "a.stop_time {} '{}' and ",
+                            operator.0, &formatted_datetime
+                        ));
+                    }
+                }
+            }
+
+            if let Some(meta_filters) = &filters.meta {
+                for (key, meta_operator) in meta_filters {
+                    if let Some(c) = &meta_operator.c {
+                        let meta_value = ValidName::parse(c.clone().to_string());
+                        if meta_value.is_ok() {
+                            query.push(format!("Array['{}'] = ANY(SELECT r.values FROM unnest(m.meta) AS r(key text, values text[]) WHERE r.key = '{}') and ", &c, &key));
+                        } else {
+                            println!("meta value validation Failed")
+                        }
+                    }
+                    if let Some(dnc) = &meta_operator.dnc {
+                        let meta_value = ValidName::parse(dnc.clone().to_string());
+                        if meta_value.is_ok() {
+                            query.push(format!(" (NOT EXISTS (SELECT r.values FROM unnest(css.components) AS r(key text, values text[]) WHERE r.key = '{}' AND Array['{}'] @> r.values)) and ", &key, &dnc));
+                        } else {
+                            println!("meta value verification failed");
+                        }
+                    }
+                }
+            }
+
+            if let Some(component_filters) = &filters.component {
+                for (key, component_operator) in component_filters {
+                    if let Some(operators) = get_operator(component_operator) {
+                        for operator in operators {
+                            query.push(format!("css.components[1].name = '{}' AND css.components[2].amount {} {} and ", &key, &operator.0, &operator.1));
+                        }
+                    }
+                }
+            }
+
+            // The previous implementation of get and get_since is replicated. Getting all records also includes
+            // the records whose runtime IS NOT NULL. But while querying with the start_time or stop_time,
+            // we also specify the query to only include the records whose runtime is NOT NULL
+
+            if let Some(runtime_filters) = &filters.runtime {
+                if let Some(operators) = get_operator(runtime_filters) {
+                    for operator in operators {
+                        query.push(format!("a.runtime {} {} and ", operator.0, operator.1));
+                    }
+                }
+            } else {
+                query.push("a.runtime IS NOT NULL".to_string());
+            }
+        }
+    }
+
+    if let Some(filters) = &filters {
+        if let Some(sort_by) = &filters.sort_by {
+            if let SortOption::ASC(asc) = sort_by {
+                query.push(format!("ORDER BY a.{} ASC", &asc.to_string()));
+            }
+            if let SortOption::DESC(desc) = sort_by {
+                query.push(format!("ORDER BY a.{} DESC", &desc.to_string()));
+            }
+        } else {
+            query.push(" ORDER BY a.stop_time ".to_string());
+        }
+
+        if let Some(limit) = &filters.limit {
+            query.push(format!(" LIMIT {}", &limit));
+        }
+    }
+
+    fn get_operator<T>(operator: &Operator<T>) -> Option<Vec<(&str, &T)>>
+    where
+        T: 'static,
+    {
+        let mut operators: Vec<(&str, &T)> = Vec::new();
+
+        if operator.gt.is_some() && operator.gte.is_some()
+            || operator.lt.is_some() && operator.lte.is_some()
+        {
+            return None;
+        }
+
+        if let Some(gt) = &operator.gt {
+            operators.push((">", gt));
+        }
+        if let Some(lt) = &operator.lt {
+            operators.push(("<", lt));
+        }
+        if let Some(gte) = &operator.gte {
+            operators.push((">=", gte));
+        }
+        if let Some(lte) = &operator.lte {
+            operators.push(("<=", lte));
+        }
+        if let Some(equals) = &operator.equals {
+            if !is_datetime::<T>() {
+                operators.push(("=", equals));
+            }
+        }
+        if !operators.is_empty() {
+            Some(operators)
+        } else {
+            None
+        }
+    }
+
+    // Helper function to check if T is Datetime
+    fn is_datetime<T: 'static>() -> bool {
+        std::any::TypeId::of::<T>() == std::any::TypeId::of::<DateTime<Utc>>()
+    }
+
+    let rows = query
+        .build()
+        .fetch_all(pool)
+        .await
+        .map_err(GetRecordError)?;
+
+    let result: Vec<RecordDatabase> = rows
+        .iter()
+        .map(|row| RecordDatabase {
+            record_id: row.try_get("record_id").unwrap(),
+            meta: row.try_get("meta").ok().unwrap_or(None),
+            components: row.try_get("components").ok().unwrap_or(None),
+            start_time: row.try_get("start_time").ok().unwrap_or(None),
+            stop_time: row.try_get("stop_time").ok().unwrap_or(None),
+            runtime: row.try_get("runtime").ok().unwrap_or(None),
+        })
+        .collect();
+
+    result
+        .into_iter()
+        .map(Record::try_from)
+        .collect::<Result<Vec<Record>, anyhow::Error>>()
+}
+
+#[tracing::instrument(name = "Getting one record using record_id", skip(record_id, pool))]
+pub async fn get_one_record(
+    record_id: String,
+    pool: &PgPool,
+) -> Result<Option<Record>, anyhow::Error> {
+    let is_valid_record_id = ValidName::parse(record_id.clone().to_string());
+    if is_valid_record_id.is_ok() {
+        Ok(sqlx::query_as!(
+                RecordDatabase,
+                r#"SELECT a.record_id,
+                          m.meta as "meta: Vec<(String, Vec<String>)>",
+                          css.components as "components: Vec<Component>",
+                          a.start_time as "start_time?",
+                          a.stop_time,
+                          a.runtime
+                   FROM accounting a
+                   LEFT JOIN (
+                       WITH subquery AS (
+                           SELECT m.record_id as record_id, m.key as key, array_agg(m.value) as values
+                           FROM meta as m
+                           GROUP BY m.record_id, m.key
+                       )
+                       SELECT s.record_id as record_id, array_agg(row(s.key, s.values)) as meta
+                       FROM subquery as s
+                       GROUP BY s.record_id
+                       ) m ON m.record_id = a.record_id
+                   LEFT JOIN (
+                       WITH subquery AS (
+                          SELECT 
+                              c.id as cid,
+                              COALESCE(array_agg(row(s.name, s.value)::score) FILTER (WHERE s.name IS NOT NULL AND s.value IS NOT NULL), '{}'::score[]) as scores
+                          FROM components as c
+                          LEFT JOIN components_scores as cs
+                          ON c.id = cs.component_id
+                          LEFT JOIN scores as s
+                          ON cs.score_id = s.id
+                          GROUP BY c.id
+                       )
+                       SELECT rc.record_id as id, array_agg(row(c.name, c.amount, sq.scores)::component) as components
+                       FROM records_components AS rc
+                       LEFT JOIN components as c
+                       ON rc.component_id = c.id
+                       LEFT JOIN subquery AS sq
+                       ON sq.cid = rc.component_id
+                       GROUP BY rc.record_id
+                   ) css ON css.id = a.id
+                   WHERE a.record_id = $1
+               "#,
+               &record_id,
+            )
+            .fetch_one(pool)
+            .await
+            .map(Record::try_from)
+            .map_err(GetRecordError)?
+            .ok())
+    } else {
+        return Ok(None);
+    }
+}
+
+struct GetRecordError(sqlx::Error);
+error_for_error!(GetRecordError);
+debug_for_error!(GetRecordError);
+display_for_error!(
+    GetRecordError,
+    "A database error was encountered while trying to get a record from the database"
+);

--- a/auditor/src/routes/mod.rs
+++ b/auditor/src/routes/mod.rs
@@ -6,6 +6,7 @@
 // copied, modified, or distributed except according to those terms.
 
 mod add;
+mod advanced_record_filters;
 mod get;
 mod get_since;
 mod health_check;
@@ -13,6 +14,7 @@ mod record_handlers;
 mod update;
 
 pub use add::*;
+pub use advanced_record_filters::*;
 pub use get::*;
 pub use get_since::*;
 pub use health_check::*;

--- a/auditor/src/startup.rs
+++ b/auditor/src/startup.rs
@@ -6,7 +6,7 @@
 // copied, modified, or distributed except according to those terms.
 
 use crate::metrics::{DatabaseMetricsWatcher, PrometheusExporterBuilder, PrometheusExporterConfig};
-use crate::routes::{add, health_check, query_records, update};
+use crate::routes::{add, health_check, query_one_record, query_records, update};
 use actix_web::dev::Server;
 use actix_web::{web, App, HttpServer};
 use actix_web_opentelemetry::{PrometheusMetricsHandler, RequestMetrics};
@@ -46,6 +46,7 @@ pub fn run(
                     .route(web::put().to(update))
                     .route(web::get().to(query_records)),
             )
+            .route("/record/{record_id}", web::get().to(query_one_record))
             // DB connection pool
             .app_data(db_pool.clone())
     })

--- a/auditor/tests/api/advanced_queries.rs
+++ b/auditor/tests/api/advanced_queries.rs
@@ -1,0 +1,561 @@
+use crate::helpers::spawn_app;
+use auditor::client::{ComponentQuery, MetaOperator, MetaQuery, Operator, QueryBuilder, SortBy};
+use auditor::domain::{Record, RecordTest};
+use chrono::{TimeZone, Utc};
+use fake::{Fake, Faker};
+use std::collections::HashMap;
+
+#[tokio::test]
+async fn get_advanced_queries_returns_a_200_and_list_of_records() {
+    // Arange
+    let app = spawn_app().await;
+
+    // First send a couple of records
+    let test_cases = (1..10)
+        .map(|i| {
+            Faker
+                .fake::<RecordTest>()
+                // Giving a name which is sorted the same as the time is useful for asserting later
+                .with_record_id(format!("r{i}"))
+                .with_start_time(format!("2022-10-0{i}T12:00:00-00:00"))
+        })
+        .collect::<Vec<_>>();
+
+    for case in test_cases.iter() {
+        let response = app.add_record(&case).await;
+
+        assert_eq!(200, response.status().as_u16());
+    }
+
+    // Try different start dates and receive records
+    for i in 1..10 {
+        let query = QueryBuilder::new()
+            .with_start_time(
+                Operator::default()
+                    .gte(Utc.with_ymd_and_hms(2022, 10, i, 9, 47, 0).unwrap().into()),
+            )
+            .build();
+
+        let response = app.advanced_queries(query).await;
+        println!("{:?}", response);
+
+        assert_eq!(200, response.status().as_u16());
+
+        let mut received_records = response.json::<Vec<Record>>().await.unwrap();
+
+        // make sure they are both sorted
+        received_records.sort_by(|a, b| a.record_id.cmp(&b.record_id));
+
+        for (j, (record, received)) in test_cases
+            .iter()
+            .skip(usize::try_from(i).unwrap() - 1)
+            .zip(received_records.iter())
+            .enumerate()
+        {
+            assert_eq!(
+                record,
+                received,
+                "Check {i}|{j}: Record {} and {} did not match.",
+                record.record_id.as_ref().unwrap(),
+                received.record_id
+            );
+        }
+    }
+}
+
+#[tokio::test]
+async fn get_started_since_returns_a_list_of_sorted_records() {
+    // Arange
+    let app = spawn_app().await;
+
+    // First send a couple of records
+    let test_cases = (1..10)
+        .map(|i| {
+            Faker
+                .fake::<RecordTest>()
+                // Giving a name which is sorted the same as the time is useful for asserting later
+                .with_record_id(format!("r{i}"))
+                .with_start_time(format!("2022-10-0{i}T12:00:00-00:00"))
+        })
+        .collect::<Vec<_>>();
+
+    for case in test_cases.iter() {
+        let response = app.add_record(&case).await;
+
+        assert_eq!(200, response.status().as_u16());
+    }
+
+    // Try different start dates and receive records
+    for i in 1..10 {
+        let query = QueryBuilder::new()
+            .with_start_time(
+                Operator::default()
+                    .gte(Utc.with_ymd_and_hms(2022, 10, i, 9, 47, 0).unwrap().into()),
+            )
+            .build();
+        let response = app.advanced_queries(query).await;
+
+        assert_eq!(200, response.status().as_u16());
+
+        let received_records = response.json::<Vec<Record>>().await.unwrap();
+
+        // make sure the test cases are sorted by stop_time
+        let mut tmp_test_cases = test_cases
+            .iter()
+            .skip(usize::try_from(i).unwrap() - 1)
+            .cloned()
+            .collect::<Vec<_>>();
+        tmp_test_cases.sort_by(|a, b| a.stop_time.cmp(&b.stop_time));
+
+        for (j, (record, received)) in tmp_test_cases
+            .iter()
+            .zip(received_records.iter())
+            .enumerate()
+        {
+            assert_eq!(
+                record,
+                received,
+                "Check {}|{}: Record {} and {} did not match.",
+                i,
+                j,
+                record.record_id.as_ref().unwrap(),
+                received.record_id
+            );
+        }
+    }
+}
+
+#[tokio::test]
+async fn get_started_since_returns_a_200_and_no_records() {
+    let app = spawn_app().await;
+
+    let query = QueryBuilder::new()
+        .with_start_time(
+            Operator::default().gte(Utc.with_ymd_and_hms(2022, 10, 3, 9, 47, 0).unwrap().into()),
+        )
+        .build();
+
+    let response = app.advanced_queries(query).await;
+
+    assert_eq!(200, response.status().as_u16());
+
+    let received_records = response.json::<Vec<Record>>().await.unwrap();
+
+    assert!(received_records.is_empty());
+}
+
+#[tokio::test]
+async fn get_stopped_since_returns_a_200_and_list_of_records() {
+    // Arange
+    let app = spawn_app().await;
+
+    // First send a couple of records
+    let test_cases = (1..10)
+        .map(|i| {
+            Faker
+                .fake::<RecordTest>()
+                // Giving a name which is sorted the same as the time is useful for asserting later
+                .with_record_id(format!("r{i}"))
+                .with_stop_time(format!("2022-10-0{i}T12:00:00-00:00"))
+        })
+        .collect::<Vec<_>>();
+
+    for case in test_cases.iter() {
+        let response = app.add_record(&case).await;
+
+        assert_eq!(200, response.status().as_u16());
+    }
+
+    // Try different start dates and receive records
+    for i in 1..10 {
+        let query = QueryBuilder::new()
+            .with_stop_time(
+                Operator::default()
+                    .gte(Utc.with_ymd_and_hms(2022, 10, i, 9, 47, 0).unwrap().into()),
+            )
+            .build();
+
+        let response = app.advanced_queries(query).await;
+
+        assert_eq!(200, response.status().as_u16());
+
+        let mut received_records = response.json::<Vec<Record>>().await.unwrap();
+
+        // make sure they are both sorted
+        received_records.sort_by(|a, b| a.record_id.cmp(&b.record_id));
+
+        for (j, (record, received)) in test_cases
+            .iter()
+            .skip(usize::try_from(i).unwrap() - 1)
+            .zip(received_records.iter())
+            .enumerate()
+        {
+            assert_eq!(
+                record,
+                received,
+                "Check {}|{}: Record {} and {} did not match.",
+                i,
+                j,
+                record.record_id.as_ref().unwrap(),
+                received.record_id
+            );
+        }
+    }
+}
+
+#[tokio::test]
+async fn get_stopped_since_returns_a_list_of_sorted_records() {
+    // Arange
+    let app = spawn_app().await;
+
+    // First send a couple of records
+    let test_cases = (1..10)
+        .map(|i| {
+            Faker
+                .fake::<RecordTest>()
+                // Giving a name which is sorted the same as the time is useful for asserting later
+                .with_record_id(format!("r{i}"))
+                .with_stop_time(format!("2022-10-0{i}T12:00:00-00:00"))
+        })
+        .collect::<Vec<_>>();
+
+    for case in test_cases.iter() {
+        let response = app.add_record(&case).await;
+
+        assert_eq!(200, response.status().as_u16());
+    }
+
+    // Try different start dates and receive records
+    for i in 1..10 {
+        let query = QueryBuilder::new()
+            .with_stop_time(
+                Operator::default()
+                    .gte(Utc.with_ymd_and_hms(2022, 10, i, 9, 47, 0).unwrap().into()),
+            )
+            .build();
+
+        let response = app.advanced_queries(query).await;
+
+        assert_eq!(200, response.status().as_u16());
+
+        let received_records = response.json::<Vec<Record>>().await.unwrap();
+
+        // make sure the test cases are sorted by stop_time
+        let mut tmp_test_cases = test_cases
+            .iter()
+            .skip(usize::try_from(i).unwrap() - 1)
+            .cloned()
+            .collect::<Vec<_>>();
+        tmp_test_cases.sort_by(|a, b| a.stop_time.cmp(&b.stop_time));
+
+        for (j, (record, received)) in tmp_test_cases
+            .iter()
+            .zip(received_records.iter())
+            .enumerate()
+        {
+            assert_eq!(
+                record,
+                received,
+                "Check {}|{}: Record {} and {} did not match.",
+                i,
+                j,
+                record.record_id.as_ref().unwrap(),
+                received.record_id
+            );
+        }
+    }
+}
+
+#[tokio::test]
+async fn get_stopped_since_returns_a_200_and_no_records() {
+    let app = spawn_app().await;
+
+    let query = QueryBuilder::new()
+        .with_start_time(
+            Operator::default().gte(Utc.with_ymd_and_hms(2022, 10, 3, 9, 47, 0).unwrap().into()),
+        )
+        .build();
+
+    let response = app.advanced_queries(query).await;
+
+    assert_eq!(200, response.status().as_u16());
+
+    let received_records = response.json::<Vec<Record>>().await.unwrap();
+
+    assert!(received_records.is_empty());
+}
+
+// Test should return the same meta data which are added to auditor using 'contains' operator
+#[tokio::test]
+async fn get_meta_queries_c_returns_a_200_and_list_of_records() {
+    // Arange
+    let app = spawn_app().await;
+
+    // First send a couple of records
+    let mut meta: HashMap<String, Vec<String>> = HashMap::new();
+    meta.insert("group_id".to_string(), vec!["group_1".to_string()]);
+    let test_cases = (1..10)
+        .map(|i| {
+            Faker
+                .fake::<RecordTest>()
+                // Giving a name which is sorted the same as the time is useful for asserting later
+                .with_record_id(format!("r{i}"))
+                .with_meta(meta.clone())
+                .with_start_time(format!("2022-10-0{i}T12:00:00-00:00"))
+        })
+        .collect::<Vec<_>>();
+
+    for case in test_cases.iter() {
+        let response = app.add_record(&case).await;
+
+        assert_eq!(200, response.status().as_u16());
+    }
+
+    // Try different start dates and receive records
+    for i in 1..10 {
+        let query = QueryBuilder::new()
+            .with_start_time(
+                Operator::default()
+                    .gte(Utc.with_ymd_and_hms(2022, 10, i, 9, 47, 0).unwrap().into()),
+            )
+            .with_meta_query(MetaQuery::new().meta_operator(
+                "group_id".to_string(),
+                MetaOperator::default().contains("group_1".to_string()),
+            ))
+            .build();
+
+        let response = app.advanced_queries(query).await;
+        println!("{:?}", response);
+
+        assert_eq!(200, response.status().as_u16());
+
+        let mut received_records = response.json::<Vec<Record>>().await.unwrap();
+
+        // make sure they are both sorted
+        received_records.sort_by(|a, b| a.record_id.cmp(&b.record_id));
+
+        for (j, (record, received)) in test_cases
+            .iter()
+            .skip(usize::try_from(i).unwrap() - 1)
+            .zip(received_records.iter())
+            .enumerate()
+        {
+            assert_eq!(
+                record,
+                received,
+                "Check {i}|{j}: Record {} and {} did not match.",
+                record.record_id.as_ref().unwrap(),
+                received.record_id
+            );
+        }
+    }
+}
+
+#[tokio::test]
+async fn get_component_query_returns_a_200_and_list_of_records() {
+    // Arange
+    let app = spawn_app().await;
+
+    // First send a couple of records
+    //let component_cpu = Component::new("cpu", 4)?
+    //                    .with_score(Score::new("HEPSPEC06", 9.2)?);)
+    let test_cases = (1..10)
+        .map(|i| {
+            Faker
+                .fake::<RecordTest>()
+                // Giving a name which is sorted the same as the time is useful for asserting later
+                .with_record_id(format!("r{i}"))
+                .with_start_time(format!("2022-10-0{i}T12:00:00-00:00"))
+                .with_component("cpu", 4, vec![])
+        })
+        .collect::<Vec<_>>();
+
+    for case in test_cases.iter() {
+        let response = app.add_record(&case).await;
+
+        assert_eq!(200, response.status().as_u16());
+    }
+
+    // Try different start dates and receive records
+    for i in 1..10 {
+        let count: u8 = 4;
+        let query =
+            QueryBuilder::new()
+                .with_component_query(ComponentQuery::new().component_operator(
+                    "cpu".to_string(),
+                    Operator::default().equals(count.into()),
+                ))
+                .build();
+
+        let response = app.advanced_queries(query).await;
+        println!("{:?}", response);
+
+        assert_eq!(200, response.status().as_u16());
+
+        let mut received_records = response.json::<Vec<Record>>().await.unwrap();
+
+        // make sure they are both sorted
+        received_records.sort_by(|a, b| a.record_id.cmp(&b.record_id));
+
+        for (j, (record, received)) in test_cases.iter().zip(received_records.iter()).enumerate() {
+            assert_eq!(
+                record,
+                received,
+                "Check {i}|{j}: Record {} and {} did not match.",
+                record.record_id.as_ref().unwrap(),
+                received.record_id
+            );
+        }
+    }
+}
+
+#[tokio::test]
+async fn sort_by_returns_a_200_and_list_of_records() {
+    // Arange
+    let app = spawn_app().await;
+
+    // First send a couple of records
+    //let component_cpu = Component::new("cpu", 4)?
+    //                    .with_score(Score::new("HEPSPEC06", 9.2)?);)
+    let test_cases = (1..10)
+        .map(|i| {
+            Faker
+                .fake::<RecordTest>()
+                // Giving a name which is sorted the same as the time is useful for asserting later
+                .with_record_id(format!("r{i}"))
+                .with_start_time(format!("2022-10-0{i}T12:00:00-00:00"))
+        })
+        .collect::<Vec<_>>();
+
+    for case in test_cases.iter() {
+        let response = app.add_record(&case).await;
+
+        assert_eq!(200, response.status().as_u16());
+    }
+
+    // Try different start dates and receive records
+    for i in 1..10 {
+        let query = QueryBuilder::new()
+            .sort_by(SortBy::new().descending("start_time".to_string()))
+            .build();
+
+        let response = app.advanced_queries(query).await;
+        println!("{:?}", response);
+
+        assert_eq!(200, response.status().as_u16());
+
+        let received_records = response.json::<Vec<Record>>().await.unwrap();
+
+        for (j, (record, received)) in test_cases
+            .iter()
+            .rev()
+            .zip(received_records.iter())
+            .enumerate()
+        {
+            assert_eq!(
+                record,
+                received,
+                "Check {i}|{j}: Record {} and {} did not match.",
+                record.record_id.as_ref().unwrap(),
+                received.record_id
+            );
+        }
+    }
+}
+
+#[tokio::test]
+async fn limit_query_records_returns_a_200_and_list_of_records() {
+    // Arange
+    let app = spawn_app().await;
+
+    // First send a couple of records
+    //let component_cpu = Component::new("cpu", 4)?
+    //                    .with_score(Score::new("HEPSPEC06", 9.2)?);)
+    let test_cases = (1..10)
+        .map(|i| {
+            Faker
+                .fake::<RecordTest>()
+                // Giving a name which is sorted the same as the time is useful for asserting later
+                .with_record_id(format!("r{i}"))
+                .with_start_time(format!("2022-10-0{i}T12:00:00-00:00"))
+        })
+        .collect::<Vec<_>>();
+
+    for case in test_cases.iter() {
+        let response = app.add_record(&case).await;
+
+        assert_eq!(200, response.status().as_u16());
+    }
+
+    let number: u64 = 4;
+    // Try different start dates and receive records
+    for i in 1..10 {
+        let query = QueryBuilder::new()
+            .sort_by(SortBy::new().descending("start_time".to_string()))
+            .limit(number)
+            .build();
+
+        let response = app.advanced_queries(query).await;
+        println!("{:?}", response);
+
+        assert_eq!(200, response.status().as_u16());
+
+        let received_records = response.json::<Vec<Record>>().await.unwrap();
+
+        assert_eq!(received_records.len(), 4);
+
+        for (j, (record, received)) in test_cases
+            .iter()
+            .rev()
+            .zip(received_records.iter())
+            .enumerate()
+        {
+            assert_eq!(
+                record,
+                received,
+                "Check {i}|{j}: Record {} and {} did not match.",
+                record.record_id.as_ref().unwrap(),
+                received.record_id
+            );
+        }
+    }
+}
+
+#[tokio::test]
+async fn exact_record_id_returns_a_200_and_list_of_records() {
+    // Arange
+    let app = spawn_app().await;
+
+    // First send a couple of records
+    //let component_cpu = Component::new("cpu", 4)?
+    //                    .with_score(Score::new("HEPSPEC06", 9.2)?);)
+    let test_cases = (1..10)
+        .map(|i| {
+            Faker
+                .fake::<RecordTest>()
+                // Giving a name which is sorted the same as the time is useful for asserting later
+                .with_record_id(format!("r{i}"))
+                .with_start_time(format!("2022-10-0{i}T12:00:00-00:00"))
+        })
+        .collect::<Vec<_>>();
+
+    for case in test_cases.iter() {
+        let response = app.add_record(&case).await;
+
+        assert_eq!(200, response.status().as_u16());
+    }
+
+    // Try different start dates and receive records
+    let query = QueryBuilder::new().with_record_id("r3".to_string()).build();
+
+    let response = app.advanced_queries(query).await;
+    println!("{:?}", response);
+
+    assert_eq!(200, response.status().as_u16());
+
+    let received_record = response.json::<Vec<Record>>().await.unwrap();
+
+    assert_eq!(received_record.len(), 1);
+
+    assert_eq!(received_record[0].record_id, "r3".to_string());
+}

--- a/auditor/tests/api/client.rs
+++ b/auditor/tests/api/client.rs
@@ -1,5 +1,5 @@
 use crate::helpers::spawn_app;
-use auditor::client::AuditorClientBuilder;
+use auditor::client::{AuditorClientBuilder, Operator, QueryBuilder};
 use auditor::domain::{Component, Record, RecordAdd, RecordDatabase, RecordTest, RecordUpdate};
 use chrono::{TimeZone, Utc};
 use fake::{Fake, Faker};
@@ -465,8 +465,11 @@ async fn get_started_since_returns_a_list_of_records() {
         transaction.commit().await.unwrap();
     }
 
-    let mut received_records = client
-        .get_started_since(&Utc.with_ymd_and_hms(2022, 3, 15, 0, 0, 0).unwrap())
+    let date = Utc.with_ymd_and_hms(2022, 3, 15, 0, 0, 0).unwrap();
+
+    let mut received_records = QueryBuilder::new()
+        .with_start_time(Operator::default().gte(date.into()))
+        .get(client)
         .await
         .unwrap();
 
@@ -614,8 +617,10 @@ async fn get_stopped_since_returns_a_list_of_records() {
         transaction.commit().await.unwrap();
     }
 
-    let mut received_records = client
-        .get_stopped_since(&Utc.with_ymd_and_hms(2022, 3, 15, 0, 0, 0).unwrap())
+    let date = Utc.with_ymd_and_hms(2022, 3, 15, 0, 0, 0).unwrap();
+    let mut received_records = QueryBuilder::new()
+        .with_stop_time(Operator::default().gte(date.into()))
+        .get(client)
         .await
         .unwrap();
 

--- a/auditor/tests/api/get_one_record.rs
+++ b/auditor/tests/api/get_one_record.rs
@@ -1,0 +1,45 @@
+use crate::helpers::spawn_app;
+use auditor::domain::{Record, RecordTest};
+use fake::{Fake, Faker};
+
+#[tokio::test]
+async fn get_one_record_returns_a_200_and_get_one_record() {
+    // Arange
+    let app = spawn_app().await;
+
+    // First send a couple of records
+    //let component_cpu = Component::new("cpu", 4)?
+    //                    .with_score(Score::new("HEPSPEC06", 9.2)?);)
+    let test_cases = (1..10)
+        .map(|i| {
+            Faker
+                .fake::<RecordTest>()
+                // Giving a name which is sorted the same as the time is useful for asserting later
+                .with_record_id(format!("r{i}"))
+                .with_start_time(format!("2022-10-0{i}T12:00:00-00:00"))
+        })
+        .collect::<Vec<_>>();
+
+    for case in test_cases.iter() {
+        let response = app.add_record(&case).await;
+
+        assert_eq!(200, response.status().as_u16());
+    }
+
+    // Try different start dates and receive records
+    for i in 1..10 {
+        let response = app.get_single_record(format!("r{i}")).await;
+
+        assert_eq!(200, response.status().as_u16());
+
+        let received_record = response.json::<Record>().await.unwrap();
+
+        assert_eq!(
+            test_cases[i - 1],
+            received_record,
+            "Check {i}: Record {} and {} did not match",
+            test_cases[i - 1].record_id.as_ref().unwrap(),
+            received_record.record_id
+        )
+    }
+}

--- a/auditor/tests/api/helpers.rs
+++ b/auditor/tests/api/helpers.rs
@@ -60,7 +60,7 @@ impl TestApp {
         let encoded_since = encode(timestamp_str);
         reqwest::Client::new()
             .get(&format!(
-                "{}/record?state=started&since={}",
+                "{}/record?start_time[gte]={}",
                 &self.address, encoded_since
             ))
             .send()
@@ -76,12 +76,34 @@ impl TestApp {
         let encoded_since = encode(timestamp_str);
         reqwest::Client::new()
             .get(&format!(
-                "{}/record?state=stopped&since={}",
+                "{}/record?stop_time[gte]={}",
                 &self.address, encoded_since
             ))
             .send()
             .await
             .expect("Failed to execute request.")
+    }
+
+    pub async fn advanced_queries<T: AsRef<str> + std::fmt::Display>(
+        &self,
+        query_string: T,
+    ) -> reqwest::Response {
+        reqwest::Client::new()
+            .get(&format!("{}/record?{}", &self.address, query_string))
+            .send()
+            .await
+            .expect("Failed to execute queries.")
+    }
+
+    pub async fn get_single_record<T: AsRef<str> + std::fmt::Display>(
+        &self,
+        record_id: T,
+    ) -> reqwest::Response {
+        reqwest::Client::new()
+            .get(&format!("{}/record/{}", &self.address, record_id))
+            .send()
+            .await
+            .expect("Failed to execute queries.")
     }
 }
 

--- a/auditor/tests/api/main.rs
+++ b/auditor/tests/api/main.rs
@@ -1,6 +1,8 @@
 mod add;
+mod advanced_queries;
 mod client;
 mod get;
+mod get_one_record;
 mod get_since;
 mod health_check;
 mod helpers;

--- a/plugins/priority/src/main.rs
+++ b/plugins/priority/src/main.rs
@@ -6,7 +6,7 @@
 // copied, modified, or distributed except according to those terms.
 
 use anyhow::Error;
-use auditor::client::AuditorClientBuilder;
+use auditor::client::{AuditorClientBuilder, Operator, QueryBuilder};
 use auditor::domain::Record;
 use auditor::telemetry::{get_subscriber, init_subscriber};
 use chrono::Utc;
@@ -292,8 +292,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 _ = interval.tick() => {
 
                 let records = match config.duration {
-                    Some(duration) => client
-                        .get_stopped_since(&(Utc::now() - duration))
+                    Some(duration) =>
+                        QueryBuilder::new()
+                        .with_start_time(Operator::default().gte((Utc::now() - duration).into()))
+                        .get(client.clone())
                         .await
                         .unwrap(),
                     None => client.get().await.unwrap(),

--- a/pyauditor/Cargo.toml
+++ b/pyauditor/Cargo.toml
@@ -32,3 +32,4 @@ pyo3-asyncio = { version = "0.19", features = ["attributes", "tokio-runtime"] }
 tokio = "1"
 chrono = { version = "0.4.31", features = ["serde"] }
 serde_json = "1.0.108"
+serde = "1"

--- a/pyauditor/docs/conf.py
+++ b/pyauditor/docs/conf.py
@@ -7,7 +7,7 @@
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 
 project = "pyauditor"
-copyright = "2023, Stefan Kroboth"
+copyright = "2023, Auditor"
 author = "Stefan Kroboth"
 
 # -- General configuration ---------------------------------------------------

--- a/pyauditor/scripts/test_advanced_query.py
+++ b/pyauditor/scripts/test_advanced_query.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+
+import asyncio
+from pyauditor import AuditorClientBuilder, Record, Meta, Component, Score, SortBy
+import datetime
+from tzlocal import get_localzone
+from pyauditor import (
+    Operator,
+    QueryBuilder,
+    Value,
+    MetaOperator,
+    MetaQuery,
+    ComponentQuery,
+)
+
+
+async def main():
+    local_tz = get_localzone()
+    print("LOCAL TIMEZONE: " + str(local_tz))
+
+    client = AuditorClientBuilder().address("127.0.0.1", 8000).timeout(10).build()
+
+    print("Testing /health_check endpoint")
+    health = await client.health_check()
+    assert health
+
+    print("get should not return anything because there are not records in Auditor yet")
+    empty_array = await client.get()
+    assert len(empty_array) == 0
+
+    print("Adding a records to Auditor")
+
+    for i in range(0, 24):
+        record_id = f"record-{i:02d}"
+
+        # datetimes sent to auditor MUST BE in UTC.
+        start = datetime.datetime(2022, 8, 8, i, 0, 0, 0, tzinfo=datetime.timezone.utc)
+        stop = datetime.datetime(2022, 8, 9, i, 0, 0, 0, tzinfo=datetime.timezone.utc)
+        meta = (
+            Meta()
+            .insert("site_id", ["site_A"])
+            .insert("group_id", ["group_1"])
+            .insert("nodes", ["node1", "node2"])
+        )
+        score1 = Score("HEPSPEC", 1.0)
+        component1 = Component("comp-1", 10).with_score(score1)
+
+        record = (
+            Record(record_id, start)
+            .with_stop_time(stop)
+            .with_meta(meta)
+            .with_component(component1)
+        )
+
+        await client.add(record)
+
+    print("Check if all records made it to Auditor")
+
+    all_records = await client.get()
+    assert len(all_records) == 24
+
+    print("Checking advanced queries")
+    start_time = datetime.datetime(
+        2022, 8, 8, 11, 30, 0, 0, tzinfo=datetime.timezone.utc
+    )
+    value = Value.set_datetime(start_time)
+    operator = Operator().gt(value)
+    query_string = QueryBuilder().with_start_time(operator).build()
+
+    records = await client.advanced_query(query_string)
+    assert len(records) == 12
+
+    stop_time = datetime.datetime(
+        2022, 8, 8, 11, 30, 0, 0, tzinfo=datetime.timezone.utc
+    )
+    value = Value.set_datetime(stop_time)
+    operator = Operator().gt(value)
+    query_string = QueryBuilder().with_start_time(operator).build()
+
+    records = await client.advanced_query(query_string)
+    assert len(records) == 12
+
+    start_time = datetime.datetime(
+        2022, 8, 8, 11, 30, 0, 0, tzinfo=datetime.timezone.utc
+    )
+    stop_time = datetime.datetime(
+        2022, 8, 8, 11, 30, 0, 0, tzinfo=datetime.timezone.utc
+    )
+    value1 = Value.set_datetime(start_time)
+    value2 = Value.set_datetime(stop_time)
+    operator1 = Operator().gt(value1)
+    operator2 = Operator().gt(value2)
+    query_string = (
+        QueryBuilder().with_start_time(operator1).with_stop_time(operator2).build()
+    )
+
+    records = await client.advanced_query(query_string)
+    assert len(records) == 12
+
+    start_time1 = datetime.datetime(
+        2022, 8, 8, 11, 30, 0, 0, tzinfo=datetime.timezone.utc
+    )
+    start_time2 = datetime.datetime(
+        2022, 8, 8, 15, 30, 0, 0, tzinfo=datetime.timezone.utc
+    )
+    value1 = Value.set_datetime(start_time1)
+    value2 = Value.set_datetime(start_time2)
+    operator = Operator().gt(value1).lt(value2)
+    query_string = QueryBuilder().with_start_time(operator).build()
+
+    records = await client.advanced_query(query_string)
+    assert len(records) == 4
+
+    meta_operator = MetaOperator().contains("group_1")
+    meta_query = MetaQuery().meta_operator("group_id", meta_operator)
+    records = QueryBuilder().with_meta_query(meta_query).build()
+
+    records = await client.advanced_query(records)
+    record = records[0]
+    assert record.meta.get("group_id") == ["group_1"]
+    assert len(records) == 24
+
+    value = Value.set_count(4)
+    component_operator = Operator().equals(value)
+    component_query = ComponentQuery().component_operator("cpu", component_operator)
+    query_string = QueryBuilder().with_component_query(component_query).build()
+
+    records = await client.advanced_query(query_string)
+    record = records[0]
+    assert record.components[0].name == "comp-1"
+    assert record.components[0].amount == 10
+    assert record.components[0].scores[0].name == "HEPSPEC"
+    assert record.components[0].scores[0].value == 1.0
+    assert len(records) == 24
+
+    sort_by = SortBy().descending("start_time")
+    query_string = QueryBuilder().sort_by(sort_by).build()
+
+    records = await client.advanced_query(query_string)
+    assert len(records) == 24
+
+    for i in range(0, 24):
+        assert records[i].record_id == f"record-{23-i:02d}"
+
+    query_string = QueryBuilder().limit(4).build()
+
+    records = await client.advanced_query(query_string)
+    assert len(records) == 4
+
+    query_string = QueryBuilder().with_record_id(f"record-{3:02d}").build()
+
+    records = await client.advanced_query(query_string)
+    assert len(records) == 1
+
+
+if __name__ == "__main__":
+    import time
+
+    s = time.perf_counter()
+    asyncio.run(main())
+    elapsed = time.perf_counter() - s
+    print(f"{__file__} executed in {elapsed:0.2f} seconds.")

--- a/pyauditor/scripts/test_get_single_record.py
+++ b/pyauditor/scripts/test_get_single_record.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+
+import asyncio
+from pyauditor import AuditorClientBuilder, Record
+import datetime
+from tzlocal import get_localzone
+
+
+async def main():
+    local_tz = get_localzone()
+    print("LOCAL TIMEZONE: " + str(local_tz))
+
+    client = AuditorClientBuilder().address("127.0.0.1", 8000).timeout(10).build()
+
+    print("Testing /health_check endpoint")
+    health = await client.health_check()
+    assert health
+
+    print("get should not return anything because there are not records in Auditor yet")
+    empty_array = await client.get()
+    assert len(empty_array) == 0
+
+    print("Adding a records to Auditor")
+
+    for i in range(0, 24):
+        record_id = f"record-{i:02d}"
+
+        # datetimes sent to auditor MUST BE in UTC.
+        start = datetime.datetime(2022, 8, 8, i, 0, 0, 0, tzinfo=datetime.timezone.utc)
+        stop = datetime.datetime(2022, 8, 9, i, 0, 0, 0, tzinfo=datetime.timezone.utc)
+        record = Record(record_id, start).with_stop_time(stop)
+
+        await client.add(record)
+
+    print("Check if all records made it to Auditor")
+
+    records = await client.get()
+    assert len(records) == 24
+
+    records = sorted(records, key=lambda x: x.record_id)
+
+    for i in range(0, 24):
+        assert records[i].record_id == f"record-{i:02d}"
+
+    record = await client.get_single_record("record-03")
+    assert records[3].record_id == record.record_id
+
+
+if __name__ == "__main__":
+    import time
+
+    s = time.perf_counter()
+    asyncio.run(main())
+    elapsed = time.perf_counter() - s
+    print(f"{__file__} executed in {elapsed:0.2f} seconds.")

--- a/pyauditor/scripts/test_get_single_record_blocking.py
+++ b/pyauditor/scripts/test_get_single_record_blocking.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+
+from pyauditor import AuditorClientBuilder, Record
+import datetime
+from tzlocal import get_localzone
+
+
+def main():
+    local_tz = get_localzone()
+    print("LOCAL TIMEZONE: " + str(local_tz))
+
+    client = (
+        AuditorClientBuilder().address("127.0.0.1", 8000).timeout(10).build_blocking()
+    )
+
+    print("Testing /health_check endpoint")
+    health = client.health_check()
+    assert health
+
+    print("get should not return anything because there are not records in Auditor yet")
+    empty_array = client.get()
+    assert len(empty_array) == 0
+
+    print("Adding a records to Auditor")
+
+    for i in range(0, 24):
+        record_id = f"record-{i:02d}"
+
+        # datetimes sent to auditor MUST BE in UTC.
+        start = datetime.datetime(2022, 8, 8, i, 0, 0, 0, tzinfo=datetime.timezone.utc)
+        stop = datetime.datetime(2022, 8, 9, i, 0, 0, 0, tzinfo=datetime.timezone.utc)
+        record = Record(record_id, start).with_stop_time(stop)
+
+        client.add(record)
+
+    print("Check if all records made it to Auditor")
+
+    records = client.get()
+    assert len(records) == 24
+
+    records = sorted(records, key=lambda x: x.record_id)
+
+    for i in range(0, 24):
+        assert records[i].record_id == f"record-{i:02d}"
+
+    record = client.get_single_record("record-03")
+    assert records[3].record_id == record.record_id
+
+
+if __name__ == "__main__":
+    import time
+
+    s = time.perf_counter()
+    main()
+    elapsed = time.perf_counter() - s
+    print(f"{__file__} executed in {elapsed:0.2f} seconds.")

--- a/pyauditor/src/client.rs
+++ b/pyauditor/src/client.rs
@@ -6,9 +6,593 @@
 // copied, modified, or distributed except according to those terms.
 
 use crate::domain::Record;
+use anyhow::Error;
 use chrono::{DateTime, Utc};
 use pyo3::prelude::*;
 use pyo3::types::PyDateTime;
+use std::collections::HashMap;
+use std::convert::From;
+
+/// The `QueryBuilder` is used to construct `QueryParameters` using the builder pattern.
+#[pyclass]
+#[derive(Debug, Clone)]
+pub struct QueryBuilder {
+    pub(crate) inner: auditor::client::QueryBuilder,
+}
+
+/// The `Operator` is used to specify the operators on the query parameters
+#[pyclass]
+#[derive(serde::Serialize, serde::Deserialize, Debug, Default, Clone)]
+pub struct Operator {
+    pub(crate) inner: auditor::client::Operator,
+}
+
+/// Value is used to specify the type of the value which is used in the query
+#[pyclass]
+#[derive(serde::Serialize, serde::Deserialize, Debug, Clone)]
+pub struct Value {
+    pub(crate) inner: auditor::client::Value,
+}
+
+/// Creates `Value` object which is passed to set the operator value
+#[pymethods]
+impl Value {
+    /// Sets datetime for start_time and stop_time queries
+    ///
+    /// .. warning::
+    ///    The ``timestamp`` MUST be in UTC!
+    ///
+    /// :param timestamp: Timestamp in UTC
+    /// :type timestamp: datetime.datetime
+    ///
+    /// **Example**
+    ///
+    /// .. code-block:: python
+    ///
+    ///     # If the date/time is already in UTC:
+    ///     start_time = datetime.datetime(2022, 8, 8, 11, 30, 0, 0, tzinfo=datetime.timezone.utc)
+    ///
+    ///     # If it is in local time:
+    ///     from tzlocal import get_localzone
+    ///     local_tz = get_localzone()
+    ///     start_time = datetime.datetime(2022, 8, 8, 11, 30, 0, 0, tzinfo=local_tz).astimezone(datetime.timezone.utc)
+    ///
+    ///     value = Value.set_datetime(start_time)
+    #[staticmethod]
+    fn set_datetime(datetime: &PyDateTime) -> Result<Self, Error> {
+        let date_time: DateTime<Utc> = datetime.extract()?;
+        Ok(Value {
+            inner: auditor::client::Value::Datetime(auditor::client::DateTimeUtcWrapper(date_time)),
+        })
+    }
+
+    /// Sets the runtime value to query
+    ///
+    /// :param runtime: int
+    /// :type runtime: int
+    ///
+    /// **Example**
+    ///
+    /// .. code-block:: python
+    ///     
+    ///     runtime_value = 100000
+    ///     value = Value.set_runtime(runtime_value)
+    #[staticmethod]
+    fn set_runtime(runtime: u64) -> Result<Self, Error> {
+        Ok(Value {
+            inner: auditor::client::Value::Runtime(runtime),
+        })
+    }
+
+    /// Sets the count value
+    /// Sets the runtime value to query
+    ///
+    /// :param count: int
+    /// :type count: int
+    ///
+    /// **Example**
+    ///
+    /// .. code-block:: python
+    ///     
+    ///     count_value = 100000
+    ///     value = Value.set_count(count_value)
+    #[staticmethod]
+    fn set_count(count: u8) -> Result<Self, Error> {
+        Ok(Value {
+            inner: auditor::client::Value::Count(count),
+        })
+    }
+}
+
+#[pymethods]
+impl Operator {
+    /// Constructor for setting the operator value
+    #[new]
+    fn new() -> Self {
+        Operator {
+            inner: auditor::client::Operator {
+                gt: None,
+                gte: None,
+                lt: None,
+                lte: None,
+                equals: None,
+            },
+        }
+    }
+
+    /// Sets the greater than (`gt`) operator Value
+    ///
+    /// :param value: The value for greater than operator
+    /// :type value: `Value` object
+    ///
+    /// **Example**
+    ///
+    /// .. code-block:: python
+    ///     
+    ///     count_value = 100000
+    ///     value = Value.set_count(count_value)
+    ///     operator = Operator().gt(value)
+    fn gt(mut self_: PyRefMut<Self>, value: Value) -> PyRefMut<Self> {
+        self_.inner.gt = Some(value.inner);
+        self_
+    }
+
+    /// Sets the lesser than (`lt`) operator value
+    ///
+    /// :param value: The value for lesser than operator
+    /// :type value: `Value` object
+    ///
+    /// **Example**
+    ///
+    /// .. code-block:: python
+    ///     
+    ///     count_value = 100000
+    ///     value = Value.set_count(count_value)
+    ///     operator = Operator().lt(value)
+    fn lt(mut self_: PyRefMut<Self>, value: Value) -> PyRefMut<Self> {
+        self_.inner.lt = Some(value.inner);
+        self_
+    }
+
+    /// Sets the greater than or equal to (`gte`) operator value
+    ///
+    /// :param value: The value for greater than or equal to operator
+    /// :type value: `Value` object
+    ///
+    /// **Example**
+    ///
+    /// .. code-block:: python
+    ///     
+    ///     count_value = 100000
+    ///     value = Value.set_count(count_value)
+    ///     operator = Operator().gte(value)
+    fn gte(mut self_: PyRefMut<Self>, value: Value) -> PyRefMut<Self> {
+        self_.inner.gte = Some(value.inner);
+        self_
+    }
+
+    /// Sets lesser than or equal to (`lte`) operator value
+    ///
+    /// :param value: The value for greater than operator
+    /// :type value: `Value` object
+    ///
+    /// **Example**
+    ///
+    /// .. code-block:: python
+    ///     
+    ///     count_value = 100000
+    ///     value = Value.set_count(count_value)
+    ///     operator = Operator().lte(value)
+    fn lte(mut self_: PyRefMut<Self>, value: Value) -> PyRefMut<Self> {
+        self_.inner.lte = Some(value.inner);
+        self_
+    }
+
+    /// Sets equal to (`equals`) operator value
+    ///
+    /// :param value: The value for greater than operator
+    /// :type value: `Value` object
+    ///
+    /// **Example**
+    ///
+    /// .. code-block:: python
+    ///     
+    ///     count_value = 100000
+    ///     value = Value.set_count(count_value)
+    ///     operator = Operator().equals(value)
+    fn equals(mut self_: PyRefMut<Self>, value: Value) -> PyRefMut<Self> {
+        self_.inner.equals = Some(value.inner);
+        self_
+    }
+}
+
+#[pyclass]
+#[derive(serde::Serialize, serde::Deserialize, Debug, Clone)]
+pub struct MetaQuery {
+    pub(crate) inner: auditor::client::MetaQuery,
+}
+
+#[pymethods]
+impl MetaQuery {
+    /// Constructor for MetaQuery object
+    #[new]
+    fn new() -> Self {
+        MetaQuery {
+            inner: auditor::client::MetaQuery {
+                meta_query: HashMap::new(),
+            },
+        }
+    }
+
+    /// Sets meta operator Value
+    ///
+    /// :param query_id: Metadata key
+    /// :type query_id: string
+    ///
+    /// :param meta_operator: Metadata value which is set using MetaOperator object
+    /// :type meta_operator: `MetaOperator` object
+    ///
+    /// **Example**
+    ///
+    /// .. code-block:: python
+    ///     
+    ///     meta_operator = MetaOperator().contains("group_1")
+    ///     operator = MetaQuery().meta_operator("group_id", meta_operator)
+    fn meta_operator(
+        mut self_: PyRefMut<Self>,
+        query_id: String,
+        meta_operator: MetaOperator,
+    ) -> PyRefMut<Self> {
+        self_
+            .inner
+            .meta_query
+            .insert(query_id, Some(meta_operator.inner));
+        self_
+    }
+}
+
+/// The `MetaOperator` struct represents operators for metadata queries, specifying conditions for filtering
+#[pyclass]
+#[derive(serde::Serialize, serde::Deserialize, Debug, Clone)]
+pub struct MetaOperator {
+    pub(crate) inner: auditor::client::MetaOperator,
+}
+
+#[pymethods]
+impl MetaOperator {
+    /// Constructor for MetaOperator object
+    #[new]
+    fn new() -> Self {
+        MetaOperator {
+            inner: auditor::client::MetaOperator { c: None, dnc: None },
+        }
+    }
+
+    /// Sets the meta value using contains operator. This checks if the value exists for the
+    /// corresponding metadata key
+    ///
+    /// :param query_id: Metadata key
+    /// :type query_id: string
+    ///
+    /// :param c: Metadata value to be checked if it exists
+    /// :type c: string
+    ///
+    /// **Example**
+    ///
+    /// .. code-block:: python
+    ///     
+    ///     meta_operator = MetaOperator().contains("group_1")
+    ///     meta_query = MetaQuery().meta_operator("group_id", meta_operator)
+    fn contains(mut self_: PyRefMut<Self>, c: String) -> PyRefMut<Self> {
+        self_.inner.c = Some(c);
+        self_
+    }
+
+    /// Sets the meta value using  does not contains operator. This checks if the value does not exists for the
+    /// corresponding metadata key
+    ///
+    /// :param query_id: Metadata key
+    /// :type query_id: string
+    ///
+    /// :param c: Metadata value to be checked if it does not exists
+    /// :type c: string
+    ///
+    /// **Example**
+    ///
+    /// .. code-block:: python
+    ///     
+    ///     operator = MetaOperator().does_not_contains("group_1")
+    fn does_not_contains(mut self_: PyRefMut<Self>, dnc: String) -> PyRefMut<Self> {
+        self_.inner.dnc = Some(dnc);
+        self_
+    }
+}
+
+/// The `ComponentQuery` struct represents a set of component queries associated with specific query IDs.
+/// It is used to filter records based on component-related conditions
+#[pyclass]
+#[derive(serde::Serialize, serde::Deserialize, Debug, Clone)]
+pub struct ComponentQuery {
+    pub(crate) inner: auditor::client::ComponentQuery,
+}
+
+#[pymethods]
+impl ComponentQuery {
+    /// Constructor for ComponentQuery object
+    #[new]
+    fn new() -> Self {
+        ComponentQuery {
+            inner: auditor::client::ComponentQuery {
+                component_query: HashMap::new(),
+            },
+        }
+    }
+
+    /// Adds a new component operator to the `ComponentQuery` instance for a specific query ID.
+    ///
+    /// :param query_id: Component name
+    /// :type query_id: string
+    ///
+    /// :param operator: component amount
+    /// :type operator: int
+    ///
+    /// **Example**
+    ///
+    /// .. code-block:: python
+    ///
+    ///     value = Value.set_count(10)
+    ///     component_operator = Operator().equals(value)
+    ///     component_query = ComponentQuery().component_operator("cpu", component_operator)
+    fn component_operator(
+        mut self_: PyRefMut<Self>,
+        query_id: String,
+        operator: Operator,
+    ) -> PyRefMut<Self> {
+        self_
+            .inner
+            .component_query
+            .insert(query_id, Some(operator.inner));
+        self_
+    }
+}
+
+/// SortBy provides options on sorting the query records
+#[pyclass]
+#[derive(serde::Serialize, serde::Deserialize, Debug, Clone)]
+pub struct SortBy {
+    pub(crate) inner: auditor::client::SortBy,
+}
+
+#[pymethods]
+impl SortBy {
+    /// Constructor for SortBy object
+    #[new]
+    fn new() -> Self {
+        Self {
+            inner: auditor::client::SortBy {
+                asc: None,
+                desc: None,
+            },
+        }
+    }
+
+    /// Specify the column by which the query records must be sorted in ascending order
+    ///
+    /// :param column: Name of the column by which the records must be sorted. One of four values (`start_time`, `stop_time`, `runtime`, `record_id`).
+    /// :type column: string
+    ///
+    /// **Example**
+    ///
+    /// .. code-block:: python
+    ///
+    ///     sort_by = SortBy().ascending("start_time")
+    fn ascending(mut self_: PyRefMut<Self>, column: String) -> PyRefMut<Self> {
+        self_.inner.asc = Some(column);
+        self_
+    }
+
+    /// Specify the column by which the query records must be sorted in descending order
+    ///
+    /// :param column: Name of the column by which the records must be sorted. One of three values (`start_time`, `stop_time`, `runtime`, `record_id`).
+    /// :type column: string
+    ///
+    /// **Example**
+    ///
+    /// .. code-block:: python
+    ///
+    ///     sort_by = SortBy().descending("start_time")
+    fn descending(mut self_: PyRefMut<Self>, column: String) -> PyRefMut<Self> {
+        self_.inner.desc = Some(column);
+        self_
+    }
+}
+
+#[pymethods]
+impl QueryBuilder {
+    /// Constructor for QueryBuilder object
+    #[new]
+    fn new() -> Result<Self, Error> {
+        Ok(QueryBuilder {
+            inner: auditor::client::QueryBuilder {
+                query_params: auditor::client::QueryParameters {
+                    record_id: None,
+                    start_time: None,
+                    stop_time: None,
+                    runtime: None,
+                    meta: None,
+                    component: None,
+                    sort_by: None,
+                    limit: None,
+                },
+            },
+        })
+    }
+
+    /// Sets the exact record_id to retrieve
+    ///
+    /// :param record_id: Exact record_id to be retrieved
+    /// :type record_id: string
+    ///
+    ///
+    /// **Example**
+    ///
+    /// .. code-block:: python
+    ///     
+    ///     record_id = "r101"
+    ///     query_string = QueryBuilder().with_record_id(record_id).build()
+    fn with_record_id(
+        mut self_: PyRefMut<Self>,
+        record_id: String,
+    ) -> Result<PyRefMut<Self>, Error> {
+        self_.inner.query_params.record_id = Some(record_id);
+        Ok(self_)
+    }
+
+    /// Sets the start time in the query parameters
+    ///
+    /// :param operator: Operator object containing `DateTime<Utc>`
+    /// :type operator: Operator object
+    ///
+    ///
+    /// **Example**
+    ///
+    /// .. code-block:: python
+    ///     
+    ///     start_time = datetime.datetime(
+    ///      2022, 8, 8, 11, 30, 0, 0, tzinfo=datetime.timezone.utc
+    ///     )
+    ///     
+    ///     value = Value.set_datetime(start_time)
+    ///     operator = Operator().gt(value)
+    ///     query_string = QueryBuilder().with_start_time(operator).build()
+    fn with_start_time(
+        mut self_: PyRefMut<Self>,
+        operator: Operator,
+    ) -> Result<PyRefMut<Self>, Error> {
+        self_.inner.query_params.start_time = Some(operator.inner);
+        Ok(self_)
+    }
+
+    /// Sets the stop time in the query parameters
+    ///
+    /// :param operator: Operator object containing `DateTime<Utc>`
+    /// :type operator: Operator object
+    ///
+    ///
+    /// **Example**
+    ///
+    /// .. code-block:: python
+    ///     
+    ///     stop_time = datetime.datetime(
+    ///      2022, 8, 8, 11, 30, 0, 0, tzinfo=datetime.timezone.utc
+    ///     )
+    ///     
+    ///     value = Value.set_datetime(stop_time)
+    ///     operator = Operator().gt(value)
+    ///     query_string = QueryBuilder().with_stop_time(operator).build()
+    fn with_stop_time(mut self_: PyRefMut<Self>, operator: Operator) -> PyRefMut<Self> {
+        self_.inner.query_params.stop_time = Some(operator.inner);
+        self_
+    }
+
+    /// Sets the runtime in the query parameters
+    ///
+    /// :param operator: Operator object containing runtime value
+    /// :type operator: Operator object
+    ///
+    /// **Example**
+    ///
+    /// .. code-block:: python
+    ///     
+    ///     start_time = datetime.datetime(
+    ///      2022, 8, 8, 11, 30, 0, 0, tzinfo=datetime.timezone.utc
+    ///     )
+    ///      
+    ///     value = Value.set_runtime(100000)
+    ///     operator = Operator().gt(value)
+    ///     query_string = QueryBuilder().with_runtime(operator).build()
+    fn with_runtime(mut self_: PyRefMut<Self>, operator: Operator) -> PyRefMut<Self> {
+        self_.inner.query_params.runtime = Some(operator.inner);
+        self_
+    }
+
+    /// Sets the meta query in the query parameters
+    ///
+    /// :param meta- meta contains the meta key and value
+    /// :type meta- MetaQuery object
+    ///
+    ///
+    /// **Example**
+    ///
+    /// .. code-block:: python
+    ///     
+    ///     meta_operator = MetaOperator().contains("group_1")
+    ///     meta_query = MetaQuery().meta_operator("group_id", meta_operator)
+    ///     query_string = QueryBuilder().with_meta_query(meta_query).build()
+    fn with_meta_query(mut self_: PyRefMut<Self>, meta: MetaQuery) -> PyRefMut<Self> {
+        self_.inner.query_params.meta = Some(meta.inner);
+        self_
+    }
+
+    /// Sets the component query in the query parameters
+    ///
+    /// :param component: ComponentQuery object instantiated with component name and amount
+    /// :type component: ComponentQuery object
+    ///
+    /// **Example**
+    ///
+    /// .. code-block:: python
+    ///
+    ///     value = Value.count(4)
+    ///     component_operator = Operator().equals(value)
+    ///     component_query = ComponentQuery().component_operator("cpu", component_operator)
+    ///     records = QueryBuilder().with_component_query(component_query).build()
+    fn with_component_query(
+        mut self_: PyRefMut<Self>,
+        component: ComponentQuery,
+    ) -> PyRefMut<Self> {
+        self_.inner.query_params.component = Some(component.inner);
+        self_
+    }
+
+    /// SortBy provides options on sorting the query records
+    ///
+    /// :param sort_by: SortBy object instantiatied with the sorting order(asc or desc) and column
+    /// name
+    /// :type sort_by: SortBy object
+    ///
+    /// **Example**
+    ///
+    /// .. code-block:: python
+    ///
+    ///     sort_by = SortBy().ascending("start_time")
+    ///     records = QueryBuilder().sort_by(sort_by).build()
+    fn sort_by(mut self_: PyRefMut<Self>, sort_by: SortBy) -> PyRefMut<Self> {
+        self_.inner.query_params.sort_by = Some(sort_by.inner);
+        self_
+    }
+
+    /// Limits the query records
+    ///
+    /// :param number: number specifying the number of records that needs to be returned
+    /// :type number: int
+    ///
+    /// **Example**
+    ///
+    /// .. code-block:: python
+    ///
+    ///     records = QueryBuilder().limit(500).build()
+    fn limit(mut self_: PyRefMut<Self>, number: u64) -> PyRefMut<Self> {
+        self_.inner.query_params.limit = Some(number);
+        self_
+    }
+
+    /// Builds the query string for the given query parameters
+    fn build(self_: PyRef<Self>, py: Python) -> Py<PyAny> {
+        let query_string: String = self_.inner.clone().build();
+        query_string.into_py(py)
+    }
+}
 
 /// The `AuditorClient` handles the interaction with the Auditor instances and allows one to add
 /// records to the database, update records in the database and retrieve the records from the
@@ -74,11 +658,18 @@ impl AuditorClient {
         timestamp: &PyDateTime,
         py: Python<'a>,
     ) -> PyResult<&'a PyAny> {
-        let timestamp: DateTime<Utc> = timestamp.extract()?;
+        let message = py.get_type::<pyo3::exceptions::PyDeprecationWarning>();
+        PyErr::warn(py, message, "get_started_since is depreciated", 0)?;
+
+        let since: DateTime<Utc> = timestamp.extract()?;
         let inner = self_.inner.clone();
+        let query_string = auditor::client::QueryBuilder::new()
+            .with_start_time(auditor::client::Operator::default().gte(since.into()))
+            .build();
+
         pyo3_asyncio::tokio::future_into_py(py, async move {
             Ok(inner
-                .get_started_since(&timestamp)
+                .advanced_query(query_string.to_string())
                 .await
                 .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(format!("{e}")))?
                 .into_iter()
@@ -115,16 +706,82 @@ impl AuditorClient {
         timestamp: &PyDateTime,
         py: Python<'a>,
     ) -> PyResult<&'a PyAny> {
-        let timestamp: DateTime<Utc> = timestamp.extract()?;
+        let message = py.get_type::<pyo3::exceptions::PyDeprecationWarning>();
+        PyErr::warn(py, message, "get_stopped_since_since is depreciated", 0)?;
+
+        let since: DateTime<Utc> = timestamp.extract()?;
         let inner = self_.inner.clone();
+        let query_string = auditor::client::QueryBuilder::new()
+            .with_stop_time(auditor::client::Operator::default().gte(since.into()))
+            .build();
         pyo3_asyncio::tokio::future_into_py(py, async move {
             Ok(inner
-                .get_stopped_since(&timestamp)
+                .advanced_query(query_string.to_string())
                 .await
                 .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(format!("{e}")))?
                 .into_iter()
                 .map(Record::from)
                 .collect::<Vec<_>>())
+        })
+    }
+
+    /// advanced_query(query_string: string)
+    /// Get records from the database depending on the query parameters
+    ///
+    /// :param query_string: query_string constructed with QueryBuilder using .build() method
+    /// :type query_string: string
+    ///
+    /// **Example**
+    ///
+    /// .. code-block:: python
+    ///
+    ///     value1 = Value.set_datetime(start_time)
+    ///     value2 = Value.set_datetime(stop_time)
+    ///     operator1 = Operator().gt(value1)
+    ///     operator2 = Operator().gt(value2)
+    ///     query_string = QueryBuilder().with_start_time(operator1).with_stop_time(operator2).build()
+    ///     records = await client.advanced_query(record)
+    fn advanced_query<'a>(
+        self_: PyRef<'a, Self>,
+        query_string: String,
+        py: Python<'a>,
+    ) -> PyResult<&'a PyAny> {
+        let inner = self_.inner.clone();
+        pyo3_asyncio::tokio::future_into_py(py, async move {
+            Ok(inner
+                .advanced_query(query_string)
+                .await
+                .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(format!("{e}")))?
+                .into_iter()
+                .map(Record::from)
+                .collect::<Vec<_>>())
+        })
+    }
+
+    /// get_one_record(record_id: string)
+    /// Get one record using record_id
+    ///
+    /// :param record_id: record_id
+    /// :type record_id: string
+    ///
+    /// **Example**
+    ///
+    /// .. code-block:: python
+    ///
+    ///     record: &str = "record-1"
+    ///     record = await client.get_one_record(record)
+    fn get_single_record<'a>(
+        self_: PyRef<'a, Self>,
+        record_id: String,
+        py: Python<'a>,
+    ) -> PyResult<&'a PyAny> {
+        let inner = self_.inner.clone();
+        pyo3_asyncio::tokio::future_into_py(py, async move {
+            inner
+                .get_single_record(record_id)
+                .await
+                .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(format!("{e}")))
+                .map(Record::from)
         })
     }
 

--- a/pyauditor/src/lib.rs
+++ b/pyauditor/src/lib.rs
@@ -19,6 +19,13 @@ mod domain;
 fn pyauditor(_py: Python, m: &PyModule) -> PyResult<()> {
     m.add_class::<crate::builder::AuditorClientBuilder>()?;
     m.add_class::<crate::client::AuditorClient>()?;
+    m.add_class::<crate::client::Value>()?;
+    m.add_class::<crate::client::Operator>()?;
+    m.add_class::<crate::client::QueryBuilder>()?;
+    m.add_class::<crate::client::MetaQuery>()?;
+    m.add_class::<crate::client::MetaOperator>()?;
+    m.add_class::<crate::client::ComponentQuery>()?;
+    m.add_class::<crate::client::SortBy>()?;
     m.add_class::<crate::blocking_client::AuditorClientBlocking>()?;
     m.add_class::<crate::domain::Record>()?;
     m.add_class::<crate::domain::Meta>()?;


### PR DESCRIPTION
This closes #466 #555 #550 #552
This branch handles the advanced querying of auditor records using time, meta, component, sort_by and limit filters.
The auditor client.rs contains the client methods to build a custom query.
The corresponding pyo3 bindings for pyauditor are written to client.rs

