### PR TITLE
update sqlx to 0.8.2 

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -19,7 +19,7 @@ jobs:
         ports:
           - 5432:5432
     env:
-      SQLX_VERSION: 0.7.4
+      SQLX_VERSION: 0.8.2
       SQLX_FEATURES: postgres,rustls,sqlite
       CARGO_TERM_COLOR: always
 

--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -22,7 +22,7 @@ jobs:
         ports:
           - 5432:5432
     env:
-      SQLX_VERSION: 0.7.4
+      SQLX_VERSION: 0.8.2
       SQLX_FEATURES: postgres,rustls,sqlite
     steps:
       - name: Checkout repository
@@ -100,7 +100,7 @@ jobs:
         ports:
           - 5432:5432
     env:
-      SQLX_VERSION: 0.7.4
+      SQLX_VERSION: 0.8.2
       SQLX_FEATURES: postgres,rustls,sqlite
     steps:
       - name: Checkout repository
@@ -194,7 +194,7 @@ jobs:
         ports:
           - 5432:5432
     env:
-      SQLX_VERSION: 0.7.4
+      SQLX_VERSION: 0.8.2
       SQLX_FEATURES: postgres,rustls,sqlite
       RUSTFLAGS: -C link-arg=-s
     steps:

--- a/.github/workflows/priority-plugin.yml
+++ b/.github/workflows/priority-plugin.yml
@@ -22,7 +22,7 @@ jobs:
         ports:
           - 5432:5432
     env:
-      SQLX_VERSION: 0.7.4
+      SQLX_VERSION: 0.8.2
       SQLX_FEATURES: postgres,rustls,sqlite
       RUSTFLAGS: -C link-arg=-s
     steps:

--- a/.github/workflows/pyauditor_integration_tests.yml
+++ b/.github/workflows/pyauditor_integration_tests.yml
@@ -20,7 +20,7 @@ jobs:
         ports:
           - 5432:5432
     env:
-      SQLX_VERSION: 0.7.4
+      SQLX_VERSION: 0.8.2
       SQLX_FEATURES: postgres,rustls,sqlite
       RUSTFLAGS: -C link-arg=-s
     steps:

--- a/.github/workflows/slurm-collector.yml
+++ b/.github/workflows/slurm-collector.yml
@@ -23,7 +23,7 @@ jobs:
         ports:
           - 5432:5432
     env:
-      SQLX_VERSION: 0.7.4
+      SQLX_VERSION: 0.8.2
       SQLX_FEATURES: postgres,rustls,sqlite
       RUSTFLAGS: -C link-arg=-s
     steps:

--- a/.github/workflows/slurm-epilog-collector.yml
+++ b/.github/workflows/slurm-epilog-collector.yml
@@ -23,7 +23,7 @@ jobs:
         ports:
           - 5432:5432
     env:
-      SQLX_VERSION: 0.7.4
+      SQLX_VERSION: 0.8.2
       SQLX_FEATURES: postgres,rustls,sqlite
       RUSTFLAGS: -C link-arg=-s
     steps:

--- a/.github/workflows/sqlx.yml
+++ b/.github/workflows/sqlx.yml
@@ -7,7 +7,7 @@ jobs:
   sqlx:
     runs-on: ubuntu-latest
     env:
-      SQLX_VERSION: 0.7.4
+      SQLX_VERSION: 0.8.2
       SQLX_FEATURES: postgres,rustls,sqlite
       RUSTFLAGS: -C link-arg=-s
     steps:

--- a/.github/workflows/test_db_migration.yml
+++ b/.github/workflows/test_db_migration.yml
@@ -22,7 +22,7 @@ jobs:
         ports:
           - 5432:5432
     env:
-      SQLX_VERSION: 0.7.4
+      SQLX_VERSION: 0.8.2
       SQLX_FEATURES: postgres,rustls,sqlite
       RUSTFLAGS: -C link-arg=-s
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Auditor Docker container: Switch from fixed to latest Rust version ([@dirksammel](https://github.com/dirksammel))
 - Dependencies: Update crate-ci/typos from 1.26.8 to 1.27.2 ([@dirksammel](https://github.com/dirksammel))
 - Dependencies: Update ruff from 0.7.1 to 0.7.2 ([@dirksammel](https://github.com/dirksammel))
+- Dependencies: Update sqlx from 0.7.4 to 0.8.2 (missed some occurrences) ([@dirksammel](https://github.com/dirksammel))
 
 ### Removed
 

--- a/containers/auditor/Dockerfile
+++ b/containers/auditor/Dockerfile
@@ -10,7 +10,7 @@ RUN cargo chef prepare --recipe-path recipe.json
 
 FROM chef AS builder
 # Install sqlx-cli
-RUN cargo install --version=0.7.4 sqlx-cli --no-default-features --features postgres,rustls,sqlite
+RUN cargo install --version=0.8.2 sqlx-cli --no-default-features --features postgres,rustls,sqlite
 # Only build project dependencies
 COPY --from=planner /auditor/recipe.json recipe.json
 RUN cargo chef cook --release --recipe-path recipe.json

--- a/media/website/content/_index.md
+++ b/media/website/content/_index.md
@@ -96,7 +96,7 @@ curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 Now `sqlx` can be installed via `cargo`:
 
 ```bash
-cargo install --version=0.7.4 sqlx-cli --no-default-features --features postgres,rustls,sqlite
+cargo install --version=0.8.2 sqlx-cli --no-default-features --features postgres,rustls,sqlite
 ```
 
 Clone the repository and `cd` into the directory.

--- a/media/website/content/development.md
+++ b/media/website/content/development.md
@@ -82,7 +82,7 @@ curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 ### sqlx
 
 ```bash
-cargo install --version=0.7.4 sqlx-cli --no-default-features --features postgres,rustls
+cargo install --version=0.8.2 sqlx-cli --no-default-features --features postgres,rustls
 ```
 
 ### bunyan
@@ -218,6 +218,7 @@ Example PR: [https://github.com/ALU-Schumacher/AUDITOR/pull/547](https://github.
 
 - Update the version number in all `Cargo.toml` files
 - Run `cargo update` to update dependencies in `Cargo.lock`
+- If `sqlx` is updated, don't forget to also change the version in all workflows, containers, documentation, etc.
 - Update the version number in all `pyproject.toml` files
 - Finalize the [changelog](https://github.com/ALU-Schumacher/AUDITOR/blob/main/CHANGELOG.md)
   - Rename `Unreleased` to version number, add date

--- a/scripts/init_client_sqlite.sh
+++ b/scripts/init_client_sqlite.sh
@@ -5,7 +5,7 @@ set -eo pipefail
 if ! [ -x "$(command -v sqlx)" ]; then
 	echo >&2 "Error: sqlx is not installed."
 	echo >&2 "Use:"
-	echo >&2 "    cargo install --version=0.7.4 sqlx-cli --no-default-features --features postgres,rustls,sqlite"
+	echo >&2 "    cargo install --version=0.8.2 sqlx-cli --no-default-features --features postgres,rustls,sqlite"
 	echo >&2 "to install it."
 	exit 1
 fi

--- a/scripts/init_db.sh
+++ b/scripts/init_db.sh
@@ -10,7 +10,7 @@ fi
 if ! [ -x "$(command -v sqlx)" ]; then
 	echo >&2 "Error: sqlx is not installed."
 	echo >&2 "Use:"
-	echo >&2 "    cargo install --version=0.7.4 sqlx-cli --no-default-features --features postgres,rustls,sqlite"
+	echo >&2 "    cargo install --version=0.8.2 sqlx-cli --no-default-features --features postgres,rustls,sqlite"
 	echo >&2 "to install it."
 	exit 1
 fi

--- a/scripts/init_slurm_collector_sqlite.sh
+++ b/scripts/init_slurm_collector_sqlite.sh
@@ -5,7 +5,7 @@ set -eo pipefail
 if ! [ -x "$(command -v sqlx)" ]; then
 	echo >&2 "Error: sqlx is not installed."
 	echo >&2 "Use:"
-	echo >&2 "    cargo install --version=0.7.4 sqlx-cli --no-default-features --features postgres,rustls,sqlite"
+	echo >&2 "    cargo install --version=0.8.2 sqlx-cli --no-default-features --features postgres,rustls,sqlite"
 	echo >&2 "to install it."
 	exit 1
 fi


### PR DESCRIPTION
We missed some occurrences of `sqlx` when we updated to 0.8.2., this PR fixes that and adds a reminder to the documentation.