### PR TITLE
Send summary per site and switch to JSON for storing times

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Breaking changes
+- Apel plugin: change config parameter `time_db_path` to `time_json_path`
 
 ### Security
 - [RUSTSEC-2024-0019]: Update mio from 0.8.10 to 0.8.11 ([@QuantumDancer](https://github.com/QuantumDancer))
@@ -19,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Apel plugin: Reduce unnecessary high number of records for sync messages ([@dirksammel](https://github.com/dirksammel))
+- Apel plugin: Send separate summary messages per site ([@dirksammel](https://github.com/dirksammel))
 - Client: Reduce logging information in info mode (#680) ([@QuantumDancer](https://github.com/QuantumDancer))
 - Slurm collector: Reduce logging information in info mode (#680) ([@QuantumDancer](https://github.com/QuantumDancer))
 - Dependencies: Update actix-web from 4.4.1 to 4.5.1 ([@QuantumDancer](https://github.com/QuantumDancer))

--- a/media/website/content/_index.md
+++ b/media/website/content/_index.md
@@ -561,34 +561,34 @@ options:
 
 The following fields need to be present in the config file:
 
-| Parameter             | Description                                                                                                                                                                   |
-|-----------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `log_level`           | Can be set to `DEBUG`, `INFO`, `WARNING`, `ERROR`, or `CRITICAL` (with decreasing verbosity).                                                                                 |
-| `time_db_path`        | Path of the `time.db`. The database should be located at a persistent path and stores the end time of the latest reported job, and the time of the latest report to APEL.     |
-| `report_interval`     | Time in seconds between reports to APEL.                                                                                                                                      |
-| `publish_since`       | Date and time (UTC) after which jobs will be published. Only relevant for first run when no `time.db` is present yet.                                                         |
-| `sites_to_report`     | Dictionary of the sites that will be reported. The keys are the names of the sites in the GOCDB, the values are lists of the corresponding site names in the AUDITOR records. |
-| `default_submit_host` | Default submit host if this information is missing in the AUDITOR record.                                                                                                     |
-| `infrastructure_type` | Origin of the job, can be set to `grid` or `local`.                                                                                                                           |
-| `benchmark_type`      | Name of the benchmark that will be reported to APEL.                                                                                                                          |
-| `auditor_ip`          | IP of the AUDITOR instance.                                                                                                                                                   |
-| `auditor_port`        | Port of the AUDITOR instance.                                                                                                                                                 |
-| `auditor_timeout`     | Time in seconds after which the connection to the AUDITOR instance times out.                                                                                                 |
-| `benchmark_name`      | Name of the `benchmark` field in the AUDITOR records.                                                                                                                         |
-| `cores_name`          | Name of the `cores` field in the AUDITOR records.                                                                                                                             |
-| `cpu_time_name`       | Name of the field that stores the total CPU time in the AUDITOR records.                                                                                                      |
-| `cpu_time_unit`       | Unit of total CPU time in the AUDITOR records, can be `seconds` or `milliseconds`.                                                                                            |
-| `nnodes_name`         | Name of the field that stores the number of nodes in the AUDITOR records.                                                                                                     |
-| `meta_key_site`       | Name of the field that stores the name of the site in the AUDITOR records.                                                                                                    |
-| `meta_key_submithost` | Name of the field that stores the submithost in the AUDITOR records.                                                                                                          |
-| `meta_key_voms`       | Name of the field that stores the VOMS information in the AUDITOR records.                                                                                                    |
-| `meta_key_user`       | Name of the field that stores the GlobalUserName in the AUDITOR records.                                                                                                      |
-| `auth_url`            | URL from which the APEL authentication token is received.                                                                                                                     |
-| `ams_url`             | URL to which the reports are sent.                                                                                                                                            |
-| `client_cert`         | Path of the host certificate.                                                                                                                                                 |
-| `client_key`          | Path of the host key.                                                                                                                                                         |
-| `ca_path`             | Path of the local certificate folder.                                                                                                                                         |
-| `verify_ca`           | Controls the verification of the certificate of the APEL server. Can be set to `True` or `False` (the latter might be necessary for local test setups).                       |
+| Parameter             | Description                                                                                                                                                                                  |
+|-----------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `log_level`           | Can be set to `DEBUG`, `INFO`, `WARNING`, `ERROR`, or `CRITICAL` (with decreasing verbosity).                                                                                                |
+| `time_json_path`      | Path of the `time.json` file. The JSON file should be located at a persistent path and stores the stop times of the latest reported job per site, and the time of the latest report to APEL. |
+| `report_interval`     | Time in seconds between reports to APEL.                                                                                                                                                     |
+| `publish_since`       | Date and time in ISO 8601 format (in UTC, hence add +00:00) after which jobs will be published. Only relevant for first run when no `time.json` is present yet.                              |
+| `sites_to_report`     | Dictionary of the sites that will be reported. The keys are the names of the sites in the GOCDB, the values are lists of the corresponding site names in the AUDITOR records.                |
+| `default_submit_host` | Default submit host if this information is missing in the AUDITOR record.                                                                                                                    |
+| `infrastructure_type` | Origin of the job, can be set to `grid` or `local`.                                                                                                                                          |
+| `benchmark_type`      | Name of the benchmark that will be reported to APEL.                                                                                                                                         |
+| `auditor_ip`          | IP of the AUDITOR instance.                                                                                                                                                                  |
+| `auditor_port`        | Port of the AUDITOR instance.                                                                                                                                                                |
+| `auditor_timeout`     | Time in seconds after which the connection to the AUDITOR instance times out.                                                                                                                |
+| `benchmark_name`      | Name of the `benchmark` field in the AUDITOR records.                                                                                                                                        |
+| `cores_name`          | Name of the `cores` field in the AUDITOR records.                                                                                                                                            |
+| `cpu_time_name`       | Name of the field that stores the total CPU time in the AUDITOR records.                                                                                                                     |
+| `cpu_time_unit`       | Unit of total CPU time in the AUDITOR records, can be `seconds` or `milliseconds`.                                                                                                           |
+| `nnodes_name`         | Name of the field that stores the number of nodes in the AUDITOR records.                                                                                                                    |
+| `meta_key_site`       | Name of the field that stores the name of the site in the AUDITOR records.                                                                                                                   |
+| `meta_key_submithost` | Name of the field that stores the submithost in the AUDITOR records.                                                                                                                         |
+| `meta_key_voms`       | Name of the field that stores the VOMS information in the AUDITOR records.                                                                                                                   |
+| `meta_key_user`       | Name of the field that stores the GlobalUserName in the AUDITOR records.                                                                                                                     |
+| `auth_url`            | URL from which the APEL authentication token is received.                                                                                                                                    |
+| `ams_url`             | URL to which the reports are sent.                                                                                                                                                           |
+| `client_cert`         | Path of the host certificate.                                                                                                                                                                |
+| `client_key`          | Path of the host key.                                                                                                                                                                        |
+| `ca_path`             | Path of the local certificate folder.                                                                                                                                                        |
+| `verify_ca`           | Controls the verification of the certificate of the APEL server. Can be set to `True` or `False` (the latter might be necessary for local test setups).                                      |
 
 Example config:
 
@@ -597,7 +597,7 @@ Example config:
 log_level = INFO
 
 [paths]
-time_db_path = /etc/auditor_apel_plugin/time.db
+time_json_path = /etc/auditor_apel_plugin/time.json
 
 [intervals]
 report_interval = 86400
@@ -638,10 +638,10 @@ When using the Docker container, `auditor-apel-publish` for example can be start
 docker run -it --rm --network host -u "$(id -u):$(id -g)" -v ./config_folder:/app/ aluschumacher/auditor-apel-plugin:edge auditor-apel-publish -c auditor_apel_plugin.cfg
 ```
 
-In this example, the local directory `config_folder` contains the config file `auditor_apel_plugin.cfg`, the client certificate `hostcert.pem`, and the client key `hostkey.pem`. The database `time.db` will also be written in `config_folder`. The corresponding entries in the config file would be:
+In this example, the local directory `config_folder` contains the config file `auditor_apel_plugin.cfg`, the client certificate `hostcert.pem`, and the client key `hostkey.pem`. The JSON file `time.json` will also be written in `config_folder`. The corresponding entries in the config file would be:
 
 ```
-time_db_path = time.db
+time_json_path = time.json
 client_cert = hostcert.pem
 client_key = hostkey.pem
 ```

--- a/media/website/content/migration.md
+++ b/media/website/content/migration.md
@@ -6,6 +6,22 @@ weight = 3
 
 # From 0.4.0 to 0.5.0
 
+## Apel plugin
+
+The stop times of the latest reported job per site and the time of the latest report to APEL are now stored in a JSON file instead of a SQLite database. Therefore, the config parameter `time_db_path` has to be changed to `time_json_path`.
+To migrate an existing database to a JSON file, run `migration-0_4_0-to-0_5_0.py` located in the `scripts` folder:
+
+```bash
+usage: migration-0_4_0-to-0_5_0.py [-h] -c CONFIG -d DB -j JSON
+
+options:
+  -h, --help            show this help message and exit
+  -c CONFIG, --config CONFIG
+                        Path to the config file
+  -d DB, --db DB        Path to the time database file
+  -j JSON, --json JSON  Path to the time JSON file
+```
+
 ## Development
 
 ### Update to [sqlx 0.7.4](https://github.com/launchbadge/sqlx/blob/main/sqlx-cli/README.md)

--- a/plugins/apel/.gitignore
+++ b/plugins/apel/.gitignore
@@ -4,6 +4,7 @@ venv/
 __pycache__/
 *egg-info/
 *.db
+*.json
 .coverage
 dist/
 build/

--- a/plugins/apel/scripts/migration-0_4_0-to-0_5_0.py
+++ b/plugins/apel/scripts/migration-0_4_0-to-0_5_0.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: © 2024 Dirk Sammel <dirk.sammel@gmail.com>
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+
+import configparser
+import argparse
+import sqlite3
+import json
+from datetime import datetime, timezone
+
+parser = argparse.ArgumentParser()
+parser.add_argument("-c", "--config", required=True, help="Path to the config file")
+parser.add_argument("-d", "--db", required=True, help="Path to the time database file")
+parser.add_argument("-j", "--json", required=True, help="Path to the time JSON file")
+args = parser.parse_args()
+
+config = configparser.ConfigParser()
+config.read(args.config)
+
+sites_to_report = json.loads(config["site"].get("sites_to_report")).keys()
+
+db_path = args.db
+json_path = args.json
+
+time_db = sqlite3.connect(
+    db_path,
+    detect_types=sqlite3.PARSE_DECLTYPES | sqlite3.PARSE_COLNAMES,
+)
+
+cur = time_db.cursor()
+cur.row_factory = lambda cursor, row: row[0]
+
+cur.execute("SELECT last_end_time FROM times")
+last_end_time_row = cur.fetchall()
+last_end_time = datetime.fromtimestamp(last_end_time_row[0], tz=timezone.utc)
+
+cur.execute("SELECT last_report_time FROM times")
+last_report_time_row = cur.fetchall()
+last_report_time = last_report_time_row[0]
+
+cur.close()
+time_db.close()
+
+time_dict = {
+    "last_report_time": last_report_time.isoformat(),
+    "site_end_times": {},
+}
+
+for site in sites_to_report:
+    time_dict["site_end_times"][site] = last_end_time.isoformat()
+
+with open(json_path, "w", encoding="utf-8") as f:
+    json.dump(time_dict, f)

--- a/plugins/apel/src/auditor_apel_plugin/publish.py
+++ b/plugins/apel/src/auditor_apel_plugin/publish.py
@@ -6,13 +6,14 @@
 import logging
 from pyauditor import AuditorClientBuilder
 from datetime import datetime, timedelta, timezone
+import json
 import configparser
 import argparse
 import base64
 from time import sleep
 from auditor_apel_plugin.core import (
     get_token,
-    get_time_db,
+    get_time_json,
     get_report_time,
     get_start_time,
     create_summary_db,
@@ -21,93 +22,89 @@ from auditor_apel_plugin.core import (
     sign_msg,
     build_payload,
     send_payload,
-    update_time_db,
+    update_time_json,
     get_begin_previous_month,
     get_begin_current_month,
     create_sync_db,
     group_sync_db,
     create_sync,
     get_records,
-    check_sites_in_records,
 )
 
 
 def run(config, client):
     report_interval = config["intervals"].getint("report_interval")
+    sites_to_report = json.loads(config["site"].get("sites_to_report"))
     token = get_token(config)
     logging.debug(token)
 
     while True:
-        time_db_conn = get_time_db(config)
-        last_report_time = get_report_time(time_db_conn)
+        time_dict = get_time_json(config)
+        last_report_time = get_report_time(time_dict)
         current_time = datetime.now()
         time_since_report = (current_time - last_report_time).total_seconds()
 
         if time_since_report < report_interval:
             logging.info("Not enough time since last report")
-            time_db_conn.close()
             sleep(report_interval - time_since_report)
             continue
         else:
             logging.info("Enough time since last report, create new report")
 
-        start_time = get_start_time(time_db_conn)
-        logging.info(f"Getting records since {start_time}")
+        for site in sites_to_report.keys():
+            logging.info(f"Getting records for {site}")
 
-        records_summary = get_records(config, client, start_time, 30)
+            start_time = get_start_time(config, time_dict, site)
+            logging.info(f"Getting records since {start_time}")
 
-        if len(records_summary) == 0:
-            logging.info("No new records, do nothing for now")
-            time_db_conn.close()
-            logging.info(
-                "Next report scheduled for "
-                f"{datetime.now() + timedelta(seconds=report_interval)}"
+            records_summary = get_records(config, client, start_time, 30, site=site)
+
+            if len(records_summary) == 0:
+                logging.info(f"No new records for {site}")
+                continue
+
+            latest_stop_time = records_summary[-1].stop_time.replace(
+                tzinfo=timezone.utc
             )
-            sleep(report_interval)
-            continue
 
-        sites_to_report = check_sites_in_records(config, records_summary)
-        logging.info(f"Create reports for {sites_to_report}")
+            logging.debug(f"Latest stop time is {latest_stop_time}")
+            summary_db = create_summary_db(config, records_summary)
+            grouped_summary_list = group_summary_db(summary_db)
+            summary = create_summary(config, grouped_summary_list)
+            logging.debug(summary)
+            signed_summary = sign_msg(config, summary)
+            logging.debug(signed_summary)
+            encoded_summary = base64.b64encode(signed_summary).decode("utf-8")
+            logging.debug(encoded_summary)
+            payload_summary = build_payload(encoded_summary)
+            logging.debug(payload_summary)
+            post_summary = send_payload(config, token, payload_summary)
+            logging.debug(post_summary.status_code)
 
-        latest_stop_time = records_summary[-1].stop_time.replace(tzinfo=timezone.utc)
+            if current_time.day == 1:
+                begin_month = get_begin_previous_month(current_time)
+            else:
+                begin_month = get_begin_current_month(current_time)
 
-        logging.debug(f"Latest stop time is {latest_stop_time}")
-        summary_db = create_summary_db(config, records_summary)
-        grouped_summary_list = group_summary_db(summary_db)
-        summary = create_summary(config, grouped_summary_list)
-        logging.debug(summary)
-        signed_summary = sign_msg(config, summary)
-        logging.debug(signed_summary)
-        encoded_summary = base64.b64encode(signed_summary).decode("utf-8")
-        logging.debug(encoded_summary)
-        payload_summary = build_payload(encoded_summary)
-        logging.debug(payload_summary)
-        post_summary = send_payload(config, token, payload_summary)
-        logging.debug(post_summary.status_code)
+            records_sync = get_records(config, client, begin_month, 30, site=site)
+            sync_db = create_sync_db(config, records_sync)
+            grouped_sync_list = group_sync_db(sync_db)
+            sync = create_sync(grouped_sync_list)
+            logging.debug(sync)
+            signed_sync = sign_msg(config, sync)
+            logging.debug(signed_sync)
+            encoded_sync = base64.b64encode(signed_sync).decode("utf-8")
+            logging.debug(encoded_sync)
+            payload_sync = build_payload(encoded_sync)
+            logging.debug(payload_sync)
+            post_sync = send_payload(config, token, payload_sync)
+            logging.debug(post_sync.status_code)
 
-        if current_time.day == 1:
-            begin_month = get_begin_previous_month(current_time)
-        else:
-            begin_month = get_begin_current_month(current_time)
+            latest_report_time = datetime.now()
+            update_time_json(
+                config, time_dict, site, latest_stop_time, latest_report_time
+            )
 
-        records_sync = get_records(config, client, begin_month, 30)
-        sync_db = create_sync_db(config, records_sync)
-        grouped_sync_list = group_sync_db(sync_db)
-        sync = create_sync(grouped_sync_list)
-        logging.debug(sync)
-        signed_sync = sign_msg(config, sync)
-        logging.debug(signed_sync)
-        encoded_sync = base64.b64encode(signed_sync).decode("utf-8")
-        logging.debug(encoded_sync)
-        payload_sync = build_payload(encoded_sync)
-        logging.debug(payload_sync)
-        post_sync = send_payload(config, token, payload_sync)
-        logging.debug(post_sync.status_code)
-
-        latest_report_time = datetime.now()
-        update_time_db(time_db_conn, latest_stop_time.timestamp(), latest_report_time)
-
-        time_db_conn.close()
         logging.info(
             "Next report scheduled for "
             f"{datetime.now() + timedelta(seconds=report_interval)}"

--- a/plugins/apel/src/auditor_apel_plugin/republish.py
+++ b/plugins/apel/src/auditor_apel_plugin/republish.py
@@ -27,11 +27,11 @@ def run(config, client, args):
     year = args.year
     site = args.site
 
-    begin_month = datetime(year, month, 1).replace(tzinfo=timezone.utc)
+    begin_month = datetime(year, month, 1, tzinfo=timezone.utc)
     if month == 12:
-        end_month = datetime(year + 1, 1, 1).replace(tzinfo=timezone.utc)
+        end_month = datetime(year + 1, 1, 1, tzinfo=timezone.utc)
     else:
-        end_month = datetime(year, month + 1, 1).replace(tzinfo=timezone.utc)
+        end_month = datetime(year, month + 1, 1, tzinfo=timezone.utc)
 
     records = get_records(config, client, begin_month, 30, site, end_month)
 


### PR DESCRIPTION
This PR changes the summary messages that are sent to APEL. Previously, the summaries for all sites were sent in one message. Now, one summary message per site is sent.
In addition, the latest report time and and latest stop time of reported jobs are now stored in a JSON file instead of an SQLite database file.