### PR TITLE
Safely write APEL timestamp JSON

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Dependencies: Update crate-ci/typos from 1.26.8 to 1.27.2 ([@dirksammel](https://github.com/dirksammel))
 - Dependencies: Update ruff from 0.7.1 to 0.7.2 ([@dirksammel](https://github.com/dirksammel))
 - Dependencies: Update sqlx from 0.7.4 to 0.8.2 (missed some occurrences) ([@dirksammel](https://github.com/dirksammel))
+- Apel plugin: Update timestamp JSON atomically ([@maxfischer2781](https://github.com/maxfischer2781))
 
 ### Removed
 

--- a/plugins/apel/src/auditor_apel_plugin/core.py
+++ b/plugins/apel/src/auditor_apel_plugin/core.py
@@ -26,6 +26,7 @@ from auditor_apel_plugin.message import (
     SummaryMessage,
     SyncMessage,
 )
+
 from .utility import write_transaction
 
 logger = logging.getLogger("apel_plugin")

--- a/plugins/apel/src/auditor_apel_plugin/core.py
+++ b/plugins/apel/src/auditor_apel_plugin/core.py
@@ -26,6 +26,7 @@ from auditor_apel_plugin.message import (
     SummaryMessage,
     SyncMessage,
 )
+from .utility import write_transaction
 
 logger = logging.getLogger("apel_plugin")
 
@@ -127,7 +128,7 @@ def create_time_json(time_json_path):
     }
 
     try:
-        with open(time_json_path, "w", encoding="utf-8") as f:
+        with write_transaction(time_json_path, encoding="utf-8") as f:
             json.dump(time_dict, f)
     except FileNotFoundError:
         logger.critical(f"Path {time_json_path} not found, could not create time json")
@@ -158,7 +159,7 @@ def update_time_json(config, time_dict, site, stop_time, report_time):
     time_dict["site_end_times"][site] = stop_time.isoformat()
 
     try:
-        with open(time_json_path, "w", encoding="utf-8") as f:
+        with write_transaction(time_json_path, encoding="utf-8") as f:
             json.dump(time_dict, f)
     except FileNotFoundError:
         logger.critical(f"Path {time_json_path} not found, could not update time json")

--- a/plugins/apel/src/auditor_apel_plugin/utility.py
+++ b/plugins/apel/src/auditor_apel_plugin/utility.py
@@ -1,7 +1,7 @@
 import os
 import pathlib
 from contextlib import contextmanager
-from typing import Literal, overload, IO, ContextManager
+from typing import IO, ContextManager, Literal, overload
 
 
 @overload

--- a/plugins/apel/src/auditor_apel_plugin/utility.py
+++ b/plugins/apel/src/auditor_apel_plugin/utility.py
@@ -22,6 +22,11 @@ def write_transaction(
 ):
     """Open `path` for overwriting but discard the new content if an exception occurs"""
     tmp_path = pathlib.Path(path).parent / f".{pathlib.Path(path).name}.tmp"
-    with open(tmp_path, mode, **kwargs) as out_stream:
-        yield out_stream
-    tmp_path.rename(path)
+    try:
+        with open(tmp_path, mode, **kwargs) as out_stream:
+            yield out_stream
+    except BaseException:
+        tmp_path.unlink(True)
+        raise
+    else:
+        tmp_path.rename(path)

--- a/plugins/apel/src/auditor_apel_plugin/utility.py
+++ b/plugins/apel/src/auditor_apel_plugin/utility.py
@@ -1,4 +1,3 @@
-import os
 import pathlib
 from contextlib import contextmanager
 from typing import IO, ContextManager, Literal, overload
@@ -6,19 +5,19 @@ from typing import IO, ContextManager, Literal, overload
 
 @overload
 def write_transaction(
-    path: "str | os.PathLike[str]", mode: Literal["w"] = ..., **kwargs
+    path: "str | pathlib.PurePath", mode: Literal["w"] = ..., **kwargs
 ) -> ContextManager[IO[str]]: ...
 
 
 @overload
 def write_transaction(
-    path: "str | os.PathLike[str]", mode: Literal["wb"], **kwargs
+    path: "str | pathlib.PurePath", mode: Literal["wb"], **kwargs
 ) -> ContextManager[IO[bytes]]: ...
 
 
 @contextmanager
 def write_transaction(
-    path: "str | os.PathLike[str]", mode: Literal["w", "wb"] = "w", **kwargs
+    path: "str | pathlib.PurePath", mode: Literal["w", "wb"] = "w", **kwargs
 ):
     """Open `path` for overwriting but discard the new content if an exception occurs"""
     tmp_path = pathlib.Path(path).parent / f".{pathlib.Path(path).name}.tmp"

--- a/plugins/apel/src/auditor_apel_plugin/utility.py
+++ b/plugins/apel/src/auditor_apel_plugin/utility.py
@@ -6,19 +6,19 @@ from typing import IO, ContextManager, Literal, overload
 
 @overload
 def write_transaction(
-    path: str | os.PathLike[str], mode: Literal["w"] = ..., **kwargs
+    path: "str | os.PathLike[str]", mode: Literal["w"] = ..., **kwargs
 ) -> ContextManager[IO[str]]: ...
 
 
 @overload
 def write_transaction(
-    path: str | os.PathLike[str], mode: Literal["wb"], **kwargs
+    path: "str | os.PathLike[str]", mode: Literal["wb"], **kwargs
 ) -> ContextManager[IO[bytes]]: ...
 
 
 @contextmanager
 def write_transaction(
-    path: str | os.PathLike[str], mode: Literal["w", "wb"] = "w", **kwargs
+    path: "str | os.PathLike[str]", mode: Literal["w", "wb"] = "w", **kwargs
 ):
     """Open `path` for overwriting but discard the new content if an exception occurs"""
     tmp_path = pathlib.Path(path).parent / f".{pathlib.Path(path).name}.tmp"

--- a/plugins/apel/src/auditor_apel_plugin/utility.py
+++ b/plugins/apel/src/auditor_apel_plugin/utility.py
@@ -1,15 +1,27 @@
 import os
 import pathlib
 from contextlib import contextmanager
-from typing import Generator, TextIO
+from typing import Literal, overload, IO, ContextManager
+
+
+@overload
+def write_transaction(
+    path: str | os.PathLike[str], mode: Literal["w"] = ..., **kwargs
+) -> ContextManager[IO[str]]: ...
+
+
+@overload
+def write_transaction(
+    path: str | os.PathLike[str], mode: Literal["wb"], **kwargs
+) -> ContextManager[IO[bytes]]: ...
 
 
 @contextmanager
 def write_transaction(
-    path: str | os.PathLike[str], **kwargs
-) -> Generator[TextIO, None, None]:
+    path: str | os.PathLike[str], mode: Literal["w", "wb"] = "w", **kwargs
+):
     """Open `path` for overwriting but discard the new content if an exception occurs"""
     tmp_path = pathlib.Path(path).parent / f".{pathlib.Path(path).name}.tmp"
-    with open(tmp_path, "w", **kwargs) as out_stream:
+    with open(tmp_path, mode, **kwargs) as out_stream:
         yield out_stream
     tmp_path.rename(path)

--- a/plugins/apel/src/auditor_apel_plugin/utility.py
+++ b/plugins/apel/src/auditor_apel_plugin/utility.py
@@ -1,0 +1,15 @@
+import os
+import pathlib
+from contextlib import contextmanager
+from typing import Generator, TextIO
+
+
+@contextmanager
+def write_transaction(
+    path: str | os.PathLike[str], **kwargs
+) -> Generator[TextIO, None, None]:
+    """Open `path` for overwriting but discard the new content if an exception occurs"""
+    tmp_path = pathlib.Path(path).parent / f".{pathlib.Path(path).name}.tmp"
+    with open(tmp_path, "w", **kwargs) as out_stream:
+        yield out_stream
+    tmp_path.rename(path)

--- a/plugins/apel/tests/test_utility.py
+++ b/plugins/apel/tests/test_utility.py
@@ -3,7 +3,7 @@ import secrets
 
 import pytest
 
-from auditor_apel_plugin.utiliy import write_transaction
+from auditor_apel_plugin.utility import write_transaction
 
 
 CONTENT = [

--- a/plugins/apel/tests/test_utility.py
+++ b/plugins/apel/tests/test_utility.py
@@ -5,7 +5,6 @@ import pytest
 
 from auditor_apel_plugin.utility import write_transaction
 
-
 CONTENT = [
     "Hello World!",
     "  \t  \n \t\n",

--- a/plugins/apel/tests/test_utiliy.py
+++ b/plugins/apel/tests/test_utiliy.py
@@ -1,0 +1,54 @@
+import pathlib
+import secrets
+
+import pytest
+
+from auditor_apel_plugin.utiliy import write_transaction
+
+
+CONTENT = [
+    "Hello World!",
+    "  \t  \n \t\n",
+    "",
+    secrets.token_hex(),
+    secrets.token_hex(4096),
+    "\n".join([secrets.token_hex(1025) for _ in range(9)]),
+]
+# Some content is very long and randomized, parametrize over indizes to keep tests manageable
+CONTENT_IDXS = range(len(CONTENT))
+
+
+@pytest.mark.parametrize("initial_idx", CONTENT_IDXS)
+@pytest.mark.parametrize("final_idx", CONTENT_IDXS)
+def test_write_transaction(tmp_path: pathlib.Path, initial_idx: int, final_idx: int):
+    initial, final = CONTENT[initial_idx], CONTENT[final_idx]
+    file_path = tmp_path / "test_file.txt"
+    file_path.write_text(initial)
+    with write_transaction(file_path) as out_stream:
+        for line in final.splitlines(keepends=True):
+            out_stream.write(line)
+            assert file_path.read_text() == initial
+    assert file_path.read_text() == final
+
+
+@pytest.mark.parametrize("initial_idx", CONTENT_IDXS)
+@pytest.mark.parametrize("final_idx", CONTENT_IDXS)
+@pytest.mark.parametrize(
+    "failure",
+    [KeyError, EOFError, IOError, GeneratorExit, SystemExit],
+)
+def test_write_transaction_failure(
+    tmp_path: pathlib.Path,
+    initial_idx: int,
+    final_idx: int,
+    failure: "type[BaseException]",
+):
+    initial, final = CONTENT[initial_idx], CONTENT[final_idx]
+    file_path = tmp_path / "test_file.txt"
+    file_path.write_text(initial)
+    with write_transaction(file_path) as out_stream, pytest.raises(failure):
+        for line in final.splitlines(keepends=True):
+            out_stream.write(line)
+            assert file_path.read_text() == initial
+        raise failure
+    assert file_path.read_text() == final


### PR DESCRIPTION
This PR adds an "atomic write" for the APEL timestamp JSON. This avoids an (admittedly rare) race where opening the JSON for writing but not actually writing the content due to shutdown would leave the file empty.