### PR TITLE
only include complete previous month in sync message if it is the first of the current month

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CI: Add workflow for building the Rust documentation ([@dirksammel](https://github.com/dirksammel))
 
 ### Changed
+- Apel plugin: Reduce unnecessary high number of records for sync messages ([@dirksammel](https://github.com/dirksammel))
 - Dependencies: Update actix-web from 4.4.1 to 4.5.1 ([@QuantumDancer](https://github.com/QuantumDancer))
 - Dependencies: Update anyhow from 1.0.79 to 1.0.80 ([@QuantumDancer](https://github.com/QuantumDancer))
 - Dependencies: Update chrono from 0.4.33 to 0.4.34 ([@QuantumDancer](https://github.com/QuantumDancer))

--- a/plugins/apel/src/auditor_apel_plugin/core.py
+++ b/plugins/apel/src/auditor_apel_plugin/core.py
@@ -84,6 +84,14 @@ def get_begin_previous_month(current_time):
     return begin_previous_month_utc
 
 
+def get_begin_current_month(current_time):
+    first_current_month = current_time.replace(day=1)
+    begin_current_month = datetime.combine(first_current_month, time())
+    begin_current_month_utc = begin_current_month.replace(tzinfo=timezone.utc)
+
+    return begin_current_month_utc
+
+
 def get_time_db(config):
     time_db_path = config["paths"].get("time_db_path")
     publish_since = config["site"].get("publish_since")

--- a/plugins/apel/src/auditor_apel_plugin/publish.py
+++ b/plugins/apel/src/auditor_apel_plugin/publish.py
@@ -23,6 +23,7 @@ from auditor_apel_plugin.core import (
     send_payload,
     update_time_db,
     get_begin_previous_month,
+    get_begin_current_month,
     create_sync_db,
     group_sync_db,
     create_sync,
@@ -84,8 +85,12 @@ def run(config, client):
         post_summary = send_payload(config, token, payload_summary)
         logging.debug(post_summary.status_code)
 
-        begin_previous_month = get_begin_previous_month(current_time)
-        records_sync = get_records(config, client, begin_previous_month, 30)
+        if current_time.day == 1:
+            begin_month = get_begin_previous_month(current_time)
+        else:
+            begin_month = get_begin_current_month(current_time)
+
+        records_sync = get_records(config, client, begin_month, 30)
         sync_db = create_sync_db(config, records_sync)
         grouped_sync_list = group_sync_db(sync_db)
         sync = create_sync(grouped_sync_list)

--- a/plugins/apel/tests/test_auditor_apel_plugin.py
+++ b/plugins/apel/tests/test_auditor_apel_plugin.py
@@ -1,6 +1,7 @@
 import pytest
 from auditor_apel_plugin.core import (
     get_begin_previous_month,
+    get_begin_current_month,
     create_time_db,
     get_time_db,
     sign_msg,
@@ -95,6 +96,16 @@ class TestAuditorApelPlugin:
 
         result = get_begin_previous_month(time_b)
         assert result == datetime(1969, 12, 1, 00, 00, 00, tzinfo=timezone.utc)
+
+    def test_get_begin_current_month(self):
+        time_a = datetime(2022, 10, 23, 12, 23, 55)
+        time_b = datetime(1970, 1, 1, 00, 00, 00)
+
+        result = get_begin_current_month(time_a)
+        assert result == datetime(2022, 10, 1, 00, 00, 00, tzinfo=timezone.utc)
+
+        result = get_begin_current_month(time_b)
+        assert result == datetime(1970, 1, 1, 00, 00, 00, tzinfo=timezone.utc)
 
     def test_create_time_db(self):
         path = ":memory:"


### PR DESCRIPTION
This PR improves the size of retrieved records for the sync message. The records for the complete previous month are only sent if it is the first day of the current month.
Closes #698.