### PR TITLE
Fix: Incorrect meta and component queries returns an empty vector and…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Auditor+pyauditor: Deprecate `get_started_since()` and `get_stopped_since()` functions ([@raghuvar-vijay](https://github.com/raghuvar-vijay))
 - Auditor: Restructure `/record` endpoint to handle single record operations and `/records` endpoint to handle multiple records operations (#629) ([@raghuvar-vijay](https://github.com/raghuvar-vijay))
+- Auditor: Incorrect meta and component query returns an empty vector and implement more edge case testing for advanced queries (#638) ([@raghuvar-vijay](https://github.com/raghuvar-vijay))
 - Dependencies: Update actions/setup-python from 4 to 5 ([@dirksammel](https://github.com/dirksammel))
 - Dependencies: Update actions/download-artifact from 3 to 4 ([@dirksammel](https://github.com/dirksammel))
 - Dependencies: Update actions/upload-artifact from 3 to 4 ([@dirksammel](https://github.com/dirksammel))

--- a/pyauditor/scripts/test_advanced_query.py
+++ b/pyauditor/scripts/test_advanced_query.py
@@ -54,10 +54,34 @@ async def main():
 
         await client.add(record)
 
+    for i in range(0, 10):
+        record_id = f"record2-{i:02d}"
+
+        # datetimes sent to auditor MUST BE in UTC.
+        start = datetime.datetime(2023, 8, 8, i, 0, 0, 0, tzinfo=datetime.timezone.utc)
+        stop = datetime.datetime(2023, 8, 9, i, 0, 0, 0, tzinfo=datetime.timezone.utc)
+        meta = (
+            Meta()
+            .insert("site_id", ["site_B"])
+            .insert("group_id", ["group_2"])
+            .insert("nodes", ["node1", "node2"])
+        )
+        score2 = Score("HEPSPEC", 1.0)
+        component2 = Component("comp-2", 8).with_score(score2)
+
+        record = (
+            Record(record_id, start)
+            .with_stop_time(stop)
+            .with_meta(meta)
+            .with_component(component2)
+        )
+
+        await client.add(record)
+
     print("Check if all records made it to Auditor")
 
     all_records = await client.get()
-    assert len(all_records) == 24
+    assert len(all_records) == 34
 
     print("Checking advanced queries")
     start_time = datetime.datetime(
@@ -68,7 +92,7 @@ async def main():
     query_string = QueryBuilder().with_start_time(operator).build()
 
     records = await client.advanced_query(query_string)
-    assert len(records) == 12
+    assert len(records) == 22
 
     stop_time = datetime.datetime(
         2022, 8, 8, 11, 30, 0, 0, tzinfo=datetime.timezone.utc
@@ -78,13 +102,13 @@ async def main():
     query_string = QueryBuilder().with_start_time(operator).build()
 
     records = await client.advanced_query(query_string)
-    assert len(records) == 12
+    assert len(records) == 22
 
     start_time = datetime.datetime(
         2022, 8, 8, 11, 30, 0, 0, tzinfo=datetime.timezone.utc
     )
     stop_time = datetime.datetime(
-        2022, 8, 8, 11, 30, 0, 0, tzinfo=datetime.timezone.utc
+        2022, 8, 9, 11, 30, 0, 0, tzinfo=datetime.timezone.utc
     )
     value1 = Value.set_datetime(start_time)
     value2 = Value.set_datetime(stop_time)
@@ -95,7 +119,7 @@ async def main():
     )
 
     records = await client.advanced_query(query_string)
-    assert len(records) == 12
+    assert len(records) == 22
 
     start_time1 = datetime.datetime(
         2022, 8, 8, 11, 30, 0, 0, tzinfo=datetime.timezone.utc
@@ -120,9 +144,23 @@ async def main():
     assert record.meta.get("group_id") == ["group_1"]
     assert len(records) == 24
 
-    value = Value.set_count(4)
+    meta_operator = MetaOperator().contains("group_2")
+    meta_query = MetaQuery().meta_operator("group_id", meta_operator)
+    records = QueryBuilder().with_meta_query(meta_query).build()
+
+    records = await client.advanced_query(records)
+    assert len(records) == 10
+
+    meta_operator = MetaOperator().contains("placeholder")
+    meta_query = MetaQuery().meta_operator("group_id", meta_operator)
+    records = QueryBuilder().with_meta_query(meta_query).build()
+
+    records = await client.advanced_query(records)
+    assert len(records) == 0
+
+    value = Value.set_count(10)
     component_operator = Operator().equals(value)
-    component_query = ComponentQuery().component_operator("cpu", component_operator)
+    component_query = ComponentQuery().component_operator("comp-1", component_operator)
     query_string = QueryBuilder().with_component_query(component_query).build()
 
     records = await client.advanced_query(query_string)
@@ -133,14 +171,37 @@ async def main():
     assert record.components[0].scores[0].value == 1.0
     assert len(records) == 24
 
+    value = Value.set_count(8)
+    component_operator = Operator().equals(value)
+    component_query = ComponentQuery().component_operator("comp-2", component_operator)
+    query_string = QueryBuilder().with_component_query(component_query).build()
+
+    records = await client.advanced_query(query_string)
+    record = records[0]
+    assert record.components[0].name == "comp-2"
+    assert record.components[0].amount == 8
+    assert record.components[0].scores[0].name == "HEPSPEC"
+    assert record.components[0].scores[0].value == 1.0
+    assert len(records) == 10
+
+    value = Value.set_count(8)
+    component_operator = Operator().equals(value)
+    component_query = ComponentQuery().component_operator(
+        "placeholder", component_operator
+    )
+    query_string = QueryBuilder().with_component_query(component_query).build()
+
+    records = await client.advanced_query(query_string)
+    assert len(records) == 0
+
     sort_by = SortBy().descending("start_time")
     query_string = QueryBuilder().sort_by(sort_by).build()
 
     records = await client.advanced_query(query_string)
-    assert len(records) == 24
+    assert len(records) == 34
 
-    for i in range(0, 24):
-        assert records[i].record_id == f"record-{23-i:02d}"
+    for i in range(0, 10):
+        assert records[i].record_id == f"record2-{9-i:02d}"
 
     query_string = QueryBuilder().limit(4).build()
 

--- a/pyauditor/scripts/test_advanced_query_blocking.py
+++ b/pyauditor/scripts/test_advanced_query_blocking.py
@@ -56,10 +56,34 @@ def main():
 
         client.add(record)
 
+    for i in range(0, 10):
+        record_id = f"record2-{i:02d}"
+
+        # datetimes sent to auditor MUST BE in UTC.
+        start = datetime.datetime(2023, 8, 8, i, 0, 0, 0, tzinfo=datetime.timezone.utc)
+        stop = datetime.datetime(2023, 8, 9, i, 0, 0, 0, tzinfo=datetime.timezone.utc)
+        meta = (
+            Meta()
+            .insert("site_id", ["site_B"])
+            .insert("group_id", ["group_2"])
+            .insert("nodes", ["node1", "node2"])
+        )
+        score2 = Score("HEPSPEC", 1.0)
+        component2 = Component("comp-2", 8).with_score(score2)
+
+        record = (
+            Record(record_id, start)
+            .with_stop_time(stop)
+            .with_meta(meta)
+            .with_component(component2)
+        )
+
+        client.add(record)
+
     print("Check if all records made it to Auditor")
 
     all_records = client.get()
-    assert len(all_records) == 24
+    assert len(all_records) == 34
 
     print("Checking advanced queries")
     start_time = datetime.datetime(
@@ -70,7 +94,7 @@ def main():
     query_string = QueryBuilder().with_start_time(operator).build()
 
     records = client.advanced_query(query_string)
-    assert len(records) == 12
+    assert len(records) == 22
 
     stop_time = datetime.datetime(
         2022, 8, 8, 11, 30, 0, 0, tzinfo=datetime.timezone.utc
@@ -80,13 +104,13 @@ def main():
     query_string = QueryBuilder().with_start_time(operator).build()
 
     records = client.advanced_query(query_string)
-    assert len(records) == 12
+    assert len(records) == 22
 
     start_time = datetime.datetime(
         2022, 8, 8, 11, 30, 0, 0, tzinfo=datetime.timezone.utc
     )
     stop_time = datetime.datetime(
-        2022, 8, 8, 11, 30, 0, 0, tzinfo=datetime.timezone.utc
+        2022, 8, 9, 11, 30, 0, 0, tzinfo=datetime.timezone.utc
     )
     value1 = Value.set_datetime(start_time)
     value2 = Value.set_datetime(stop_time)
@@ -97,7 +121,7 @@ def main():
     )
 
     records = client.advanced_query(query_string)
-    assert len(records) == 12
+    assert len(records) == 22
 
     start_time1 = datetime.datetime(
         2022, 8, 8, 11, 30, 0, 0, tzinfo=datetime.timezone.utc
@@ -122,9 +146,23 @@ def main():
     assert record.meta.get("group_id") == ["group_1"]
     assert len(records) == 24
 
-    value = Value.set_count(4)
+    meta_operator = MetaOperator().contains("group_2")
+    meta_query = MetaQuery().meta_operator("group_id", meta_operator)
+    records = QueryBuilder().with_meta_query(meta_query).build()
+
+    records = client.advanced_query(records)
+    assert len(records) == 10
+
+    meta_operator = MetaOperator().contains("placeholder")
+    meta_query = MetaQuery().meta_operator("group_id", meta_operator)
+    records = QueryBuilder().with_meta_query(meta_query).build()
+
+    records = client.advanced_query(records)
+    assert len(records) == 0
+
+    value = Value.set_count(10)
     component_operator = Operator().equals(value)
-    component_query = ComponentQuery().component_operator("cpu", component_operator)
+    component_query = ComponentQuery().component_operator("comp-1", component_operator)
     query_string = QueryBuilder().with_component_query(component_query).build()
 
     records = client.advanced_query(query_string)
@@ -135,14 +173,39 @@ def main():
     assert record.components[0].scores[0].value == 1.0
     assert len(records) == 24
 
+    value = Value.set_count(8)
+    component_operator = Operator().equals(value)
+    component_query = ComponentQuery().component_operator("comp-2", component_operator)
+    query_string = QueryBuilder().with_component_query(component_query).build()
+
+    records = client.advanced_query(query_string)
+    record = records[0]
+    assert record.components[0].name == "comp-2"
+    assert record.components[0].amount == 8
+    assert record.components[0].scores[0].name == "HEPSPEC"
+    assert record.components[0].scores[0].value == 1.0
+    assert len(records) == 10
+
+    value = Value.set_count(8)
+    component_operator = Operator().equals(value)
+    component_query = ComponentQuery().component_operator(
+        "placeholder", component_operator
+    )
+    query_string = QueryBuilder().with_component_query(component_query).build()
+    records = client.advanced_query(query_string)
+    assert len(records) == 0
+
+    records = client.advanced_query(query_string)
+    assert len(records) == 0
+
     sort_by = SortBy().descending("start_time")
     query_string = QueryBuilder().sort_by(sort_by).build()
 
     records = client.advanced_query(query_string)
-    assert len(records) == 24
+    assert len(records) == 34
 
-    for i in range(0, 24):
-        assert records[i].record_id == f"record-{23-i:02d}"
+    for i in range(0, 10):
+        assert records[i].record_id == f"record2-{9-i:02d}"
 
     query_string = QueryBuilder().limit(4).build()
 


### PR DESCRIPTION
… add more edge case testing

This closes (#638)

Meta and component queries are returning all records if the query string doesn't match the records. 

This is fixed by adding the meta and component fields to the if clause in advanced_record_filters. It allows the query to be performed if any of the fields is present in the query. 

The component query is changed slightly. Now, we are un-nesting the component column and then checking if the component names and the values match the query string.

Additional edge case testing are added to both the clients in python. 