### PR TITLE
add python 3.12 to workflows

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -18,7 +18,7 @@ jobs:
   build-pyauditor-linux:
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
     uses: ./.github/workflows/build_pyauditor_linux.yml
     with:
       python-version: ${{ matrix.python-version }}
@@ -26,7 +26,7 @@ jobs:
   build-pyauditor-windows:
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
     uses: ./.github/workflows/build_pyauditor_windows.yml
     with:
       python-version: ${{ matrix.python-version }}
@@ -34,7 +34,7 @@ jobs:
   build-pyauditor-macos:
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
     uses: ./.github/workflows/build_pyauditor_macos.yml
     with:
       python-version: ${{ matrix.python-version }}
@@ -42,7 +42,7 @@ jobs:
   python-unit-tests:
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
     needs: build-pyauditor-linux
     uses: ./.github/workflows/python_unit_tests.yml
     with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Docs: Add steps for creating a new release ([@QuantumDancer](https://github.com/QuantumDancer))
+- CI: Add Python 3.12 to workflows ([@dirksammel](https://github.com/dirksammel))
 
 ### Changed
 - Dependencies: Update pytest from 7.4.2 to 7.4.3 ([@dirksammel](https://github.com/dirksammel))


### PR DESCRIPTION
This PR adds Python 3.12 to the `build-pyauditor` and `python-unit-tests` workflows.