### PR TITLE
Add versioning for webpage and python docs

### DIFF
--- a/.github/workflows/pyauditor.yml
+++ b/.github/workflows/pyauditor.yml
@@ -219,6 +219,9 @@ jobs:
     env:
       SQLX_OFFLINE: true
     steps:
+      - name: Set RELEASE_VERSION env
+        run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" | sed "s/main/edge/" >> $GITHUB_ENV
+
       - name: Checkout repository
         uses: actions/checkout@v4
 
@@ -234,9 +237,34 @@ jobs:
 
       - name: Deploy pyauditor docs
         uses: JamesIves/github-pages-deploy-action@v4
-        if: github.ref == 'refs/heads/main'
+        if: ${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/') }}
         with:
           folder: pyauditor/docs/_build/html
-          target-folder: pyauditor
+          target-folder: pyauditor/${{ env.RELEASE_VERSION }}
           token: ${{ secrets.GITHUB_TOKEN }}
           clean: false
+
+      # Only for tag push: Update latest to new release version
+
+      - name: Checkout gh-pages
+        uses: actions/checkout@v4
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          ref: gh-pages
+          fetch-depth: 0 # otherwise, you will failed to push refs to dest repo
+
+      - name: Redirect latest to new release
+        if: startsWith(github.ref, 'refs/tags/')
+        run: |
+            echo "Redirecting latest to newly released version " $RELEASE_VERSION
+            rm -rf pyauditor/latest
+            ln -s pyauditor/$RELEASE_VERSION pyauditor/latest
+            git add pyauditor/latest
+            git commit -m "CI: Redirect latest to new version $RELEASE_VERSION (pyauditor)"
+
+      - name: Push changes
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: ad-m/github-push-action@master
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          branch: gh-pages

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - main
+    tags:
+      - v*
   pull_request:
 
 env:
@@ -13,22 +15,50 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout main
+      - name: Set RELEASE_VERSION env
+        run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" | sed "s/main/edge/" >> $GITHUB_ENV
+
+      - name: Checkout main/tag
         uses: actions/checkout@v4
+
       - name: Build only 
         uses: shalzz/zola-deploy-action@master
         env:
           BUILD_DIR: media/website
           BUILD_ONLY: true
           OUT_DIR: public
-          # BUILD_FLAGS: --drafts
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Deploy website
         uses: JamesIves/github-pages-deploy-action@v4
-        if: github.ref == 'refs/heads/main'
+        if: ${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/') }}
         with:
           folder: media/website/public
-          target-folder: .
+          target-folder: ${{ env.RELEASE_VERSION }}
           token: ${{ secrets.GITHUB_TOKEN }}
           clean: false
+
+      # Only for tag push: Update latest to new release version
+
+      - name: Checkout gh-pages
+        uses: actions/checkout@v4
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          ref: gh-pages
+          fetch-depth: 0 # otherwise, you will failed to push refs to dest repo
+
+      - name: Redirect latest to new release
+        if: startsWith(github.ref, 'refs/tags/')
+        run: |
+            echo "Redirecting latest to newly released version " $RELEASE_VERSION
+            rm -rf latest
+            ln -s $RELEASE_VERSION latest
+            git add latest
+            git commit -m "CI: Redirect latest to new version $RELEASE_VERSION"
+
+      - name: Push changes
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: ad-m/github-push-action@master
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          branch: gh-pages

--- a/media/website/content/_index.md
+++ b/media/website/content/_index.md
@@ -757,3 +757,4 @@ at your option.
 
 Unless you explicitly state otherwise, any contribution intentionally submitted for inclusion in the work by you, as defined in the Apache-2.0 license, shall be dual licensed as above, without any additional terms or conditions.
 
+## Test


### PR DESCRIPTION
This adjusts the workflows so that different versions are kept for the webpage and Python docs.

Before merging this, first merge: #546
