### PR TITLE
Add bulk_insert option to add list of records using auditor client and pyauditor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Auditor+pyauditor: Added advanced filtering when querying records (#466) ([@raghuvar-vijay](https://github.com/raghuvar-vijay))
+- Auditor-pyauditor: Added bulk_insert option to insert list of records using auditor client and pyauditor (#580) ([@raghuvar-vijay](https://github.com/raghuvar-vijay))
 
 ### Changed
 - Auditor+pyauditor: Deprecate `get_started_since()` and `get_stopped_since()` functions ([@raghuvar-vijay](https://github.com/raghuvar-vijay))

--- a/auditor/.sqlx/query-3da9ad5248c244c040b47e27cbbca081b156fd5b88bffac65be6bb7ba7aabafe.json
+++ b/auditor/.sqlx/query-3da9ad5248c244c040b47e27cbbca081b156fd5b88bffac65be6bb7ba7aabafe.json
@@ -1,0 +1,16 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n                INSERT INTO meta (record_id, key, value)\n                SELECT * FROM UNNEST($1::text[], $2::text[], $3::text[])\n                ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "TextArray",
+        "TextArray",
+        "TextArray"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "3da9ad5248c244c040b47e27cbbca081b156fd5b88bffac65be6bb7ba7aabafe"
+}

--- a/auditor/.sqlx/query-50c6776ca37b9b56b92848573f32d72f44631c9ff702bb468dc7a7f5520a6f48.json
+++ b/auditor/.sqlx/query-50c6776ca37b9b56b92848573f32d72f44631c9ff702bb468dc7a7f5520a6f48.json
@@ -1,0 +1,18 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n                WITH insert_components AS (\n                    INSERT INTO components (name, amount)\n                    VALUES ($1, $2)\n                    RETURNING id\n                ),\n                insert_scores AS (\n                    INSERT INTO scores (name, value)\n                    SELECT * FROM UNNEST($3::text[], $4::double precision[])\n                    -- Update if already in table. This isn't great, but \n                    -- otherwise RETURNING won't return anything.\n                    ON CONFLICT (name, value) DO UPDATE\n                    SET value = EXCLUDED.value, name = EXCLUDED.name\n                    RETURNING id\n                ),\n                insert_components_scores AS (\n                    INSERT INTO components_scores (component_id, score_id)\n                    SELECT (SELECT id FROM insert_components), id\n                    FROM insert_scores\n                )\n                INSERT INTO records_components (record_id, component_id)\n                SELECT $5, (SELECT id from insert_components) \n                ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Int8",
+        "TextArray",
+        "Float8Array",
+        "Int4"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "50c6776ca37b9b56b92848573f32d72f44631c9ff702bb468dc7a7f5520a6f48"
+}

--- a/auditor/.sqlx/query-520d88dec0363b824ca4af064510c2e837819eb7877850ff8077643a5bdbe3e2.json
+++ b/auditor/.sqlx/query-520d88dec0363b824ca4af064510c2e837819eb7877850ff8077643a5bdbe3e2.json
@@ -1,0 +1,26 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        INSERT INTO accounting (\n            record_id, start_time, stop_time, runtime, updated_at\n        )\n        SELECT * FROM UNNEST($1::text[], $2::timestamptz[], $3::timestamptz[], $4::bigint[], $5::timestamptz[])\n        RETURNING id;\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Int4"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "TextArray",
+        "TimestamptzArray",
+        "TimestamptzArray",
+        "Int8Array",
+        "TimestamptzArray"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "520d88dec0363b824ca4af064510c2e837819eb7877850ff8077643a5bdbe3e2"
+}

--- a/auditor/src/lib.rs
+++ b/auditor/src/lib.rs
@@ -73,7 +73,7 @@
 //! # }
 //! ```
 //!
-//! ## Pushing records to Auditor
+//! ## Pushing one record to Auditor
 //!
 //! Assuming that a record and a client were already created,
 //! the record can be pushed to Auditor with
@@ -95,6 +95,29 @@
 //! # Ok(())
 //! # }
 //! ```
+//!
+//!  ## Pushing multiple records to AuditorClientBuilder
+//!
+//!  Assuming that list of records and a client were already created,
+//!  the records can be pushed to Auditor with_ymd_and_hms
+//!
+//! # use auditor::client::{AuditorClientBuilder, ClientError};
+//! # use auditor::domain::RecordAdd;
+//! # use chrono::{DateTime, TimeZone, Utc};
+//! # use std::collections::HashMap;
+//! # #[tokio::main]
+//! # async fn main() -> Result<(), anyhow::Error> {
+//! # let client = AuditorClientBuilder::new()
+//! #     .address(&"localhost", 8000)
+//! #     .timeout(20)
+//! #     .build()?;
+//! # let start_time: DateTime<Utc> = Utc.with_ymd_and_hms(2023, 1, 1, 0, 0, 0).unwrap();
+//! # let records: Vec<RecordAdd> = (0..5)
+//! #    .map(|i| RecordAdd::new(&format!("record-{}", i), HashMap::new(), vec![], start_time))
+//! #    .collect();
+//! client.bulk_insert(&records).await?;
+//! # Ok(())
+//! # }
 //!
 //! ## Updating records in Auditor
 //!

--- a/auditor/src/routes/add.rs
+++ b/auditor/src/routes/add.rs
@@ -182,6 +182,138 @@ pub async fn add_record(record: &RecordAdd, pool: &PgPool) -> Result<(), AddReco
     }
 }
 
+#[tracing::instrument(name = "Adding multiple records to the database", skip(records, pool))]
+pub async fn bulk_add(
+    records: web::Json<Vec<RecordAdd>>,
+    pool: web::Data<PgPool>,
+) -> Result<HttpResponse, AddError> {
+    bulk_insert(&records, &pool)
+        .await
+        .map_err(|e| match e.0.as_database_error() {
+            Some(db_err) => match db_err.code().as_ref() {
+                Some(code) => match code.as_ref() {
+                    "23505" => AddError::RecordExists,
+                    _ => AddError::UnexpectedError(e.into()),
+                },
+                _ => AddError::UnexpectedError(e.into()),
+            },
+            _ => AddError::UnexpectedError(e.into()),
+        })?;
+    Ok(HttpResponse::Ok().finish())
+}
+
+#[tracing::instrument(name = "Inserting bulk records into database", skip(records, pool))]
+pub async fn bulk_insert(records: &Vec<RecordAdd>, pool: &PgPool) -> Result<(), AddRecordError> {
+    let mut transaction = match pool.begin().await {
+        Ok(transaction) => transaction,
+        Err(e) => return Err(AddRecordError(e)),
+    };
+
+    let record_ids: Vec<_> = records
+        .iter()
+        .map(|r| r.record_id.as_ref().to_string())
+        .collect();
+    let start_times: Vec<_> = records.iter().map(|r| r.start_time).collect();
+    let stop_times: Vec<_> = records.iter().map(|r| r.stop_time).collect();
+    let runtimes: Vec<_> = records
+        .iter()
+        .map(|r| r.stop_time.map(|stop| (stop - r.start_time).num_seconds()))
+        .collect();
+    let updated_at_vec: Vec<_> = std::iter::repeat(Utc::now()).take(records.len()).collect();
+
+    let ids = sqlx::query_unchecked!(
+        r#"
+        INSERT INTO accounting (
+            record_id, start_time, stop_time, runtime, updated_at
+        )
+        SELECT * FROM UNNEST($1::text[], $2::timestamptz[], $3::timestamptz[], $4::bigint[], $5::timestamptz[])
+        RETURNING id;
+        "#,
+        &record_ids[..],
+        &start_times[..],
+        &stop_times[..],
+        &runtimes[..],
+        &updated_at_vec[..],
+    )
+    .fetch_all(&mut *transaction)
+    .await
+    .map_err(AddRecordError)?;
+
+    for (record, id) in records.iter().zip(ids.iter()) {
+        for component in record.components.iter() {
+            let (names, scores): (Vec<String>, Vec<f64>) = component
+                .scores
+                .iter()
+                .map(|s| (s.name.as_ref().to_string(), s.value.as_ref()))
+                .unzip();
+
+            sqlx::query_unchecked!(
+                r#"
+                WITH insert_components AS (
+                    INSERT INTO components (name, amount)
+                    VALUES ($1, $2)
+                    RETURNING id
+                ),
+                insert_scores AS (
+                    INSERT INTO scores (name, value)
+                    SELECT * FROM UNNEST($3::text[], $4::double precision[])
+                    -- Update if already in table. This isn't great, but 
+                    -- otherwise RETURNING won't return anything.
+                    ON CONFLICT (name, value) DO UPDATE
+                    SET value = EXCLUDED.value, name = EXCLUDED.name
+                    RETURNING id
+                ),
+                insert_components_scores AS (
+                    INSERT INTO components_scores (component_id, score_id)
+                    SELECT (SELECT id FROM insert_components), id
+                    FROM insert_scores
+                )
+                INSERT INTO records_components (record_id, component_id)
+                SELECT $5, (SELECT id from insert_components) 
+                "#,
+                component.name.as_ref(),
+                component.amount,
+                &names[..],
+                &scores[..],
+                &id.id,
+            )
+            .execute(&mut *transaction)
+            .await
+            .map_err(AddRecordError)?;
+        }
+
+        if let Some(data) = record.meta.as_ref() {
+            let data = data.to_vec();
+
+            let (rid, names, values): (Vec<String>, Vec<String>, Vec<String>) =
+                itertools::multiunzip(data.into_iter().flat_map(|(k, v)| {
+                    v.into_iter()
+                        .map(|v| (record.record_id.as_ref().to_string(), k.clone(), v))
+                        .collect::<Vec<_>>()
+                }));
+
+            sqlx::query!(
+                r#"
+                INSERT INTO meta (record_id, key, value)
+                SELECT * FROM UNNEST($1::text[], $2::text[], $3::text[])
+                "#,
+                &rid[..],
+                &names[..],
+                &values[..],
+            )
+            .execute(&mut *transaction)
+            .await
+            .map_err(AddRecordError)?;
+        }
+    }
+
+    if let Err(e) = transaction.commit().await {
+        return Err(AddRecordError(e));
+    } else {
+        return Ok(());
+    }
+}
+
 pub struct AddRecordError(sqlx::Error);
 
 debug_for_error!(AddRecordError);

--- a/auditor/src/startup.rs
+++ b/auditor/src/startup.rs
@@ -6,7 +6,7 @@
 // copied, modified, or distributed except according to those terms.
 
 use crate::metrics::{DatabaseMetricsWatcher, PrometheusExporterBuilder, PrometheusExporterConfig};
-use crate::routes::{add, health_check, query_one_record, query_records, update};
+use crate::routes::{add, bulk_add, health_check, query_one_record, query_records, update};
 use actix_web::dev::Server;
 use actix_web::{web, App, HttpServer};
 use actix_web_opentelemetry::{PrometheusMetricsHandler, RequestMetrics};
@@ -48,6 +48,7 @@ pub fn run(
             )
             .route("/record/{record_id}", web::get().to(query_one_record))
             // DB connection pool
+            .service(web::resource("/records").route(web::post().to(bulk_add)))
             .app_data(db_pool.clone())
     })
     .listen(listener)?

--- a/auditor/tests/api/add.rs
+++ b/auditor/tests/api/add.rs
@@ -160,3 +160,169 @@ async fn add_returns_a_500_for_duplicate_records() {
     let response = app.add_record(&record).await;
     assert_eq!(500, response.status().as_u16());
 }
+
+#[tokio::test]
+async fn bulk_insert_records() {
+    let app = spawn_app().await;
+
+    let records: Vec<RecordTest> = (0..100).map(|_| Faker.fake()).collect();
+
+    let response = app.bulk_insert(&records).await;
+
+    assert_eq!(200, response.status().as_u16());
+
+    for record in records {
+        let saved = sqlx::query_as!(
+            RecordDatabase,
+            r#"SELECT a.record_id,
+                      m.meta as "meta: Vec<(String, Vec<String>)>",
+                      css.components as "components: Vec<Component>",
+                      a.start_time as "start_time?",
+                      a.stop_time,
+                      a.runtime
+               FROM accounting a
+               LEFT JOIN (
+                   WITH subquery AS (
+                       SELECT m.record_id as record_id, m.key as key, array_agg(m.value) as values
+                       FROM meta as m
+                       WHERE m.record_id = $1
+                       GROUP BY m.record_id, m.key
+                   )
+                   SELECT s.record_id as record_id, array_agg(row(s.key, s.values)) as meta
+                   FROM subquery as s
+                   GROUP BY s.record_id
+                   ) m ON m.record_id = a.record_id
+               LEFT JOIN (
+                   WITH subquery AS (
+                      SELECT 
+                          c.id as cid,
+                          COALESCE(array_agg(row(s.name, s.value)::score) FILTER (WHERE s.name IS NOT NULL AND s.value IS NOT NULL), '{}'::score[]) as scores
+                      FROM components as c
+                      LEFT JOIN components_scores as cs
+                      ON c.id = cs.component_id
+                      LEFT JOIN scores as s
+                      ON cs.score_id = s.id
+                      GROUP BY c.id
+                   )
+                   SELECT rc.record_id as id, array_agg(row(c.name, c.amount, sq.scores)::component) as components
+                   FROM records_components AS rc
+                   LEFT JOIN components as c
+                   ON rc.component_id = c.id
+                   LEFT JOIN subquery AS sq
+                   ON sq.cid = rc.component_id
+                   GROUP BY rc.record_id
+               ) css ON css.id = a.id
+               WHERE a.record_id = $1
+            "#,
+            record.record_id.as_ref().unwrap(),
+        )
+        .fetch_one(&app.db_pool)
+        .await
+        .expect("Failed to fetch data")
+        .try_into()
+        .expect("Failed to convert from RecordDatabase to Record");
+
+        assert_eq!(record, saved);
+    }
+}
+
+#[tokio::test]
+async fn bulk_insert_returns_a_400_for_invalid_json_data() {
+    let app = spawn_app().await;
+
+    let forbidden_strings: Vec<String> = ['/', '(', ')', '"', '<', '>', '\\', '{', '}']
+        .into_iter()
+        .map(|s| format!("test{s}test"))
+        .collect();
+
+    for _field in ["record_id"] {
+        for fs in forbidden_strings.iter() {
+            let records: Vec<RecordTest> = (0..100)
+                .map(|_| {
+                    let mut record: RecordTest = Faker.fake();
+                    record.record_id = Some(fs.clone());
+                    record
+                })
+                .collect();
+
+            let response = app.bulk_insert(&records).await;
+
+            assert_eq!(400, response.status().as_u16());
+
+            let saved: Vec<_> = sqlx::query!(r#"SELECT record_id FROM accounting"#,)
+                .fetch_all(&app.db_pool)
+                .await
+                .expect("Failed to fetch data");
+
+            assert_eq!(saved.len(), 0);
+        }
+    }
+}
+
+#[tokio::test]
+async fn bulk_insert_returns_a_400_when_data_is_missing() {
+    let app = spawn_app().await;
+
+    let test_cases = vec![
+        ("record_id is missing", {
+            let records: Vec<RecordTest> = (0..2)
+                .map(|_| {
+                    let mut record: RecordTest = Faker.fake();
+                    record.record_id = None;
+                    record
+                })
+                .collect();
+            records
+        }),
+        ("components is missing", {
+            let records: Vec<RecordTest> = (0..2)
+                .map(|_| {
+                    let mut record: RecordTest = Faker.fake();
+                    record.components = None;
+                    record
+                })
+                .collect();
+            records
+        }),
+        ("start_time is missing", {
+            let records: Vec<RecordTest> = (0..2)
+                .map(|_| {
+                    let mut record: RecordTest = Faker.fake();
+                    record.start_time = None;
+                    record
+                })
+                .collect();
+            records
+        }),
+    ];
+
+    for (error_message, invalid_body) in test_cases {
+        let response = app.add_record(&invalid_body).await;
+
+        assert_eq!(
+            400,
+            response.status().as_u16(),
+            "The API did not fail with 400 Bad Request when the payload was {error_message}."
+        );
+
+        let saved: Vec<_> = sqlx::query!(r#"SELECT record_id FROM accounting"#,)
+            .fetch_all(&app.db_pool)
+            .await
+            .expect("Failed to fetch data");
+
+        assert_eq!(saved.len(), 0);
+    }
+}
+
+#[tokio::test]
+async fn bulk_insert_returns_a_500_for_duplicate_records() {
+    let app = spawn_app().await;
+
+    let records: Vec<RecordTest> = (0..2).map(|_| Faker.fake()).collect();
+
+    let response = app.bulk_insert(&records).await;
+    assert_eq!(200, response.status().as_u16());
+
+    let response = app.bulk_insert(&records).await;
+    assert_eq!(500, response.status().as_u16());
+}

--- a/auditor/tests/api/helpers.rs
+++ b/auditor/tests/api/helpers.rs
@@ -44,6 +44,16 @@ impl TestApp {
             .expect("Failed to execute request.")
     }
 
+    pub async fn bulk_insert<T: serde::Serialize>(&self, record: &T) -> reqwest::Response {
+        reqwest::Client::new()
+            .post(&format!("{}/records", &self.address))
+            .header("Content-Type", "application/json")
+            .json(record)
+            .send()
+            .await
+            .expect("Failed to execute request.")
+    }
+
     pub async fn get_records(&self) -> reqwest::Response {
         reqwest::Client::new()
             .get(&format!("{}/record", &self.address))

--- a/pyauditor/docs/examples.rst
+++ b/pyauditor/docs/examples.rst
@@ -98,6 +98,14 @@ Assuming that a record and a client were already created, the record can be push
 
    await client.add(record)
 
+Pushing a list of records to Auditor
+==================================
+
+Assuming that a list of records and a client were already created, the record can be pushed to Auditor like this:
+
+.. code-block:: python
+
+   await client.bulk_insert(records)
 
 Updating records in Auditor
 ===========================

--- a/pyauditor/scripts/test_bulk_insert.py
+++ b/pyauditor/scripts/test_bulk_insert.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+
+import asyncio
+from pyauditor import AuditorClientBuilder, Record
+import datetime
+from tzlocal import get_localzone
+
+
+async def main():
+    local_tz = get_localzone()
+    print("LOCAL TIMEZONE: " + str(local_tz))
+
+    client = AuditorClientBuilder().address("127.0.0.1", 8000).timeout(10).build()
+
+    print("Testing /health_check endpoint")
+    health = await client.health_check()
+    assert health
+
+    print("get should not return anything because there are no records in Auditor yet")
+    empty_array = await client.get()
+    assert len(empty_array) == 0
+
+    print("Adding a record to Auditor")
+    record_id = "record-1"
+
+    # datetimes sent to auditor MUST BE in UTC.
+    start = datetime.datetime(
+        2021, 12, 6, 16, 29, 43, 79043, tzinfo=local_tz
+    ).astimezone(datetime.timezone.utc)
+    record = Record(record_id, start)
+
+    records = [record]
+
+    await client.bulk_insert(records)
+
+    print("Asserting that record in auditor db is correct")
+    records = await client.get()
+    assert len(records) == 1
+    record = records[0]
+    assert record.record_id == record_id
+    assert record.start_time.replace(tzinfo=datetime.timezone.utc) == start
+
+    print("Updating record: Adding stop time")
+    stop = datetime.datetime.now(tz=local_tz).astimezone(datetime.timezone.utc)
+
+    record = record.with_stop_time(stop)
+    await client.update(record)
+
+    print("Asserting that record in auditor db is correct")
+    records = await client.get()
+    assert len(records) == 1
+    record = records[0]
+    assert record.record_id == record_id
+    assert record.start_time.replace(tzinfo=datetime.timezone.utc) == start
+    assert record.stop_time.replace(tzinfo=datetime.timezone.utc) == stop
+
+    print("Script test_add_update.py finished.")
+
+
+if __name__ == "__main__":
+    import time
+
+    s = time.perf_counter()
+    asyncio.run(main())
+    elapsed = time.perf_counter() - s
+    print(f"{__file__} executed in {elapsed:0.2f} seconds.")

--- a/pyauditor/scripts/test_bulk_insert_blocking.py
+++ b/pyauditor/scripts/test_bulk_insert_blocking.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+
+from pyauditor import AuditorClientBuilder, Record
+import datetime
+from tzlocal import get_localzone
+
+
+def main():
+    local_tz = get_localzone()
+    print("LOCAL TIMEZONE: " + str(local_tz))
+
+    client = (
+        AuditorClientBuilder().address("127.0.0.1", 8000).timeout(10).build_blocking()
+    )
+
+    print("Testing /health_check endpoint")
+    health = client.health_check()
+    assert health
+
+    print("get should not return anything because there are no records in Auditor yet")
+    empty_array = client.get()
+    assert len(empty_array) == 0
+
+    print("Adding a record to Auditor")
+    record_id = "record-1"
+
+    # datetimes sent to auditor MUST BE in UTC.
+    start = datetime.datetime(
+        2021, 12, 6, 16, 29, 43, 79043, tzinfo=local_tz
+    ).astimezone(datetime.timezone.utc)
+
+    record = Record(record_id, start)
+
+    records = [record]
+
+    client.bulk_insert(records)
+
+    print("Asserting that record in auditor db is correct")
+    records = client.get()
+    assert len(records) == 1
+    record = records[0]
+    assert record.record_id == record_id
+    assert record.start_time.replace(tzinfo=datetime.timezone.utc) == start
+
+    print("Updating record: Adding stop time")
+    stop = datetime.datetime.now(tz=local_tz).astimezone(datetime.timezone.utc)
+
+    record = record.with_stop_time(stop)
+    client.update(record)
+
+    print("Asserting that record in auditor db is correct")
+    records = client.get()
+    assert len(records) == 1
+    record = records[0]
+    assert record.record_id == record_id
+    assert record.start_time.replace(tzinfo=datetime.timezone.utc) == start
+    assert record.stop_time.replace(tzinfo=datetime.timezone.utc) == stop
+
+    print("Script test_add_update.py finished.")
+
+
+if __name__ == "__main__":
+    import time
+
+    s = time.perf_counter()
+    main()
+    elapsed = time.perf_counter() - s
+    print(f"{__file__} executed in {elapsed:0.2f} seconds.")

--- a/pyauditor/src/blocking_client.rs
+++ b/pyauditor/src/blocking_client.rs
@@ -121,6 +121,19 @@ impl AuditorClientBlocking {
             .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(format!("{e}")))
     }
 
+    /// add(record: Record)
+    /// Push a list of records to the Auditor instance
+    fn bulk_insert(&self, records: Vec<Record>) -> PyResult<()> {
+        let bulk_insert_records: Result<Vec<auditor::domain::RecordAdd>, anyhow::Error> = records
+            .into_iter()
+            .map(|r| auditor::domain::RecordAdd::try_from(r.inner))
+            .collect();
+
+        self.inner
+            .bulk_insert(&bulk_insert_records?)
+            .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(format!("{e}")))
+    }
+
     /// update(record: Record)
     /// Update an existing record in the Auditor instance
     fn update(&self, record: Record) -> PyResult<()> {


### PR DESCRIPTION
This closes #580 

Bulk insertion of records is implemented for auditor. This allows list of records to be passed as an argument to auditor client and pyauditor methods. 
Added unit test, API tests for auditor and pyauditor client.

Created new end point called /records - this will be used to perform bulk operations (in the future, this can be extended to update as well using PUT method)

Written doc strings and tutorial to use bulk_insert functionality. 

Added CHANGELOG.md