### PR TITLE
CI: Switch to stable toolchain for coverage

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -27,7 +27,6 @@ jobs:
       - name: Checkout repository,
         uses: actions/checkout@v4
 
-      - uses: dtolnay/rust-toolchain@nightly
       - uses: dtolnay/rust-toolchain@stable
 
       - name: Cache dependencies
@@ -68,7 +67,7 @@ jobs:
         uses: taiki-e/install-action@cargo-llvm-cov
 
       - name: Generate code coverage
-        run: cargo +nightly llvm-cov --doctests --all-features --workspace --lcov --output-path lcov.info
+        run: cargo llvm-cov --all-features --workspace --lcov --output-path lcov.info
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Dependencies: Update uuid from 1.7.0 to 1.8.0 ([@QuantumDancer](https://github.com/QuantumDancer))
 - Dependencies: Update wiremock from 0.5.22 to 0.6.0 ([@QuantumDancer](https://github.com/QuantumDancer))
 - CI: Remove deprecated options from cargo.deny (#709) ([@QuantumDancer](https://github.com/QuantumDancer))
+- CI: Switch to stable toolchain for coverage job ([@QuantumDancer](https://github.com/QuantumDancer))
 
 ### Removed
 


### PR DESCRIPTION
We occasionally have issues with running the coverage job for Auditor because it is using the nightly toolchain. For example, updating a crate fails because some features have changed in nightly and the crate (or any depending crates) have not yet been updated.

We are doing this to include the doctests in the coverage (`cargo llvm-cov --doctests` is currently only supported in the nightly toolchain). Since we don't use the coverage information anyway and using the nightly toolchain brings more issues than benefits, we decided to switch to the stable version for our coverage job. This means that we no longer consider the doctests when computing the coverage.