### PR TITLE
build(deps): bump h2 from 0.3.24 to 0.3.26 and from 0.4.2 to 0.4.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [RUSTSEC-2024-0019]: Update mio from 0.8.10 to 0.8.11 ([@QuantumDancer](https://github.com/QuantumDancer))
 - [RUSTSEC-2024-0020]: Update whoami from 1.4.1 to 1.5.0 ([@QuantumDancer](https://github.com/QuantumDancer))
 - [RUSTSEC-2024-0021]: Update eyre from 0.6.11 to 0.6.12 ([@QuantumDancer](https://github.com/QuantumDancer))
+- [RUSTSEC-2024-0332]: Update h2 from 0.3.24 to 0.3.26 ([@QuantumDancer](https://github.com/QuantumDancer))
+- [RUSTSEC-2024-0332]: Update h2 from 0.4.2 to 0.4.4 ([@QuantumDancer](https://github.com/QuantumDancer))
 
 ### Added
 - API: The health check (`GET /health_check`) now fails with an `500 INTERNAL SERVER ERROR` if no connection can be made to the database (#622) ([@QuantumDancer](https://github.com/QuantumDancer))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,7 +39,7 @@ dependencies = [
  "encoding_rs",
  "flate2",
  "futures-core",
- "h2 0.3.24",
+ "h2 0.3.26",
  "http 0.2.11",
  "httparse",
  "httpdate",
@@ -1124,9 +1124,9 @@ checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
 name = "h2"
-version = "0.3.24"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb2c4422095b67ee78da96fbb51a4cc413b3b25883c7717ff7ca1ab31022c9c9"
+checksum = "81fe527a889e1532da5c525686d96d4c2e74cdd345badf8dfef9f6b39dd5f5e8"
 dependencies = [
  "bytes",
  "fnv",
@@ -1143,9 +1143,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.2"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31d030e59af851932b72ceebadf4a2b5986dba4c3b99dd2493f8273a0f151943"
+checksum = "816ec7294445779408f36fe57bc5b7fc1cf59664059096c65f905c1c61f58069"
 dependencies = [
  "bytes",
  "fnv",
@@ -1302,7 +1302,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "h2 0.4.2",
+ "h2 0.4.4",
  "http 1.0.0",
  "http-body",
  "httparse",


### PR DESCRIPTION
This fixes https://rustsec.org/advisories/RUSTSEC-2024-0332

We are using both the 0.3.x and 0.4.x version of h2.