### PR TITLE
use advanced querying to apply filters when fetching records

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Breaking changes
 - API: Deprecate get_[started/stopped]_since endpoint (#525) ([@raghuvar-vijay](https://github.com/raghuvar-vijay))
+- Apel plugin: Remove `site_name_mapping` config parameter and change structure of `sites_to_report` config parameter ([@dirksammel](https://github.com/dirksammel))
 
 ### Security
 - [RUSTSEC-2023-0071]: Ignored, because vulnerable code is not actually used by us ([@QuantumDancer](https://github.com/QuantumDancer)
@@ -59,6 +60,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CI: Replace unmaintained actions-rs/audit-check action with maintained one from rustsec ([@QuantumDancer](https://github.com/QuantumDancer))
 - CI: Introduce dependency between pyauditor release and release of python packages ([@dirksammel](https://github.com/dirksammel))
 - Apel plugin: Replace all URL encodings in meta fields with single-character equivalent ([@dirksammel](https://github.com/dirksammel))
+- Apel plugin: Use advanced querying for filtering records ([@dirksammel](https://github.com/dirksammel))
 - Docs: Pyauditor- Fix pyauditor tutorial for creating new records (#631) ([@raghuvar-vijay](https://github.com/raghuvar-vijay))
 
 ### Removed

--- a/media/website/content/_index.md
+++ b/media/website/content/_index.md
@@ -561,35 +561,34 @@ options:
 
 The following fields need to be present in the config file:
 
-| Parameter             | Description                                                                                                                                                               |
-|-----------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `log_level`           | Can be set to `DEBUG`, `INFO`, `WARNING`, `ERROR`, or `CRITICAL` (with decreasing verbosity).                                                                             |
-| `time_db_path`        | Path of the `time.db`. The database should be located at a persistent path and stores the end time of the latest reported job, and the time of the latest report to APEL. |
-| `report_interval`     | Time in seconds between reports to APEL.                                                                                                                                  |
-| `publish_since`       | Date and time (UTC) after which jobs will be published. Only relevant for first run when no `time.db` is present yet.                                                     |
-| `sites_to_report`     | List of sites that will be reported. Uses the site name as stored in the AUDITOR records.                                                                                 |
-| `site_name_mapping`   | Maps the site name as stored in the AUDITOR record to the name of the site in the GOCDB.                                                                                  |
-| `default_submit_host` | Default submit host if this information is missing in the AUDITOR record.                                                                                                 |
-| `infrastructure_type` | Origin of the job, can be set to `grid` or `local`.                                                                                                                       |
-| `benchmark_type`      | Name of the benchmark that will be reported to APEL.                                                                                                                      |
-| `auditor_ip`          | IP of the AUDITOR instance.                                                                                                                                               |
-| `auditor_port`        | Port of the AUDITOR instance.                                                                                                                                             |
-| `auditor_timeout`     | Time in seconds after which the connection to the AUDITOR instance times out.                                                                                             |
-| `benchmark_name`      | Name of the `benchmark` field in the AUDITOR records.                                                                                                                     |
-| `cores_name`          | Name of the `cores` field in the AUDITOR records.                                                                                                                         |
-| `cpu_time_name`       | Name of the field that stores the total CPU time in the AUDITOR records.                                                                                                  |
-| `cpu_time_unit`       | Unit of total CPU time in the AUDITOR records, can be `seconds` or `milliseconds`.                                                                                        |
-| `nnodes_name`         | Name of the field that stores the number of nodes in the AUDITOR records.                                                                                                 |
-| `meta_key_site`       | Name of the field that stores the name of the site in the AUDITOR records.                                                                                                |
-| `meta_key_submithost` | Name of the field that stores the submithost in the AUDITOR records.                                                                                                      |
-| `meta_key_voms`       | Name of the field that stores the VOMS information in the AUDITOR records.                                                                                                |
-| `meta_key_user`       | Name of the field that stores the GlobalUserName in the AUDITOR records.                                                                                                  |
-| `auth_url`            | URL from which the APEL authentication token is received.                                                                                                                 |
-| `ams_url`             | URL to which the reports are sent.                                                                                                                                        |
-| `client_cert`         | Path of the host certificate.                                                                                                                                             |
-| `client_key`          | Path of the host key.                                                                                                                                                     |
-| `ca_path`             | Path of the local certificate folder.                                                                                                                                     |
-| `verify_ca`           | Controls the verification of the certificate of the APEL server. Can be set to `True` or `False` (the latter might be necessary for local test setups).                   |
+| Parameter             | Description                                                                                                                                                                   |
+|-----------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `log_level`           | Can be set to `DEBUG`, `INFO`, `WARNING`, `ERROR`, or `CRITICAL` (with decreasing verbosity).                                                                                 |
+| `time_db_path`        | Path of the `time.db`. The database should be located at a persistent path and stores the end time of the latest reported job, and the time of the latest report to APEL.     |
+| `report_interval`     | Time in seconds between reports to APEL.                                                                                                                                      |
+| `publish_since`       | Date and time (UTC) after which jobs will be published. Only relevant for first run when no `time.db` is present yet.                                                         |
+| `sites_to_report`     | Dictionary of the sites that will be reported. The keys are the names of the sites in the GOCDB, the values are lists of the corresponding site names in the AUDITOR records. |
+| `default_submit_host` | Default submit host if this information is missing in the AUDITOR record.                                                                                                     |
+| `infrastructure_type` | Origin of the job, can be set to `grid` or `local`.                                                                                                                           |
+| `benchmark_type`      | Name of the benchmark that will be reported to APEL.                                                                                                                          |
+| `auditor_ip`          | IP of the AUDITOR instance.                                                                                                                                                   |
+| `auditor_port`        | Port of the AUDITOR instance.                                                                                                                                                 |
+| `auditor_timeout`     | Time in seconds after which the connection to the AUDITOR instance times out.                                                                                                 |
+| `benchmark_name`      | Name of the `benchmark` field in the AUDITOR records.                                                                                                                         |
+| `cores_name`          | Name of the `cores` field in the AUDITOR records.                                                                                                                             |
+| `cpu_time_name`       | Name of the field that stores the total CPU time in the AUDITOR records.                                                                                                      |
+| `cpu_time_unit`       | Unit of total CPU time in the AUDITOR records, can be `seconds` or `milliseconds`.                                                                                            |
+| `nnodes_name`         | Name of the field that stores the number of nodes in the AUDITOR records.                                                                                                     |
+| `meta_key_site`       | Name of the field that stores the name of the site in the AUDITOR records.                                                                                                    |
+| `meta_key_submithost` | Name of the field that stores the submithost in the AUDITOR records.                                                                                                          |
+| `meta_key_voms`       | Name of the field that stores the VOMS information in the AUDITOR records.                                                                                                    |
+| `meta_key_user`       | Name of the field that stores the GlobalUserName in the AUDITOR records.                                                                                                      |
+| `auth_url`            | URL from which the APEL authentication token is received.                                                                                                                     |
+| `ams_url`             | URL to which the reports are sent.                                                                                                                                            |
+| `client_cert`         | Path of the host certificate.                                                                                                                                                 |
+| `client_key`          | Path of the host key.                                                                                                                                                         |
+| `ca_path`             | Path of the local certificate folder.                                                                                                                                         |
+| `verify_ca`           | Controls the verification of the certificate of the APEL server. Can be set to `True` or `False` (the latter might be necessary for local test setups).                       |
 
 Example config:
 
@@ -605,8 +604,7 @@ report_interval = 86400
 
 [site]
 publish_since = 2023-01-01 13:37:42+00:00
-sites_to_report = ["site1", "site2"]
-site_name_mapping = {"site1": "SITE-2-GOCDB", "site2": "SITE-2-GOCDB"}
+sites_to_report = {"SITE_A": ["site_id_1", "site_id_2"], "SITE_B": ["site_id_3"]}
 default_submit_host = gsiftp://accounting.grid_site.de:1337/jobs
 infrastructure_type = grid
 benchmark_type = hepscore23

--- a/media/website/content/migration.md
+++ b/media/website/content/migration.md
@@ -30,6 +30,21 @@ Auditor REST APIs are changed as shown in the table below.
 
 `/records` endpoint handles multiple and bulk record operations such as inserting bulk records and querying multiple records.
 
+## Apel plugin
+
+The config parameter `site_name_mapping` is removed and the structure of the config parameter `sites_to_report` is changed. `sites_to_report` is now a dictionary, where the keys are the site names as configured in the GOCDB, and the values are lists of the corresponding site names in the AUDITOR records.
+
+Before:
+```python
+sites_to_report = ["site_id_1", "site_id_2", "site_id_3"]
+site_name_mapping = {"site_id_1": "SITE_A", "site_id_2": "SITE_A", "site_id_3": "SITE_B"}
+```
+
+After:
+```python
+sites_to_report = {"SITE_A": ["site_id_1", "site_id_2"], "SITE_B": ["site_id_3"]}
+```
+
 ## Removed
 `/get_[started/stopped]_since` endpoint is removed due to the introduction of advanced query. The auditor client and pyauditor client still contains the get_started_since and get_stopped_since
 functions but throws a deprecated warning if used. 

--- a/plugins/apel/src/auditor_apel_plugin/publish.py
+++ b/plugins/apel/src/auditor_apel_plugin/publish.py
@@ -53,7 +53,7 @@ def run(config, client):
         start_time = get_start_time(time_db_conn)
         logging.info(f"Getting records since {start_time}")
 
-        records_summary = get_records(client, start_time, 30)
+        records_summary = get_records(config, client, start_time, 30)
 
         if len(records_summary) == 0:
             logging.info("No new records, do nothing for now")
@@ -66,18 +66,7 @@ def run(config, client):
             continue
 
         sites_to_report = check_sites_in_records(config, records_summary)
-
-        if not sites_to_report:
-            logging.info("No sites to report in the records, do nothing for now")
-            time_db_conn.close()
-            logging.info(
-                "Next report scheduled for "
-                f"{datetime.now() + timedelta(seconds=report_interval)}"
-            )
-            sleep(report_interval)
-            continue
-        else:
-            logging.info(f"Create reports for {sites_to_report}")
+        logging.info(f"Create reports for {sites_to_report}")
 
         latest_stop_time = records_summary[-1].stop_time.replace(tzinfo=timezone.utc)
 
@@ -96,7 +85,7 @@ def run(config, client):
         logging.debug(post_summary.status_code)
 
         begin_previous_month = get_begin_previous_month(current_time)
-        records_sync = get_records(client, begin_previous_month, 30)
+        records_sync = get_records(config, client, begin_previous_month, 30)
         sync_db = create_sync_db(config, records_sync)
         grouped_sync_list = group_sync_db(sync_db)
         sync = create_sync(grouped_sync_list)


### PR DESCRIPTION
This PR changes how records are filtered. Until now, all records since a given point in time where fetched, and then filtered for the sites that should be reported. With this PR, the filter is already applied when the records are fetched, using the new advanced querying feature.

Closes #600.