### PR TITLE
feat: Implement prepared sql queries using push_bind for advanced fil…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Auditor+pyauditor: Deprecate `get_started_since()` and `get_stopped_since()` functions ([@raghuvar-vijay](https://github.com/raghuvar-vijay))
 - Auditor: Restructure `/record` endpoint to handle single record operations and `/records` endpoint to handle multiple records operations (#629) ([@raghuvar-vijay](https://github.com/raghuvar-vijay))
 - Auditor: Incorrect meta and component query returns an empty vector and implement more edge case testing for advanced queries (#638) ([@raghuvar-vijay](https://github.com/raghuvar-vijay))
+- Auditor: Implement prepared SQL queries using push_bind for advanced filtering (#637) ([@raghuvar-vijay](https://github.com/raghuvar-vijay))
 - Dependencies: Update actions/setup-python from 4 to 5 ([@dirksammel](https://github.com/dirksammel))
 - Dependencies: Update actions/download-artifact from 3 to 4 ([@dirksammel](https://github.com/dirksammel))
 - Dependencies: Update actions/upload-artifact from 3 to 4 ([@dirksammel](https://github.com/dirksammel))


### PR DESCRIPTION
…tering

This closes (#637 ).

push_bind is used to append values to the prepared sql queries. 

String and (u8, u64) types are replaced with validname and validamount type for filter struct in advanced_record_filters.rs