### PR TITLE
specify version for CI actions

### DIFF
--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -165,7 +165,7 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Check spelling
-      uses: crate-ci/typos@master
+      uses: crate-ci/typos@v1.20.4
 
   test_prometheus_exporter:
     name: Prometheus exporter tests

--- a/.github/workflows/pyauditor_docs.yml
+++ b/.github/workflows/pyauditor_docs.yml
@@ -78,7 +78,7 @@ jobs:
           pathspec_error_handling: exitAtEnd
 
       - name: Push changes
-        uses: ad-m/github-push-action@master
+        uses: ad-m/github-push-action@v0.8.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           branch: gh-pages

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -82,7 +82,7 @@ jobs:
           pathspec_error_handling: exitAtEnd
 
       - name: Push changes
-        uses: ad-m/github-push-action@master
+        uses: ad-m/github-push-action@v0.8.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           branch: gh-pages

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CI: Remove deprecated options from cargo.deny (#709) ([@QuantumDancer](https://github.com/QuantumDancer))
 - CI: Switch to stable toolchain for coverage job ([@QuantumDancer](https://github.com/QuantumDancer))
 - CI: Update htcondor docker image from 10.9.0 to 23.5.2 ([@QuantumDancer](https://github.com/QuantumDancer))
+- CI: Use specific version for actions ([@dirksammel](https://github.com/dirksammel))
 
 ### Removed
 

--- a/plugins/apel/.gitignore
+++ b/plugins/apel/.gitignore
@@ -9,4 +9,4 @@ __pycache__/
 dist/
 build/
 _version.py
-*.local
+*.local.*


### PR DESCRIPTION
This PR adds a specific version for some actions. This was triggered by some breaking changes introduced to the `typos` action. 