### PR TITLE
Audit: Ignore RUSTSEC-2024-0320 for now

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -44,6 +44,7 @@ yanked = "warn"
 # output a note when they are encountered.
 ignore = [
     #"RUSTSEC-0000-0000",
+    "RUSTSEC-2024-0320",
 ]
 # Threshold for security vulnerabilities, any vulnerability with a CVSS score
 # lower than the range specified will be ignored. Note that ignored advisories


### PR DESCRIPTION
The [yaml-rust](https://github.com/chyh1990/yaml-rust) crate is unmaintained: [RUSTSEC-2024-0320](https://rustsec.org/advisories/RUSTSEC-2024-0320.html).

This crate is pulled in via the [config-rs](https://github.com/mehcode/config-rs/) crate, so we need to wait until this is fixed upstream.

For now, I propose to put `RUSTSEC-2024-0320` to the ignore list for cargo-deny, so that our CI does not fail. Once config-rs has been updated, this should be removed again.