### PR TITLE
Auditor: Allow users to run migrations with docker container

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,4 +3,3 @@ target/
 tests/
 **/Dockerfile
 scripts/
-migrations/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Breaking changes
 - Apel plugin: change config parameter `time_db_path` to `time_json_path` ([@dirksammel](https://github.com/dirksammel))
 - Apel plugin: change config format from INI to YAML ([@dirksammel](https://github.com/dirksammel))
+- AUDITOR: Database migrations can now be run using the Docker container (#765) ([@QuantumDancer](https://github.com/QuantumDancer))
 
 ### Security
 - [RUSTSEC-2024-0019]: Update mio from 0.8.10 to 0.8.11 ([@QuantumDancer](https://github.com/QuantumDancer))

--- a/containers/auditor/Dockerfile
+++ b/containers/auditor/Dockerfile
@@ -10,6 +10,8 @@ RUN cargo chef prepare --recipe-path recipe.json
 
 FROM chef as builder
 COPY --from=planner /auditor/recipe.json recipe.json
+# Install sqlx-cli
+RUN cargo install --version=0.7.4 sqlx-cli --no-default-features --features postgres,rustls,sqlite
 # Only build project dependencies
 RUN cargo chef cook --release --recipe-path recipe.json
 
@@ -30,8 +32,11 @@ RUN apt-get update -y \
 && rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /auditor/target/release/auditor auditor
+COPY --from=builder /usr/local/cargo/bin/sqlx sqlx
+COPY --from=builder /auditor/migrations migrations
+COPY --from=builder /auditor/containers/auditor/entrypoint.sh entrypoint.sh
 
 COPY auditor/configuration configuration
 
 ENV AUDITOR_ENVIRONMENT production
-ENTRYPOINT ["./auditor"]
+ENTRYPOINT ["./entrypoint.sh"]

--- a/containers/auditor/entrypoint.sh
+++ b/containers/auditor/entrypoint.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+set -e -o pipefail
+
+run_auditor() {
+  ./auditor "$@"
+}
+
+run_sqlx_migration() {
+
+  AUDITOR_DATABASE__USERNAME="${AUDITOR_DATABASE__USERNAME:=postgres}"
+  AUDITOR_DATABASE__PASSWORD="${AUDITOR_DATABASE__PASSWORD:=password}"
+  AUDITOR_DATABASE__HOST="${AUDITOR_DATABASE__HOST:=localhost}"
+  AUDITOR_DATABASE__PORT="${AUDITOR_DATABASE__PORT:=5432}"
+  AUDITOR_DATABASE__DATABASE_NAME="${AUDITOR_DATABASE__DATABASE_NAME:=auditor}"
+
+  export DATABASE_URL=postgres://${AUDITOR_DATABASE__USERNAME}:${AUDITOR_DATABASE__PASSWORD}@${AUDITOR_DATABASE__HOST}:${AUDITOR_DATABASE__PORT}/${AUDITOR_DATABASE__DATABASE_NAME}
+  ./sqlx database create
+  ./sqlx migrate run
+}
+
+help() {
+  echo "Available commands:"
+  echo "  auditor: Run AUDITOR"
+  echo "  migrate: Run sqlx migrations"
+  echo "  shell: Start a shell session (for debugging)"
+  echo "  help: Show this help message"
+}
+
+if [ $# -eq 0 ]; then
+  run_auditor
+fi
+
+command="$1"
+shift
+
+if [ "$command" = "auditor" ]; then
+  run_auditor "$@"
+elif [ "$command" = "migrate" ]; then
+  run_sqlx_migration
+elif [ "$command" = "shell" ]; then
+  /bin/bash
+elif [ "$command" = "help" ]; then
+  help
+elif [ "$command" = "--help" ]; then
+  help
+else
+  echo "Unknown command: $1"
+fi

--- a/media/website/content/_index.md
+++ b/media/website/content/_index.md
@@ -183,6 +183,17 @@ log_level: info
 
 This configuration file can be passed to Auditor and will overwrite the default configuration.
 
+If you have compiled Auditor from source, pass the configuration file as first argument (i.e. `cargo run <path-to-config>` or `./auditor <path-to-config>`)
+
+If you run Auditor using Docker, then you first need to mount the configuration file inside the container, before you can use it.
+Furthermore, you need to call the Docker container with the `auditor` command as first argument and the path to the config file (location inside the container) as second argument.
+
+```bash
+docker run -v <absolute-path-to-config>:/auditor/config.yaml aluschumacher/auditor:<version> auditor /auditor/config.yaml
+```
+
+However, you should default to using environment variables for configuration when running Auditor using Docker.
+
 ## Metrics exporter for Prometheus
 
 Metrics for Prometheus are exposed via the `/metrics` endpoint.

--- a/media/website/content/migration.md
+++ b/media/website/content/migration.md
@@ -25,6 +25,23 @@ options:
 
 This already requires a config file with YAML format.
 
+## Docker container
+
+The Auditor Docker container can now be used to run database migrations. For details, see the [documentation](../#migrating-the-database).
+
+If you run Auditor using the Docker container and provide an external config file, you need to change the way how you run the Docker container:
+
+- Old
+  ```bash
+  docker run -v <absolute-path-to-config>:/auditor/config.yaml aluschumacher/auditor:<version> /auditor/config.yaml
+  ```
+- New
+  ```bash
+  docker run -v <absolute-path-to-config>:/auditor/config.yaml aluschumacher/auditor:<version> auditor /auditor/config.yaml
+  ```
+
+I.e., you need to add `auditor` as the first argument before pointing to the configuration file.
+
 ## Development
 
 ### Update to [sqlx 0.7.4](https://github.com/launchbadge/sqlx/blob/main/sqlx-cli/README.md)


### PR DESCRIPTION
Closes #765 

I also added a little bit more information to the documentation (how to set up the PostgreSQL database using Docker)