### PR TITLE
drop support for Python 3.8

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -30,7 +30,7 @@ jobs:
   build-pyauditor-linux:
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
     uses: ./.github/workflows/build_pyauditor_linux.yml
     with:
       python-version: ${{ matrix.python-version }}
@@ -38,7 +38,7 @@ jobs:
   build-pyauditor-windows:
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
     uses: ./.github/workflows/build_pyauditor_windows.yml
     with:
       python-version: ${{ matrix.python-version }}
@@ -46,7 +46,7 @@ jobs:
   build-pyauditor-macos:
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
     uses: ./.github/workflows/build_pyauditor_macos.yml
     with:
       python-version: ${{ matrix.python-version }}
@@ -54,7 +54,7 @@ jobs:
   python-code-tests:
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
     needs: build-pyauditor-linux
     uses: ./.github/workflows/python_code_tests.yml
     with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Breaking changes
+- pyauditor + Apel plugin + HTCondor collector: drop support for Python 3.8 ([@dirksammel](https://github.com/dirksammel))
 
 ### Security
 

--- a/collectors/htcondor/pyproject.toml
+++ b/collectors/htcondor/pyproject.toml
@@ -10,7 +10,7 @@ packages = ["auditor_htcondor_collector"]
 name = "auditor-htcondor-collector"
 description = "AUDITOR collector for aggregating data from the HTCondor batch system"
 version = "0.6.3"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 dependencies = [
     "pyyaml==6.0.2",
     "python-auditor==0.6.3"

--- a/containers/auditor-apel-plugin/Dockerfile
+++ b/containers/auditor-apel-plugin/Dockerfile
@@ -2,7 +2,7 @@
 # BUILDER IMAGE #
 #################
 
-FROM python:3.8.17-slim-bookworm AS builder
+FROM python:3.9-slim-bookworm AS builder
 
 # install build dependencies and create python env
 RUN set -ex                                                          \
@@ -39,7 +39,7 @@ RUN    pip install --no-cache-dir /code/pyauditor/*.whl \
 # RUNNER IMAGE #
 ################
 
-FROM python:3.8.17-slim-bookworm AS runner
+FROM python:3.9-slim-bookworm AS runner
 
 # prevent python from writing *.pyc files to disc
 ENV PYTHONDONTWRITEBYTECODE=1

--- a/plugins/apel/pyproject.toml
+++ b/plugins/apel/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "auditor_apel_plugin"
 version = "0.6.3"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 dependencies = [
 	     "python-auditor==0.6.3",
 	     "requests==2.32.3",

--- a/pyauditor/docs/index.rst
+++ b/pyauditor/docs/index.rst
@@ -14,7 +14,7 @@ It provides functionality to create records and send records to and receive reco
 Installation
 ============
 
-pyauditor requires a Python version >= 3.8.
+pyauditor requires a Python version >= 3.9.
 
 .. code-block::
 

--- a/pyauditor/pyproject.toml
+++ b/pyauditor/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "python-auditor"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 authors = [
     { name = "Stefan Kroboth", email = "stefan.kroboth@gmail.com" }
 ]


### PR DESCRIPTION
This PR drops the support for Python 3.8 which is now EOL. Updating some dependencies already fails since they also dropped the support.