### PR TITLE
Change conversion of scores to float

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Dependencies: Update tarides/changelog-check-action from 2 to 3 ([@dirksammel](https://github.com/dirksammel))
 - Dependencies: Update types-pyyaml from 6.0.12.20240311 to 6.0.12.20240917 ([@dirksammel](https://github.com/dirksammel))
 - Dependencies: Update types-requests from 2.32.0.20240712 to 2.32.0.20240914 ([@dirksammel](https://github.com/dirksammel))
+- HTCondor collector: Fix bug that the machine score was stored as an integer, not as a float ([@mschnepf](https://github.com/mschnepf))
 
 ### Removed
 

--- a/collectors/htcondor/src/auditor_htcondor_collector/collector.py
+++ b/collectors/htcondor/src/auditor_htcondor_collector/collector.py
@@ -205,7 +205,7 @@ class CondorHistoryCollector(object):
                 comp = Component(name=component["name"], amount=amount)
                 for score in component.get("scores", []):
                     value = get_value(score, job) or "0.0"
-                    comp.with_score(Score(score["name"], maybe_convert(value)))
+                    comp.with_score(Score(score["name"], float(value)))
                 components.append(comp)
             else:
                 self.logger.warning(


### PR DESCRIPTION
Currently, the HTCondor collector converts the score string into integer with the [maybe_convert](https://github.com/ALU-Schumacher/AUDITOR/blame/e3c429294ea0ef609cf8e27040ada1670e29a7d1/collectors/htcondor/src/auditor_htcondor_collector/utils.py#L32) function. Therefore, the scores stored in the database are wrong.

This should fix the issue https://github.com/ALU-Schumacher/AUDITOR/issues/989