### PR TITLE
include all records of current month in summary message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Apel plugin: Reduce unnecessary high number of records for sync messages ([@dirksammel](https://github.com/dirksammel))
 - Apel plugin: Send separate summary messages per site ([@dirksammel](https://github.com/dirksammel))
+- Apel plugin: Include data of complete month in summary messages ([@dirksammel](https://github.com/dirksammel))
 - Client: Reduce logging information in info mode (#680) ([@QuantumDancer](https://github.com/QuantumDancer))
 - Slurm collector: Reduce logging information in info mode (#680) ([@QuantumDancer](https://github.com/QuantumDancer))
 - Dependencies: Update actix-web from 4.4.1 to 4.5.1 ([@QuantumDancer](https://github.com/QuantumDancer))

--- a/media/website/content/_index.md
+++ b/media/website/content/_index.md
@@ -530,7 +530,7 @@ See below for all currently available collectors.
 
 ## APEL Plugin
 
-The APEL plugin creates job summary records and sends them to APEL. It is provided as a [pip package](https://pypi.org/project/auditor-apel-plugin/) and as a Docker container from [Docker Hub](https://hub.docker.com/r/aluschumacher/auditor-apel-plugin) or from the [GitHub Container Registry](https://github.com/ALU-Schumacher/AUDITOR/pkgs/container/auditor-apel-plugin).
+The APEL plugin creates job summary records and sync messages for the current month (and the previous month if it is the first day of a month) and sends them to APEL. It is provided as a [pip package](https://pypi.org/project/auditor-apel-plugin/) and as a Docker container from [Docker Hub](https://hub.docker.com/r/aluschumacher/auditor-apel-plugin) or from the [GitHub Container Registry](https://github.com/ALU-Schumacher/AUDITOR/pkgs/container/auditor-apel-plugin).
 Two CLI commands are available after the installation via `pip`: `auditor-apel-publish` and `auditor-apel-republish`.
 
 `auditor-apel-publish` runs periodically at a given report interval.


### PR DESCRIPTION
This PR changes the content of summary messages to always include all records of the current month (and the previous month if it's the first of the month). This should fix the issue of "overwritten" accounting data on the APEL server.
Part of #737.