### PR TITLE
use correct codecov token and revert to v3

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -71,9 +71,9 @@ jobs:
         run: cargo +nightly llvm-cov --doctests --all-features --workspace --lcov --output-path lcov.info
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v3
         with:
           files: lcov.info
           fail_ci_if_error: true
-          token: 0da88fa3-3a98-4f8b-ad19-9d0785b46db
+          token: ef0e698e-e1de-4603-88fa-b3d7c10fb0e1
           #${{ secrets.CODECOV_TOKEN }} doesn't work for PRs from forks

--- a/.github/workflows/python_unit_tests.yml
+++ b/.github/workflows/python_unit_tests.yml
@@ -33,9 +33,9 @@ jobs:
       - name: Run pytest
         run: pytest
       - name: Upload coverage
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v3
         with:
           files: ./plugins/apel/lcov.info
           fail_ci_if_error: true
-          token: 0da88fa3-3a98-4f8b-ad19-9d0785b46dbc
+          token: ef0e698e-e1de-4603-88fa-b3d7c10fb0e1
           #${{ secrets.CODECOV_TOKEN }} doesn't work for PRs from forks

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Dependencies: Update anyhow from 1.0.79 to 1.0.80 ([@QuantumDancer](https://github.com/QuantumDancer))
 - Dependencies: Update build from 1.0.3 to 1.1.1 ([@dirksammel](https://github.com/dirksammel))
 - Dependencies: Update chrono from 0.4.33 to 0.4.35 ([@QuantumDancer](https://github.com/QuantumDancer))
-- Dependencies: Update codecov/codecov-action from 3 to 4 ([@dirksammel](https://github.com/dirksammel))
 - Dependencies: Update cryptography from 42.0.2 to 42.0.5 ([@dirksammel](https://github.com/dirksammel))
 - Dependencies: Update iana-time-zone from 0.1.59 to 0.1.60 ([@QuantumDancer](https://github.com/QuantumDancer))
 - Dependencies: Update num-traits from 0.2.17 to 0.2.18 ([@QuantumDancer](https://github.com/QuantumDancer))

--- a/codecov.yaml
+++ b/codecov.yaml
@@ -27,7 +27,3 @@ component_management:
       name: priority_plugin
       paths:
         - plugins/priority/**
-
-codecov:
-  token: ef0e698e-e1de-4603-88fa-b3d7c10fb0e1
-  #${{ secrets.CODECOV_TOKEN }} doesn't work for PRs from forks

--- a/plugins/apel/codecov.yml
+++ b/plugins/apel/codecov.yml
@@ -2,5 +2,3 @@ coverage:
   status:
     patch: off
     project: off
-codecov: 
- token: 90cfa924-4216-4957-872b-4fc3db26ded5


### PR DESCRIPTION
This PR corrects the usage of the codecov token and reverts the action to v3 due to problems with v4.