### PR TITLE
fix typos in the client documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Breaking changes
+- AUDITOR client: rename function `does_not_contains` to `does_not_contain`
 
 ### Security
 - [RUSTSEC-2024-0363]: Update sqlx from 0.7.4 to 0.8.2 ([@raghuvar-vijay](https://github.com/raghuvar-vijay)) 
@@ -32,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Dependencies: Update types-pyyaml from 6.0.12.20240311 to 6.0.12.20240917 ([@dirksammel](https://github.com/dirksammel))
 - Dependencies: Update types-requests from 2.32.0.20240712 to 2.32.0.20240914 ([@dirksammel](https://github.com/dirksammel))
 - HTCondor collector: Fix bug that the machine score was stored as an integer, not as a float ([@mschnepf](https://github.com/mschnepf))
+- Docs: Typo fixes in query documentation ([@dirksammel](https://github.com/dirksammel)) 
 
 ### Removed
 

--- a/auditor-client/src/lib.rs
+++ b/auditor-client/src/lib.rs
@@ -213,7 +213,7 @@
 //!
 //! #### Meta Operators
 //! - `c` (contains)
-//! - `dnc` (does not contains)
+//! - `dnc` (does not contain)
 //!
 //! #### SortBy Operators
 //! - `asc` (ascending order)
@@ -233,14 +233,14 @@
 //!| `start_time` | Start time of the event (`DateTime<Utc>`)                              | `gt`, `gte`, `lt`, `lte`               | `start_time[gt]=<timestamp>`               |
 //!| `stop_time`  | Stop time of the event (`DateTime<Utc>`)                               | `gt`, `gte`, `lt`, `lte`               | `stop_time[gt]=<timestamp>`                |
 //!| `runtime`    | Runtime of the event (in seconds)                                      | `gt`, `gte`, `lt`, `lte`               | `runtime[gt]=<u64>`                        |
-//!| `meta`       | Meta information (<meta_key>, MetaOperator(<meta_value>))              | `d`, `dnc`                             | `meta[<meta_key>][c]=<meta_value>`         |
+//!| `meta`       | Meta information (<meta_key>, MetaOperator(<meta_value>))              | `c`, `dnc`                             | `meta[<meta_key>][c]=<meta_value>`         |
 //!| `component`  | Component identifier (<component_name>, Operator(<component_amount>))  | `gt`, `gte`, `lt`, `lte`, `equals`     | `component[<component_name>][gt]=<amount>` |
 //!| `sort_by`    | Sort query results (SortBy(<column_name>))                             | `asc`, `desc`                          | `sort_by[desc]=<column_name>`              |
 //!| `limit`      | limit query records (number)                                           |                                        | `limit=5000`                               |
 //!
 //! Meta field can be used to query records by specifying the meta key and [`MetaOperator`]  must be used
 //! to specify meta values. The [`MetaOperator`] must be used to specify whether the value is
-//! contained or does not contained for the specific Metakey.
+//! contained or is not contained for the specific Metakey.
 //!
 //! Component field can be used to query records by specifying the component name (CPU) and ['Operator'] must be used
 //! to specify the amount.
@@ -248,7 +248,7 @@
 //! To query records based on a range, specify the field with two operators
 //! Either with gt or gte and lt or lte.
 //!
-//! For example, to query a records with start_time ranging between two timestamps:
+//! For example, to query records with start_time ranging between two timestamps:
 //!
 //! ```text
 //! GET records?start_time[gt]=timestamp1&start_time[lt]=timestamp2
@@ -1080,7 +1080,7 @@ impl Serialize for MetaQuery {
 pub struct MetaOperator {
     /// `contains` - Specifies if the meta key contains the value.
     pub c: Option<String>,
-    /// `does not contains` - Specifies if the meta key does not contains the value.
+    /// `does not contain` - Specifies if the meta key does not contain the value.
     pub dnc: Option<String>,
 }
 
@@ -1108,7 +1108,7 @@ impl MetaOperator {
     /// # Returns
     ///
     /// A new `MetaOperator` instance with the specified condition.
-    pub fn does_not_contains(mut self, dnc: String) -> Self {
+    pub fn does_not_contain(mut self, dnc: String) -> Self {
         self.dnc = Some(dnc);
         self
     }

--- a/pyauditor/docs/examples.rst
+++ b/pyauditor/docs/examples.rst
@@ -169,7 +169,7 @@ Meta Operators
 --------------
 
 - `c` (contains)
-- `dnc` (does not contains)
+- `dnc` (does not contain)
 
 SortBy Operators
 ----------------
@@ -202,7 +202,7 @@ The table shows the fields and the corresponding operators available for each fi
 +--------------+-----------------------------------------------+----------------------------------------+------------------------------------------+
 | `runtime`    | Runtime of the event (in seconds)             | `gt`, `gte`, `lt`, `lte`               | runtime[gt]=<int>                        |
 +--------------+-----------------------------------------------+----------------------------------------+------------------------------------------+
-| `meta`       | Meta information                              | `d`, `dnc`                             | meta[<meta_key>][c]=<meta_value>         |
+| `meta`       | Meta information                              | `c`, `dnc`                             | meta[<meta_key>][c]=<meta_value>         |
 +--------------+-----------------------------------------------+----------------------------------------+------------------------------------------+
 | `component`  | Component identifier                          | `gt`, `gte`, `lt`, `lte`, `equals`     | component[<component_name>][gt]=<amount> |
 +--------------+-----------------------------------------------+----------------------------------------+------------------------------------------+
@@ -214,7 +214,7 @@ The table shows the fields and the corresponding operators available for each fi
 
 Meta field can be used to query records by specifying the meta key and MetaOperator must be used
 to specify meta values. The MetaOperator must be used to specify whether the value is
-contained or does not contained for the specific Metakey.
+contained or is not contained for the specific Metakey.
 
 Component field can be used to query records by specifying the component name (CPU) and ['Operator'] must be used
 to specify the amount. 
@@ -223,7 +223,7 @@ To query records based on a range, specify the field with two operators
 Either with gt or gte and lt or lte.
 
 For example,
-To query a records with start_time ranging between two timestamps.
+To query records with start_time ranging between two timestamps.
 
 ```text
 Get records?start_time[gt]=timestamp1&start_time[lt]=timestamp2

--- a/pyauditor/src/client.rs
+++ b/pyauditor/src/client.rs
@@ -287,21 +287,21 @@ impl MetaOperator {
         self_
     }
 
-    /// Sets the meta value using  does not contains operator. This checks if the value does not exists for the
+    /// Sets the meta value using does not contain operator. This checks if the value does not exist for the
     /// corresponding metadata key
     ///
     /// :param query_id: Metadata key
     /// :type query_id: string
     ///
-    /// :param c: Metadata value to be checked if it does not exists
+    /// :param c: Metadata value to be checked if it does not exist
     /// :type c: string
     ///
     /// **Example**
     ///
     /// .. code-block:: python
     ///     
-    ///     operator = MetaOperator().does_not_contains("group_1")
-    fn does_not_contains(mut self_: PyRefMut<Self>, dnc: String) -> PyRefMut<Self> {
+    ///     operator = MetaOperator().does_not_contain("group_1")
+    fn does_not_contain(mut self_: PyRefMut<Self>, dnc: String) -> PyRefMut<Self> {
         self_.inner.dnc = Some(dnc);
         self_
     }


### PR DESCRIPTION
This PR fixes some typos in the client documenation:
operator for `contains` is `c` instead of `d`
also some grammatical errors

BREAKING CHANGE: 
the function `does_not_contains` is renamed to `does_not_contain`