### PR TITLE
replace all URL encodings in meta fields and add feature to configure style of summary message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Auditor: Return correct status code for errors during querying of records (#620) ([@raghuvar-vijay](https://github.com/raghuvar-vijay))
 - CI: Added new workflow to define reusable parameters for other workflows ([@dirksammel](https://github.com/dirksammel))
 - Docs: Add versioning of GitHub Pages and pyauditor docs (#551) ([@QuantumDancer](https://github.com/QuantumDancer)
+- Apel plugin: Add optional config setting for style of summary message ([@dirksammel](https://github.com/dirksammel))
 
 ### Changed
 - Auditor+pyauditor: Deprecate `get_started_since()` and `get_stopped_since()` functions ([@raghuvar-vijay](https://github.com/raghuvar-vijay))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Dependencies: Update wiremock from 0.5.21 to 0.5.22 ([@QuantumDancer](https://github.com/QuantumDancer))
 - CI: Replace unmaintained actions-rs/audit-check action with maintained one from rustsec ([@QuantumDancer](https://github.com/QuantumDancer))
 - CI: Introduce dependency between pyauditor release and release of python packages ([@dirksammel](https://github.com/dirksammel))
+- Apel plugin: Replace all URL encodings in meta fields with single-character equivalent ([@dirksammel](https://github.com/dirksammel))
 
 ### Removed
 

--- a/plugins/apel/src/auditor_apel_plugin/core.py
+++ b/plugins/apel/src/auditor_apel_plugin/core.py
@@ -12,6 +12,7 @@ from time import sleep
 import json
 import sys
 import requests
+import urllib
 from cryptography import x509
 from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.serialization import pkcs7
@@ -154,7 +155,7 @@ def update_time_db(conn, stop_time, report_time):
 
 
 def replace_record_string(string):
-    updated_string = string.replace("%2F", "/")
+    updated_string = urllib.parse.unquote(string)
 
     return updated_string
 

--- a/plugins/apel/src/auditor_apel_plugin/core.py
+++ b/plugins/apel/src/auditor_apel_plugin/core.py
@@ -577,8 +577,22 @@ def group_sync_db(sync_db):
     return grouped_sync_list
 
 
-def create_summary(grouped_summary_list):
-    summary = "APEL-summary-job-message: v0.3\n"
+def create_summary(config, grouped_summary_list):
+    apel_style = config["site"].get("apel_style", "Test")
+
+    if apel_style == "APEL-v0.2":
+        summary = "APEL-summary-job-message: v0.2\n"
+    elif apel_style == "APEL-v0.3":
+        summary = "APEL-summary-job-message: v0.3\n"
+    elif apel_style == "ARC":
+        summary = "APEL-summary-job-message: v0.2\n"
+    elif apel_style == "Test":
+        summary = "APEL-summary-job-message: v0.3\n"
+    else:
+        logging.critical(
+            f"No such style: {apel_style}, please fix apel_style in the config"
+        )
+        raise ValueError
 
     for entry in grouped_summary_list:
         summary += f"Site: {entry['site']}\n"
@@ -587,23 +601,29 @@ def create_summary(grouped_summary_list):
         if entry["user"] is not None:
             summary += f"GlobalUserName: {entry['user']}\n"
         if entry["vo"] is not None:
-            summary += f"VO: {entry['vo']}\n"
+            if apel_style == "APEL-v0.2":
+                summary += f"Group: {entry['vo']}\n"
+            else:
+                summary += f"VO: {entry['vo']}\n"
         if entry["vogroup"] is not None:
             summary += f"VOGroup: {entry['vogroup']}\n"
         if entry["vorole"] is not None:
             summary += f"VORole: {entry['vorole']}\n"
-        summary += f"SubmitHost: {entry['submithost']}\n"
-        summary += f"Infrastructure: {entry['infrastructure']}\n"
-        summary += f"Processors: {entry['cpucount']}\n"
-        summary += f"NodeCount: {entry['nodecount']}\n"
+        if apel_style != "APEL-v0.2":
+            summary += f"SubmitHost: {entry['submithost']}\n"
+            summary += f"Infrastructure: {entry['infrastructure']}\n"
+            summary += f"Processors: {entry['cpucount']}\n"
+            summary += f"NodeCount: {entry['nodecount']}\n"
         summary += f"EarliestEndTime: {entry['min_stoptime']}\n"
         summary += f"LatestEndTime: {entry['max_stoptime']}\n"
         summary += f"WallDuration : {int(entry['runtime'])}\n"
         summary += f"CpuDuration: {int(entry['cputime'])}\n"
-        summary += f"NormalisedWallDuration: {int(entry['norm_runtime'])}\n"
-        summary += f"NormalisedCpuDuration: {int(entry['norm_cputime'])}\n"
-        summary += f"ServiceLevelType: {entry['benchmarktype']}\n"
-        summary += f"ServiceLevel: {entry['benchmarkvalue']}\n"
+        if apel_style != "ARC":
+            summary += f"NormalisedWallDuration: {int(entry['norm_runtime'])}\n"
+            summary += f"NormalisedCpuDuration: {int(entry['norm_cputime'])}\n"
+        if apel_style in ["ARC", "Test"]:
+            summary += f"ServiceLevelType: {entry['benchmarktype']}\n"
+            summary += f"ServiceLevel: {entry['benchmarkvalue']}\n"
         summary += f"NumberOfJobs: {entry['jobcount']}\n"
         summary += "%%\n"
 

--- a/plugins/apel/src/auditor_apel_plugin/publish.py
+++ b/plugins/apel/src/auditor_apel_plugin/publish.py
@@ -84,7 +84,7 @@ def run(config, client):
         logging.debug(f"Latest stop time is {latest_stop_time}")
         summary_db = create_summary_db(config, records_summary)
         grouped_summary_list = group_summary_db(summary_db)
-        summary = create_summary(grouped_summary_list)
+        summary = create_summary(config, grouped_summary_list)
         logging.debug(summary)
         signed_summary = sign_msg(config, summary)
         logging.debug(signed_summary)

--- a/plugins/apel/src/auditor_apel_plugin/republish.py
+++ b/plugins/apel/src/auditor_apel_plugin/republish.py
@@ -34,7 +34,7 @@ def run(config, client, args):
 
     summary_db = create_summary_db(config, records)
     grouped_summary_list = group_summary_db(summary_db, filter_by=(month, year, site))
-    summary = create_summary(grouped_summary_list)
+    summary = create_summary(config, grouped_summary_list)
     logging.debug(summary)
     signed_summary = sign_msg(config, summary)
     logging.debug(signed_summary)

--- a/plugins/apel/tests/test_auditor_apel_plugin.py
+++ b/plugins/apel/tests/test_auditor_apel_plugin.py
@@ -900,12 +900,16 @@ class TestAuditorApelPlugin:
     def test_replace_record_string(self):
         test_str_1 = "abcd"
         test_str_2 = "%2Fa%2Fb%2Fc%2Fd%2F"
+        test_str_3 = "El%20Ni%C3%B1o"
 
         result = replace_record_string(test_str_1)
         assert result == "abcd"
 
         result = replace_record_string(test_str_2)
         assert result == "/a/b/c/d/"
+
+        result = replace_record_string(test_str_3)
+        assert result == "El Niño"
 
     def test_get_records(self):
         client = FakeAuditorClient("pass")


### PR DESCRIPTION
This PR adds the replacement of all URL encodings in the meta fields. Previously, only "%2F" was replaced, but a problem with the record format of the HTCondor collector was discovered.
Additionally, a (test-)feature to configure the style of the summary message that is sent to APEL is added. The default is the current style.