### PR TITLE
Fix tagged webpage release

### DIFF
--- a/.github/workflows/pyauditor_docs.yml
+++ b/.github/workflows/pyauditor_docs.yml
@@ -57,10 +57,11 @@ jobs:
 
       - name: Redirect latest to new release
         if: startsWith(github.ref, 'refs/tags/')
+        working-directory: pyauditor
         run: |
             echo "Redirecting latest to newly released version ${{ env.RELEASE_VERSION}}"
-            rm -rf pyauditor/latest
-            ln -s pyauditor/$RELEASE_VERSION pyauditor/latest
+            rm -rf latest
+            ln -s $RELEASE_VERSION latest
 
       - name: Commit changes
         uses: EndBug/add-and-commit@v9

--- a/.github/workflows/pyauditor_docs.yml
+++ b/.github/workflows/pyauditor_docs.yml
@@ -8,7 +8,7 @@ on:
         type: string
 
 jobs:
-  pyauditor-docs:
+  build_and_push:
     runs-on: ubuntu-latest
     env:
       SQLX_OFFLINE: true
@@ -48,15 +48,21 @@ jobs:
 
       # Only for tag push: Update latest to new release version
 
+  update_latest:
+    if: startsWith(github.ref, 'refs/tags/')
+    needs: build_and_push
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set RELEASE_VERSION env
+        run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" | sed "s/main/edge/" >> $GITHUB_ENV
+
       - name: Checkout gh-pages
         uses: actions/checkout@v4
-        if: startsWith(github.ref, 'refs/tags/')
         with:
           ref: gh-pages
           fetch-depth: 0 # otherwise, you will failed to push refs to dest repo
 
       - name: Redirect latest to new release
-        if: startsWith(github.ref, 'refs/tags/')
         working-directory: pyauditor
         run: |
             echo "Redirecting latest to newly released version ${{ env.RELEASE_VERSION}}"
@@ -65,7 +71,6 @@ jobs:
 
       - name: Commit changes
         uses: EndBug/add-and-commit@v9
-        if: startsWith(github.ref, 'refs/tags/')
         with:
           add: "pyauditor/latest"
           message: "CI: Redirect latest to new version ${{ env.RELEASE_VERSION }} (pyauditor)"
@@ -73,7 +78,6 @@ jobs:
           pathspec_error_handling: exitAtEnd
 
       - name: Push changes
-        if: startsWith(github.ref, 'refs/tags/')
         uses: ad-m/github-push-action@master
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -27,7 +27,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Build only 
-        uses: shalzz/zola-deploy-action@master
+        uses: shalzz/zola-deploy-action@v0.18.0
         env:
           BUILD_DIR: media/website
           BUILD_ONLY: true

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -12,7 +12,7 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  build:
+  build_and_push:
     runs-on: ubuntu-latest
     steps:
       - name: Set RELEASE_VERSION env
@@ -44,22 +44,30 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           clean: false
 
-      # Only for tag push: Update latest to new release version
+  # Only for tag push: Update latest to new release version
 
-      # The "cleanup old checkout" step is needed because of this bug: https://github.com/actions/checkout/issues/1014
-      - name: Cleanup old checkout
-        if: startsWith(github.ref, 'refs/tags/')
-        run: chmod +w -R ${GITHUB_WORKSPACE}; rm -rf ${GITHUB_WORKSPACE}/*;
+  # This is split into a separate job because shalzz/zola-deploy-action uses a docker container to build the webpage
+  # which messes up the permissions of the output files
+  update_latest:
+    if: startsWith(github.ref, 'refs/tags/')
+    needs: build_and_push
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set RELEASE_VERSION env
+        run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" | sed "s/main/edge/" >> $GITHUB_ENV
+
+      - name: Get URL to GitHub Pages
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: echo "GITHUB_PAGES_URL=$(gh api repos/$GITHUB_REPOSITORY/pages --jq '.html_url')" >> $GITHUB_ENV
 
       - name: Checkout gh-pages
         uses: actions/checkout@v4
-        if: startsWith(github.ref, 'refs/tags/')
         with:
           ref: gh-pages
           fetch-depth: 0 # otherwise, you will failed to push refs to dest repo
 
       - name: Redirect latest to new release
-        if: startsWith(github.ref, 'refs/tags/')
         run: |
             echo "Redirecting latest to newly released version ${{ env.RELEASE_VERSION }}"
             rm -rf latest
@@ -67,7 +75,6 @@ jobs:
 
       - name: Commit changes
         uses: EndBug/add-and-commit@v9
-        if: startsWith(github.ref, 'refs/tags/')
         with:
           add: "latest"
           message: "CI: Redirect latest to new version ${{ env.RELEASE_VERSION }}"
@@ -75,7 +82,6 @@ jobs:
           pathspec_error_handling: exitAtEnd
 
       - name: Push changes
-        if: startsWith(github.ref, 'refs/tags/')
         uses: ad-m/github-push-action@master
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CI: Add extra workflow for building the pyaudtitor source distribution ([@dirksammel](https://github.com/dirksammel))
 - CI: Fix setting symlink to latest pyauditor tag ([@QuantumDancer](https://github.com/QuantumDancer))
 - CI: Split webpage building and symlink creation into two jobs ([@QuantumDancer](https://github.com/QuantumDancer))
+- CI: Use tagged version instead of master branch for zola deploy action ([@QuantumDancer](https://github.com/QuantumDancer))
 - Apel plugin: Replace all URL encodings in meta fields with single-character equivalent ([@dirksammel](https://github.com/dirksammel))
 - Apel plugin: Use advanced querying for filtering records ([@dirksammel](https://github.com/dirksammel))
 - Apel plugin: Rename summary record field `Infrastructure` to `InfrastructureType` ([@dirksammel](https://github.com/dirksammel))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CI: Introduce dependency between pyauditor release and release of python packages ([@dirksammel](https://github.com/dirksammel))
 - CI: Add extra workflow for building the pyaudtitor source distribution ([@dirksammel](https://github.com/dirksammel))
 - CI: Fix setting symlink to latest pyauditor tag ([@QuantumDancer](https://github.com/QuantumDancer))
+- CI: Split webpage building and symlink creation into two jobs ([@QuantumDancer](https://github.com/QuantumDancer))
 - Apel plugin: Replace all URL encodings in meta fields with single-character equivalent ([@dirksammel](https://github.com/dirksammel))
 - Apel plugin: Use advanced querying for filtering records ([@dirksammel](https://github.com/dirksammel))
 - Apel plugin: Rename summary record field `Infrastructure` to `InfrastructureType` ([@dirksammel](https://github.com/dirksammel))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CI: Replace unmaintained actions-rs/audit-check action with maintained one from rustsec ([@QuantumDancer](https://github.com/QuantumDancer))
 - CI: Introduce dependency between pyauditor release and release of python packages ([@dirksammel](https://github.com/dirksammel))
 - CI: Add extra workflow for building the pyaudtitor source distribution ([@dirksammel](https://github.com/dirksammel))
+- CI: Fix setting symlink to latest pyauditor tag ([@QuantumDancer](https://github.com/QuantumDancer))
 - Apel plugin: Replace all URL encodings in meta fields with single-character equivalent ([@dirksammel](https://github.com/dirksammel))
 - Apel plugin: Use advanced querying for filtering records ([@dirksammel](https://github.com/dirksammel))
 - Apel plugin: Rename summary record field `Infrastructure` to `InfrastructureType` ([@dirksammel](https://github.com/dirksammel))


### PR DESCRIPTION
This fixes several issues with releasing a tagged webpage version

- The symlink for the new pyauditor version was set wrong. This caused issues in the `gh-pages` branch, see e.g. https://github.com/ALU-Schumacher/AUDITOR/actions/runs/7781972676/job/21217447111. A manual interaction was needed to clean up the `gh-pages` branch, see #667.
- Updating the latest symlink to the new tag did not work because the zola webpage is built in a docker container without the proper `-u` flag, so the output files belong to `root`. This causes issues down the line when we want to checkout the `gh-pages` branch to update the symlink. This is resolved by splitting up the webpage building and symlink update into two separate jobs.
- Not really a breaking issue, but we are using now a tagged version instead of `master` for the zola deploy action