### PR TITLE
Bump serde from 1.0.193 to 1.0.195

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Dependencies: Update once_cell from 1.18.0 to 1.19.0 ([@QuantumDancer](https://github.com/QuantumDancer))
 - Dependencies: Update opentelemetry_sdk from 0.21.1 to 0.21.2 ([@QuantumDancer](https://github.com/QuantumDancer))
 - Dependencies: Update reqwest from 0.11.22 to 0.11.23 ([@QuantumDancer](https://github.com/QuantumDancer))
+- Dependencies: Update serde from 1.0.193 to 1.0.195 ([@QuantumDancer](https://github.com/QuantumDancer))
 - Dependencies: Update serde-aux from 4.2.0 to 4.3.1 ([@QuantumDancer](https://github.com/QuantumDancer))
 - Dependencies: Update serde_json from 1.0.108 to 1.0.111 ([@QuantumDancer](https://github.com/QuantumDancer))
 - Dependencies: Update serde_qs from 0.11.0 to 0.12.0 ([@QuantumDancer](https://github.com/QuantumDancer)

--- a/collectors/slurm/Cargo.toml
+++ b/collectors/slurm/Cargo.toml
@@ -40,7 +40,7 @@ tracing-subscriber = { version = "0.3" }
 uuid = { version = "1.6", features = ["v4"] }
 fake = { version = "2.9", features = ["chrono"] }
 config = "0.13.4"
-serde = { version = "1.0.193", features = ["derive"] }
+serde = { version = "1.0.195", features = ["derive"] }
 serde-aux = "4.3.1"
 itertools = "0.12.0"
 regex = "1.10.2"


### PR DESCRIPTION
Didn't see that #615 also included the serde update. After merging #615 the serde PR (#616) got automatically closed.

This PR adds the missing changelog message and also updates serde for the slurm collector.