### PR TITLE
Ignore RUSTSEC-2023-0071

### DIFF
--- a/.github/workflows/audit-on-push.yml
+++ b/.github/workflows/audit-on-push.yml
@@ -12,3 +12,10 @@ jobs:
       - uses: rustsec/audit-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          # RUSTSEC-2023-0071 - Marvin Attack: potential key recovery through timing sidechannels (rsa crate)
+          # Reason for ignore: Vulnerable code is not actually used
+          # Explanation:
+          # The 'rsa' crate is pulled in by the 'sqlx-mysql' crate. The 'sqlx-mysql' crate
+          # is only pulled in because we use the `migrate` feature of `sqlx`. However, we
+          # only use the postgres and sqlite DB drivers.
+          ignore: RUSTSEC-2023-0071

--- a/.github/workflows/audit-on-push.yml
+++ b/.github/workflows/audit-on-push.yml
@@ -9,6 +9,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions-rs/audit-check@v1
+      - uses: rustsec/audit-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/scheduled-audit.yml
+++ b/.github/workflows/scheduled-audit.yml
@@ -7,6 +7,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions-rs/audit-check@v1
+      - uses: rustsec/audit-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          # RUSTSEC-2023-0071 - Marvin Attack: potential key recovery through timing sidechannels (rsa crate)
+          # Reason for ignore: Vulnerable code is not actually used
+          # Explanation:
+          # The 'rsa' crate is pulled in by the 'sqlx-mysql' crate. The 'sqlx-mysql' crate
+          # is only pulled in because we use the `migrate` feature of `sqlx`. However, we
+          # only use the postgres and sqlite DB drivers.
+          ignore: RUSTSEC-2023-0071

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Breaking changes
 
 ### Security
+- [RUSTSEC-2023-0071]: Ignored, because vulnerable code is not actually used by us ([@QuantumDancer](https://github.com/QuantumDancer)
 
 ### Added
 - Auditor+pyauditor: Added advanced filtering when querying records (#466) ([@raghuvar-vijay](https://github.com/raghuvar-vijay))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Dependencies: Update serde_qs from 0.11.0 to 0.12.0 ([@QuantumDancer](https://github.com/QuantumDancer)
 - Dependencies: Update sqlx from 0.7.2 to 0.7.3 ([@QuantumDancer](https://github.com/QuantumDancer))
 - Dependencies: Update wiremock from 0.5.21 to 0.5.22 ([@QuantumDancer](https://github.com/QuantumDancer))
+- CI: Replace unmaintained actions-rs/audit-check action with maintained one from rustsec ([@QuantumDancer](https://github.com/QuantumDancer))
 
 ### Removed
 


### PR DESCRIPTION
- Switch from unmaintained `actions-rs/audit-check` to maintained `rustsec/audit-check` action
- Add ignore for RUSTSEC-2023-0071
    Reason for ignore: Vulnerable code is not actually used
    The `rsa` crate is pulled in by the `sqlx-mysql` crate. The `sqlx-mysql` crate
     is only pulled in because we use the `migrate` feature of `sqlx`. However, we
     only use the postgres and sqlite DB drivers.