### PR TITLE
ci: fix releasing tagged webpage/pyauditor docs

### DIFF
--- a/.github/workflows/pyauditor_docs.yml
+++ b/.github/workflows/pyauditor_docs.yml
@@ -58,11 +58,19 @@ jobs:
       - name: Redirect latest to new release
         if: startsWith(github.ref, 'refs/tags/')
         run: |
-            echo "Redirecting latest to newly released version " $RELEASE_VERSION
+            echo "Redirecting latest to newly released version ${{ env.RELEASE_VERSION}}"
             rm -rf pyauditor/latest
             ln -s pyauditor/$RELEASE_VERSION pyauditor/latest
-            git add pyauditor/latest
-            git commit -m "CI: Redirect latest to new version $RELEASE_VERSION (pyauditor)"
+
+      - name: Commit changes
+        uses: EndBug/add-and-commit@v9
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          add: "pyauditor/latest"
+          message: "CI: Redirect latest to new version ${{ env.RELEASE_VERSION }} (pyauditor)"
+          default_author: "github_actions"
+          pathspec_error_handling: exitAtEnd
+
       - name: Push changes
         if: startsWith(github.ref, 'refs/tags/')
         uses: ad-m/github-push-action@master

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -46,6 +46,11 @@ jobs:
 
       # Only for tag push: Update latest to new release version
 
+      # The "cleanup old checkout" step is needed because of this bug: https://github.com/actions/checkout/issues/1014
+      - name: Cleanup old checkout
+        if: startsWith(github.ref, 'refs/tags/')
+        run: chmod +w -R ${GITHUB_WORKSPACE}; rm -rf ${GITHUB_WORKSPACE}/*;
+
       - name: Checkout gh-pages
         uses: actions/checkout@v4
         if: startsWith(github.ref, 'refs/tags/')
@@ -56,11 +61,18 @@ jobs:
       - name: Redirect latest to new release
         if: startsWith(github.ref, 'refs/tags/')
         run: |
-            echo "Redirecting latest to newly released version " $RELEASE_VERSION
+            echo "Redirecting latest to newly released version ${{ env.RELEASE_VERSION }}"
             rm -rf latest
             ln -s $RELEASE_VERSION latest
-            git add latest
-            git commit -m "CI: Redirect latest to new version $RELEASE_VERSION"
+
+      - name: Commit changes
+        uses: EndBug/add-and-commit@v9
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          add: "latest"
+          message: "CI: Redirect latest to new version ${{ env.RELEASE_VERSION }}"
+          default_author: "github_actions"
+          pathspec_error_handling: exitAtEnd
 
       - name: Push changes
         if: startsWith(github.ref, 'refs/tags/')


### PR DESCRIPTION
This fixes two issues that occur when releasing a tagged version of the webpage and pyauditor docs.

1. When building the zola webpage we need to check out the gh-pages branch to adjust the symlink. This fails with 

```
Copying '/home/runner/.gitconfig' to '/home/runner/work/_temp/f6b6dfa8-57ed-4845-99d6-49944acb70c0/.gitconfig'
Temporarily overriding HOME='/home/runner/work/_temp/f6b6dfa8-57ed-4845-99d6-49944acb70c0' before making global git config changes
Adding repository directory to the temporary git global config as a safe directory
/usr/bin/git config --global --add safe.directory /home/runner/work/AUDITOR/AUDITOR
/usr/bin/git config --local --get remote.origin.url
***github.com/ALU-Schumacher/AUDITOR.git
Deleting the contents of '/home/runner/work/AUDITOR/AUDITOR'
Error: File was unable to be removed Error: EACCES: permission denied, rmdir '/home/runner/work/AUDITOR/AUDITOR/media/website/public/about'
```

I found this workaround: https://github.com/actions/checkout/issues/1014#issuecomment-1906802802
Let's see if it works.

NB: We do a similar thing for the pyauditor docs. However, there this step does not fail.

2. After we adjust the symlink we need to push the changes to the `gh-pages` branch. This currently fails with

```
Author identity unknown

*** Please tell me who you are.

Run

  git config --global user.email "you@example.com"
  git config --global user.name "Your Name"

to set your account's default identity.
Omit --global to set the identity only in this repository.
```

Fix: Instead of manually creating the commit we are using now the [add-and-commit](https://github.com/marketplace/actions/add-commit) action which should supply author information. This fix is applied to both the zola docs and pyauditor docs.