### PR TITLE
use latest rust version in container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Security
 
 ### Changed
+- Auditor Docker container: Switch from fixed to latest Rust version ([@dirksammel](https://github.com/dirksammel))
 
 ### Removed
 

--- a/containers/auditor/Dockerfile
+++ b/containers/auditor/Dockerfile
@@ -1,5 +1,5 @@
 # Note: If you update the rust version below, make sure that the debian version which is used there matches the one in the runtime stage
-FROM lukemathwalker/cargo-chef:latest-rust-1.75-slim-bookworm AS chef
+FROM lukemathwalker/cargo-chef:latest-rust-slim-bookworm AS chef
 WORKDIR /auditor
 RUN apt update && apt install lld clang -y
 


### PR DESCRIPTION
The Rust version we use in the Docker container for AUDITOR is currently fixed. With this PR, always the latest version is used (as anywhere else in the framework).