### PR TITLE
Fix clippy warnings

### DIFF
--- a/auditor/src/client/mod.rs
+++ b/auditor/src/client/mod.rs
@@ -12,7 +12,6 @@ use crate::{
     domain::{Record, RecordAdd, RecordUpdate},
 };
 use chrono::{DateTime, Duration, Utc};
-use reqwest;
 use serde::Serialize;
 use std::collections::HashMap;
 use urlencoding::encode;

--- a/auditor/src/domain/meta.rs
+++ b/auditor/src/domain/meta.rs
@@ -11,8 +11,6 @@ use serde::{Deserialize, Serialize};
 
 use super::ValidName;
 
-use sqlx;
-
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Default)]
 pub struct ValidMeta(pub HashMap<ValidName, Vec<ValidName>>);
 

--- a/auditor/src/domain/record.rs
+++ b/auditor/src/domain/record.rs
@@ -13,11 +13,8 @@ use super::{Component, ComponentTest, Meta, ScoreTest, ValidMeta, ValidName};
 use anyhow::{Context, Error};
 use chrono::{DateTime, Utc};
 use fake::{Dummy, Fake, Faker, StringFaker};
-#[cfg(test)]
-use quickcheck;
 use rand::Rng;
 use serde::{Deserialize, Serialize};
-use sqlx;
 
 /// `RecordAdd` represents a single accountable unit that is added to Auditor.
 ///

--- a/auditor/src/routes/advanced_record_filters.rs
+++ b/auditor/src/routes/advanced_record_filters.rs
@@ -8,9 +8,9 @@
 use crate::domain::{Component, Record, RecordDatabase, ValidAmount, ValidName};
 use chrono::{DateTime, Utc};
 use core::fmt::Debug;
-use sqlx;
 use sqlx::{PgPool, QueryBuilder, Row};
 use std::collections::HashMap;
+use std::fmt::Display;
 
 #[derive(serde::Deserialize, Debug, Clone)]
 pub struct Filters {
@@ -72,13 +72,13 @@ pub enum SortField {
     RecordId,
 }
 
-impl ToString for SortField {
-    fn to_string(&self) -> String {
+impl Display for SortField {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            SortField::StartTime => String::from("start_time"),
-            SortField::StopTime => String::from("stop_time"),
-            SortField::Runtime => String::from("runtime"),
-            SortField::RecordId => String::from("record_id"),
+            SortField::StartTime => write!(f, "start_time"),
+            SortField::StopTime => write!(f, "stop_time"),
+            SortField::Runtime => write!(f, "runtime"),
+            SortField::RecordId => write!(f, "record_id"),
         }
     }
 }

--- a/auditor/src/routes/get.rs
+++ b/auditor/src/routes/get.rs
@@ -6,7 +6,6 @@
 // copied, modified, or distributed except according to those terms.
 
 use crate::domain::{Component, Record, RecordDatabase};
-use sqlx;
 use sqlx::PgPool;
 
 #[derive(thiserror::Error)]

--- a/auditor/src/routes/record_handlers.rs
+++ b/auditor/src/routes/record_handlers.rs
@@ -1,7 +1,6 @@
 use crate::routes::{advanced_record_filtering, get_one_record, Filters};
 use actix_web::{web, HttpRequest, HttpResponse, ResponseError};
 use serde_json::json;
-use sqlx;
 use sqlx::PgPool;
 use thiserror::Error;
 

--- a/auditor/src/routes/update.rs
+++ b/auditor/src/routes/update.rs
@@ -8,7 +8,6 @@
 use crate::domain::RecordUpdate;
 use actix_web::{web, HttpResponse};
 use chrono::Utc;
-use sqlx;
 use sqlx::PgPool;
 
 #[derive(thiserror::Error)]

--- a/plugins/priority/src/main.rs
+++ b/plugins/priority/src/main.rs
@@ -341,7 +341,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::configuration::{AuditorSettings, PrometheusMetricsOptions, PrometheusSettings};
+    use crate::configuration::{AuditorSettings, PrometheusSettings};
     use tracing_subscriber::filter::LevelFilter;
 
     #[test]

--- a/pyauditor/src/client.rs
+++ b/pyauditor/src/client.rs
@@ -11,7 +11,6 @@ use chrono::{DateTime, Utc};
 use pyo3::prelude::*;
 use pyo3::types::PyDateTime;
 use std::collections::HashMap;
-use std::convert::From;
 
 /// The `QueryBuilder` is used to construct `QueryParameters` using the builder pattern.
 #[pyclass]


### PR DESCRIPTION
This fixes the clippy warnings that appear in #718 due to a newer rust version being available (as a reminder: we use the beta toolchain for the CI that runs clippy)