### PR TITLE
CI: Switch to stable toolchain for clippy

### DIFF
--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -104,7 +104,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install stable toolchain
-        uses: dtolnay/rust-toolchain@beta
+        uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Dependencies: Update serde_with from 3.7.0 to 3.8.0 ([@QuantumDancer](https://github.com/QuantumDancer))
+- CI: Switch to stable toolchain for clippy job (#793) ([@QuantumDancer](https://github.com/QuantumDancer))
 
 ### Removed
 


### PR DESCRIPTION
Similar reasoning as for #739

Closes #793 