### PR TITLE
build(deps): bump rustls from 0.22.2 to 0.22.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [RUSTSEC-2024-0332]: Update h2 from 0.3.24 to 0.3.26 ([@QuantumDancer](https://github.com/QuantumDancer))
 - [RUSTSEC-2024-0332]: Update h2 from 0.4.2 to 0.4.4 ([@QuantumDancer](https://github.com/QuantumDancer))
 - [CVE-2024-32650]: Update rustls from 0.21.10 to 0.21.11 ([@QuantumDancer](https://github.com/QuantumDancer))
+- [RUSTSEC-2024-0336]: Update rustls from 0.22.2 to 0.22.4 ([@QuantumDancer](https://github.com/QuantumDancer))
 
 ### Added
 - AUDITOR: Add benchmark to measure db performance (#736) ([@raghuvar-vijay](https://github.com/raghuvar-vijay))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1480,7 +1480,7 @@ dependencies = [
  "http 1.0.0",
  "hyper",
  "hyper-util",
- "rustls 0.22.2",
+ "rustls 0.22.4",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
@@ -2508,7 +2508,7 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls 0.22.2",
+ "rustls 0.22.4",
  "rustls-pemfile 2.1.1",
  "rustls-pki-types",
  "serde",
@@ -2622,9 +2622,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.22.2"
+version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e87c9956bd9807afa1f77e0f7594af32566e830e088a5576d27c5b6f30f49d41"
+checksum = "bf4ef73721ac7bcd79b2b315da7779d8fc09718c6b3d2d1b2d94850eb8c18432"
 dependencies = [
  "log",
  "ring",
@@ -3336,7 +3336,7 @@ version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "775e0c0f0adb3a2f22a00c4745d728b479985fc15ee7ca6a2608388c5569860f"
 dependencies = [
- "rustls 0.22.2",
+ "rustls 0.22.4",
  "rustls-pki-types",
  "tokio",
 ]


### PR DESCRIPTION
This fixes [RUSTSEC-2024-0336](https://rustsec.org/advisories/RUSTSEC-2024-0336)