### PR TITLE
CI: Fix maturin version to v1.2.3

### DIFF
--- a/.github/workflows/build_pyauditor_linux.yml
+++ b/.github/workflows/build_pyauditor_linux.yml
@@ -30,6 +30,7 @@ jobs:
       - name: Maturin
         uses: messense/maturin-action@v1
         with:
+          maturin-version: v1.2.3
           target: x86_64
           manylinux: auto
           command: build

--- a/.github/workflows/build_pyauditor_macos.yml
+++ b/.github/workflows/build_pyauditor_macos.yml
@@ -30,6 +30,7 @@ jobs:
       - name: Maturin
         uses: messense/maturin-action@v1
         with:
+          maturin-version: v1.2.3
           command: build
           args: --release -o dist --target universal2-apple-darwin --interpreter python${{ inputs.python-version }} --manifest-path pyauditor/Cargo.toml
 

--- a/.github/workflows/build_pyauditor_windows.yml
+++ b/.github/workflows/build_pyauditor_windows.yml
@@ -37,6 +37,7 @@ jobs:
       - name: Maturin
         uses: messense/maturin-action@v1
         with:
+          maturin-version: v1.2.3
           command: build
           args: --release -o dist --interpreter python${{ inputs.python-version }} --manifest-path pyauditor/Cargo.toml
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Dependencies: Update serde from 1.0.192 to 1.0.193 ([@QuantumDancer](https://github.com/QuantumDancer))
 - Dependencies: Update setuptools from 68.2.2 to 69.0.2 ([@dirksammel](https://github.com/dirksammel))
 - Dependencies: Update uuid from 1.5.0 to 1.6.1 ([@QuantumDancer](https://github.com/QuantumDancer))
+- CI: Fix maturin version to v1.2.3 ([@QuantumDancer](https://github.com/QuantumDancer))
 
 ### Removed
 


### PR DESCRIPTION
Fixes #565

Strictly this is only necessary for the `build_pyauditor_linux.yml` workflow because we build the source distribution there. However, I think it's a good idea to keep the maturin versions in sync between the different workflows. I didn't modify any `pip install maturin` commands that are used in the test scripts, because this is still working.