### PR TITLE
Fix clippy warnings

### DIFF
--- a/collectors/slurm/src/sacctcaller.rs
+++ b/collectors/slurm/src/sacctcaller.rs
@@ -356,7 +356,7 @@ fn identify_site(job: &Job) -> Option<String> {
         .cloned()
         .map(|s| make_string_valid(s.name))
         .collect::<Vec<_>>()
-        .get(0)
+        .first()
         .cloned()
 }
 

--- a/plugins/priority/src/main.rs
+++ b/plugins/priority/src/main.rs
@@ -115,7 +115,7 @@ fn extract(records: Vec<Record>, config: &Settings) -> HashMap<ResourceName, Res
         // If no group_id is present in the record, then record will be silently ignored
         if let Some(meta) = r.meta.as_ref() {
             if let Some(groups) = meta.get("group_id") {
-                if let Some(group_id) = groups.get(0) {
+                if let Some(group_id) = groups.first() {
                     // Only consider configured groups
                     if config.group_mapping.contains_key(group_id) {
                         // we know that the key exists (we filled it beforehand), therefore we can unwrap


### PR DESCRIPTION
We use the beta rust toolchain for running clippy in the CI. Apparently, there was an update with more stricter rules. We now get an error for using `.get(0)` on collections. Following the suggestions from clippy, this can be easily fixed though.