### PR TITLE
some fixes for the APEL plugin

### DIFF
--- a/plugins/apel/src/auditor_apel_plugin/config.py
+++ b/plugins/apel/src/auditor_apel_plugin/config.py
@@ -205,7 +205,7 @@ class NormalisedField(Field):
                 "Multiplication not possible!"
             )
             raise TypeError
-        value = int(base_value * score_value)
+        value = round(base_value * score_value)
 
         return value
 

--- a/plugins/apel/src/auditor_apel_plugin/config.py
+++ b/plugins/apel/src/auditor_apel_plugin/config.py
@@ -195,7 +195,7 @@ class NormalisedField(Field):
     base_value: Union[ComponentField, RecordField]
     score: ScoreField
 
-    def get_value(self, record: Record) -> float:
+    def get_value(self, record: Record) -> int:
         base_value = self.base_value.get_value(record)
         score_value = self.score.get_value(record)
 
@@ -205,7 +205,7 @@ class NormalisedField(Field):
                 "Multiplication not possible!"
             )
             raise TypeError
-        value = base_value * score_value
+        value = int(base_value * score_value)
 
         return value
 

--- a/plugins/apel/src/auditor_apel_plugin/core.py
+++ b/plugins/apel/src/auditor_apel_plugin/core.py
@@ -450,6 +450,7 @@ def get_token(config):
     client_cert = config.authentication.client_cert
     client_key = config.authentication.client_key
     verify_ca = config.authentication.verify_ca
+
     if verify_ca:
         ca_path = config.authentication.ca_path
     else:
@@ -500,11 +501,11 @@ def build_payload(msg):
 
 
 def send_payload(config, token, payload):
-    ams_url = config["authentication"]["ams_url"]
-    verify_ca = config["authentication"]["verify_ca"]
+    ams_url = config.authentication.ams_url
+    verify_ca = config.authentication.verify_ca
 
     if verify_ca:
-        ca_path = config["authentication"]["ca_path"]
+        ca_path = config.authentication.ca_path
     else:
         ca_path = False
 


### PR DESCRIPTION
This PR fixes some issues with the APEL plugin:

1. NormalisedField now returns int instead of float
2. config is now accessed as object instead of dict in send_payload function