### PR TITLE
Slurm collector: Decrease logging verbosity in info mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Apel plugin: Reduce unnecessary high number of records for sync messages ([@dirksammel](https://github.com/dirksammel))
+- Client: Reduce logging information in info mode (#680) ([@QuantumDancer](https://github.com/QuantumDancer))
+- Slurm collector: Reduce logging information in info mode (#680) ([@QuantumDancer](https://github.com/QuantumDancer))
 - Dependencies: Update actix-web from 4.4.1 to 4.5.1 ([@QuantumDancer](https://github.com/QuantumDancer))
 - Dependencies: Update actix-web-opentelemetry 0.16.0 to 0.17.0 ([@QuantumDancer](https://github.com/QuantumDancer))
 - Dependencies: Update anyhow from 1.0.79 to 1.0.81 ([@QuantumDancer](https://github.com/QuantumDancer))

--- a/auditor/src/client/mod.rs
+++ b/auditor/src/client/mod.rs
@@ -644,7 +644,8 @@ impl AuditorClient {
     #[tracing::instrument(
         name = "Sending a record to AUDITOR server.",
         skip(self, record),
-        fields(record_id = %record.record_id)
+        fields(record_id = %record.record_id),
+        level = "debug"
     )]
     pub async fn add(&self, record: &RecordAdd) -> Result<(), ClientError> {
         let response = self


### PR DESCRIPTION
These changes reduce the logging information in info mode (especially information related to individual records, which scales linearly with the amount of slurm jobs). Instead, more detailed information is now moved to debug mode.

Closes #680