### PR TITLE
Dependency between pyauditor release and python packages release + python version as parameter

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -56,7 +56,12 @@ jobs:
     needs: [build-pyauditor-linux, sqlx]
     uses: ./.github/workflows/pyauditor_integration_tests.yml
 
-  release:
+  release-pyauditor:
     if: "startsWith(github.ref, 'refs/tags/')"
     needs: [build-pyauditor-linux, build-pyauditor-windows, build-pyauditor-macos]
-    uses: ./.github/workflows/release.yml
+    uses: ./.github/workflows/release_pyauditor.yml
+
+  release-python-packages:
+    if: "startsWith(github.ref, 'refs/tags/')"
+    needs: release-pyauditor
+    uses: ./.github/workflows/release_python_packages.yml

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -9,6 +9,9 @@ on:
       - v*
 
 jobs:
+  prepare-input-parameters:
+    uses: ./.github/workflows/prepare_input_parameters.yml
+
   build-auditor:
     uses: ./.github/workflows/build_auditor.yml
 
@@ -49,19 +52,27 @@ jobs:
       python-version: ${{ matrix.python-version }}
 
   pyauditor-docs:
-    needs: build-pyauditor-linux
+    needs: [build-pyauditor-linux, prepare-input-parameters]
     uses: ./.github/workflows/pyauditor_docs.yml
+    with:
+      python-version: ${{ needs.prepare-input-parameters.outputs.python_version }}
 
   pyauditor-integration-tests:
-    needs: [build-pyauditor-linux, sqlx]
+    needs: [build-pyauditor-linux, sqlx, prepare-input-parameters]
     uses: ./.github/workflows/pyauditor_integration_tests.yml
+    with:
+      python-version: ${{ needs.prepare-input-parameters.outputs.python_version }}
 
   release-pyauditor:
     if: "startsWith(github.ref, 'refs/tags/')"
-    needs: [build-pyauditor-linux, build-pyauditor-windows, build-pyauditor-macos]
+    needs: [build-pyauditor-linux, build-pyauditor-windows, build-pyauditor-macos, prepare-input-parameters]
     uses: ./.github/workflows/release_pyauditor.yml
+    with:
+      python-version: ${{ needs.prepare-input-parameters.outputs.python_version }}
 
   release-python-packages:
     if: "startsWith(github.ref, 'refs/tags/')"
-    needs: release-pyauditor
+    needs: [release-pyauditor, prepare-input-parameters]
     uses: ./.github/workflows/release_python_packages.yml
+    with:
+      python-version: ${{ needs.prepare-input-parameters.outputs.python_version }}

--- a/.github/workflows/prepare_input_parameters.yml
+++ b/.github/workflows/prepare_input_parameters.yml
@@ -1,0 +1,20 @@
+name: prepare-input-parameters
+
+on:
+  workflow_call:
+    outputs:
+      python_version:
+        description: "python version for setup"
+        value: ${{ jobs.parameters.outputs.python-version }}
+
+env:
+  PYTHON_VERSION: "python-version=3.9"
+        
+jobs:
+  parameters:
+    runs-on: ubuntu-latest
+    outputs:
+      python-version: ${{ steps.set-parameters.outputs.python-version }}
+    steps:
+      - id: set-parameters
+        run: echo $PYTHON_VERSION >> $GITHUB_OUTPUT

--- a/.github/workflows/pyauditor_docs.yml
+++ b/.github/workflows/pyauditor_docs.yml
@@ -2,6 +2,10 @@ name: pyauditor-docs
 
 on:
   workflow_call:
+    inputs:
+      python-version:
+        required: true
+        type: string
 
 jobs:
   pyauditor-docs:
@@ -15,7 +19,7 @@ jobs:
       - name: Set up python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.9
+          python-version: ${{ inputs.python-version }}
 
       - name: Download wheel
         uses: actions/download-artifact@v3

--- a/.github/workflows/pyauditor_integration_tests.yml
+++ b/.github/workflows/pyauditor_integration_tests.yml
@@ -2,6 +2,10 @@ name: pyauditor-integration-tests
 
 on:
   workflow_call:
+    inputs:
+      python-version:
+        required: true
+        type: string
 
 jobs:
   pyauditor-integration-test:
@@ -26,7 +30,7 @@ jobs:
       - name: Set up python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.9
+          python-version: ${{ inputs.python-version }}
 
       - name: Set up toolchain
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/release_pyauditor.yml
+++ b/.github/workflows/release_pyauditor.yml
@@ -1,4 +1,4 @@
-name: Release
+name: release-pyauditor
 
 on:
   workflow_call:

--- a/.github/workflows/release_pyauditor.yml
+++ b/.github/workflows/release_pyauditor.yml
@@ -2,6 +2,10 @@ name: release-pyauditor
 
 on:
   workflow_call:
+    inputs:
+      python-version:
+        required: true
+        type: string
 
 jobs:
   release-pyauditor:
@@ -19,7 +23,7 @@ jobs:
       - name: Setup python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.9
+          python-version: ${{ inputs.python-version }}
 
       - name: Publish to GitHub
         uses: softprops/action-gh-release@v1

--- a/.github/workflows/release_python_packages.yml
+++ b/.github/workflows/release_python_packages.yml
@@ -2,6 +2,10 @@ name: release-python-packages
 
 on:
   workflow_call:
+    inputs:
+      python-version:
+        required: true
+        type: string
 
 jobs:
   release-apel-plugin:
@@ -18,7 +22,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.9
+          python-version: ${{ inputs.python-version }}
       - name: Install build
         run: |
           pip install --upgrade pip
@@ -48,7 +52,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.9
+          python-version: ${{ inputs.python-version }}
       - name: Install build
         run: |
           pip install --upgrade pip

--- a/.github/workflows/release_python_packages.yml
+++ b/.github/workflows/release_python_packages.yml
@@ -1,12 +1,10 @@
-name: python-publish
+name: release-python-packages
 
 on:
-  push:
-    tags:
-      - v*.*.*
+  workflow_call:
 
 jobs:
-  publish-apel-plugin:
+  release-apel-plugin:
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -20,7 +18,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: 3.9
       - name: Install build
         run: |
           pip install --upgrade pip
@@ -36,7 +34,7 @@ jobs:
         with:
           files: plugins/apel/dist/*
           
-  publish-htcondor-collector:
+  release-htcondor-collector:
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -50,7 +48,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: 3.9
       - name: Install build
         run: |
           pip install --upgrade pip

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Auditor+pyauditor: Added advanced filtering when querying records (#466) ([@raghuvar-vijay](https://github.com/raghuvar-vijay))
 - Auditor-pyauditor: Added bulk_insert option to insert list of records using auditor client and pyauditor (#580) ([@raghuvar-vijay](https://github.com/raghuvar-vijay))
+- CI: Added new workflow to define reusable parameters for other workflows ([@dirksammel](https://github.com/dirksammel))
 
 ### Changed
 - Auditor+pyauditor: Deprecate `get_started_since()` and `get_stopped_since()` functions ([@raghuvar-vijay](https://github.com/raghuvar-vijay))
@@ -25,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Dependencies: Update sqlx from 0.7.2 to 0.7.3 ([@QuantumDancer](https://github.com/QuantumDancer))
 - Dependencies: Update wiremock from 0.5.21 to 0.5.22 ([@QuantumDancer](https://github.com/QuantumDancer))
 - CI: Replace unmaintained actions-rs/audit-check action with maintained one from rustsec ([@QuantumDancer](https://github.com/QuantumDancer))
+- CI: Introduce dependency between pyauditor release and release of python packages ([@dirksammel](https://github.com/dirksammel))
 
 ### Removed
 


### PR DESCRIPTION
This PR adds a dependency between the pyauditor release workflow and both the HTCondor collector and the APEL plugin release workflows, since the latter need the latest pyauditor release.

Additionally, the python version is now a parameter that is defined at just on place. 
This prepares the parameterization of more variables.