### PR TITLE
fix: Add advanced_query to pyauditor blocking client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Dependencies: Update thiserror from 1.0.50 to 1.0.56 ([@QuantumDancer](https://github.com/QuantumDancer))
 - Dependencies: Update tokio from 1.34.0 to 1.35.1 ([@QuantumDancer](https://github.com/QuantumDancer))
 - Dependencies: Update wiremock from 0.5.21 to 0.5.22 ([@QuantumDancer](https://github.com/QuantumDancer))
+- Dependencies: Update h2 from 0.3.22 to 0.3.24 ([@raghuvar-vijay](https://github.com/raghuvar-vijay))
 - CI: Replace unmaintained actions-rs/audit-check action with maintained one from rustsec ([@QuantumDancer](https://github.com/QuantumDancer))
 - CI: Introduce dependency between pyauditor release and release of python packages ([@dirksammel](https://github.com/dirksammel))
 - Apel plugin: Replace all URL encodings in meta fields with single-character equivalent ([@dirksammel](https://github.com/dirksammel))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1211,9 +1211,9 @@ checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
 name = "h2"
-version = "0.3.22"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d6250322ef6e60f93f9a2162799302cd6f68f79f6e5d85c8c16f14d1d958178"
+checksum = "bb2c4422095b67ee78da96fbb51a4cc413b3b25883c7717ff7ca1ab31022c9c9"
 dependencies = [
  "bytes",
  "fnv",

--- a/pyauditor/scripts/test_advanced_query_blocking.py
+++ b/pyauditor/scripts/test_advanced_query_blocking.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+
+
+from pyauditor import AuditorClientBuilder, Record, Meta, Component, Score, SortBy
+import datetime
+from tzlocal import get_localzone
+from pyauditor import (
+    Operator,
+    QueryBuilder,
+    Value,
+    MetaOperator,
+    MetaQuery,
+    ComponentQuery,
+)
+
+
+def main():
+    local_tz = get_localzone()
+    print("LOCAL TIMEZONE: " + str(local_tz))
+
+    client = (
+        AuditorClientBuilder().address("127.0.0.1", 8000).timeout(10).build_blocking()
+    )
+
+    print("Testing /health_check endpoint")
+    health = client.health_check()
+    assert health
+
+    print("get should not return anything because there are not records in Auditor yet")
+    empty_array = client.get()
+    assert len(empty_array) == 0
+
+    print("Adding a records to Auditor")
+
+    for i in range(0, 24):
+        record_id = f"record-{i:02d}"
+
+        # datetimes sent to auditor MUST BE in UTC.
+        start = datetime.datetime(2022, 8, 8, i, 0, 0, 0, tzinfo=datetime.timezone.utc)
+        stop = datetime.datetime(2022, 8, 9, i, 0, 0, 0, tzinfo=datetime.timezone.utc)
+        meta = (
+            Meta()
+            .insert("site_id", ["site_A"])
+            .insert("group_id", ["group_1"])
+            .insert("nodes", ["node1", "node2"])
+        )
+        score1 = Score("HEPSPEC", 1.0)
+        component1 = Component("comp-1", 10).with_score(score1)
+
+        record = (
+            Record(record_id, start)
+            .with_stop_time(stop)
+            .with_meta(meta)
+            .with_component(component1)
+        )
+
+        client.add(record)
+
+    print("Check if all records made it to Auditor")
+
+    all_records = client.get()
+    assert len(all_records) == 24
+
+    print("Checking advanced queries")
+    start_time = datetime.datetime(
+        2022, 8, 8, 11, 30, 0, 0, tzinfo=datetime.timezone.utc
+    )
+    value = Value.set_datetime(start_time)
+    operator = Operator().gt(value)
+    query_string = QueryBuilder().with_start_time(operator).build()
+
+    records = client.advanced_query(query_string)
+    assert len(records) == 12
+
+    stop_time = datetime.datetime(
+        2022, 8, 8, 11, 30, 0, 0, tzinfo=datetime.timezone.utc
+    )
+    value = Value.set_datetime(stop_time)
+    operator = Operator().gt(value)
+    query_string = QueryBuilder().with_start_time(operator).build()
+
+    records = client.advanced_query(query_string)
+    assert len(records) == 12
+
+    start_time = datetime.datetime(
+        2022, 8, 8, 11, 30, 0, 0, tzinfo=datetime.timezone.utc
+    )
+    stop_time = datetime.datetime(
+        2022, 8, 8, 11, 30, 0, 0, tzinfo=datetime.timezone.utc
+    )
+    value1 = Value.set_datetime(start_time)
+    value2 = Value.set_datetime(stop_time)
+    operator1 = Operator().gt(value1)
+    operator2 = Operator().gt(value2)
+    query_string = (
+        QueryBuilder().with_start_time(operator1).with_stop_time(operator2).build()
+    )
+
+    records = client.advanced_query(query_string)
+    assert len(records) == 12
+
+    start_time1 = datetime.datetime(
+        2022, 8, 8, 11, 30, 0, 0, tzinfo=datetime.timezone.utc
+    )
+    start_time2 = datetime.datetime(
+        2022, 8, 8, 15, 30, 0, 0, tzinfo=datetime.timezone.utc
+    )
+    value1 = Value.set_datetime(start_time1)
+    value2 = Value.set_datetime(start_time2)
+    operator = Operator().gt(value1).lt(value2)
+    query_string = QueryBuilder().with_start_time(operator).build()
+
+    records = client.advanced_query(query_string)
+    assert len(records) == 4
+
+    meta_operator = MetaOperator().contains("group_1")
+    meta_query = MetaQuery().meta_operator("group_id", meta_operator)
+    records = QueryBuilder().with_meta_query(meta_query).build()
+
+    records = client.advanced_query(records)
+    record = records[0]
+    assert record.meta.get("group_id") == ["group_1"]
+    assert len(records) == 24
+
+    value = Value.set_count(4)
+    component_operator = Operator().equals(value)
+    component_query = ComponentQuery().component_operator("cpu", component_operator)
+    query_string = QueryBuilder().with_component_query(component_query).build()
+
+    records = client.advanced_query(query_string)
+    record = records[0]
+    assert record.components[0].name == "comp-1"
+    assert record.components[0].amount == 10
+    assert record.components[0].scores[0].name == "HEPSPEC"
+    assert record.components[0].scores[0].value == 1.0
+    assert len(records) == 24
+
+    sort_by = SortBy().descending("start_time")
+    query_string = QueryBuilder().sort_by(sort_by).build()
+
+    records = client.advanced_query(query_string)
+    assert len(records) == 24
+
+    for i in range(0, 24):
+        assert records[i].record_id == f"record-{23-i:02d}"
+
+    query_string = QueryBuilder().limit(4).build()
+
+    records = client.advanced_query(query_string)
+    assert len(records) == 4
+
+    query_string = QueryBuilder().with_record_id(f"record-{3:02d}").build()
+
+    records = client.advanced_query(query_string)
+    assert len(records) == 1
+
+
+if __name__ == "__main__":
+    import time
+
+    s = time.perf_counter()
+    main()
+    elapsed = time.perf_counter() - s
+    print(f"{__file__} executed in {elapsed:0.2f} seconds.")

--- a/pyauditor/src/blocking_client.rs
+++ b/pyauditor/src/blocking_client.rs
@@ -113,6 +113,32 @@ impl AuditorClientBlocking {
             .collect::<Vec<_>>())
     }
 
+    /// advanced_query(query_string: string)
+    /// Get records from the database depending on the query parameters
+    ///
+    /// :param query_string: query_string constructed with QueryBuilder using .build() method
+    /// :type query_string: string
+    ///
+    /// **Example**
+    ///
+    /// .. code-block:: python
+    ///
+    ///     value1 = Value.set_datetime(start_time)
+    ///     value2 = Value.set_datetime(stop_time)
+    ///     operator1 = Operator().gt(value1)
+    ///     operator2 = Operator().gt(value2)
+    ///     query_string = QueryBuilder().with_start_time(operator1).with_stop_time(operator2).build()
+    ///     records = client.advanced_query(record)
+    fn advanced_query(self_: PyRef<'_, Self>, query_string: String) -> PyResult<Vec<Record>> {
+        Ok(self_
+            .inner
+            .advanced_query(query_string)
+            .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(format!("{e}")))?
+            .into_iter()
+            .map(Record::from)
+            .collect::<Vec<_>>())
+    }
+
     /// add(record: Record)
     /// Push a record to the Auditor instance
     fn add(&self, record: Record) -> PyResult<()> {


### PR DESCRIPTION
Advanced query is missing in pyauditor blocking client. 

The above functionality is added along with unit tests. 

Bump h2 from 0.3.22 to  0.3.24