### PR TITLE
add workflow to test python publishing

### DIFF
--- a/.github/workflows/test_python_release.yml
+++ b/.github/workflows/test_python_release.yml
@@ -1,0 +1,76 @@
+name: test-python-release
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build-pyauditor:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Cache dependencies
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: cache-dependencies-pyauditor
+
+      # We need to somehow get the SQLX_OFFLINE env variable into the container.
+      # Since `maturin-action` doesn't enable us to do that, we have to tell cargo
+      # via its configuration.
+      - name: Create fake .cargo/config.toml
+        run: |
+          mkdir -p .cargo
+          echo -e "[env]\nSQLX_OFFLINE = \"true\"" >> .cargo/config.toml
+
+      - name: Generate dynamic version
+        id: version
+        run: |
+          timestamp=$(date +%Y%m%d%H%M%S)
+          short_sha=$(git rev-parse --short HEAD)
+          echo "version=0.0.0.dev${timestamp}+${short_sha}" >> $GITHUB_OUTPUT
+
+      - name: Update version in pyproject.toml
+        run: |
+          sed -i "s/version = .*/version = \"${{ steps.version.outputs.version }}\"/" pyauditor/pyproject.toml
+          cat pyauditor/pyproject.toml
+          
+      - name: Maturin
+        uses: messense/maturin-action@v1
+        with:
+          maturin-version: v1.2.3
+          target: x86_64
+          manylinux: auto
+          command: build
+          args: --release -o dist --interpreter python3.9 --manifest-path pyauditor/Cargo.toml
+
+      - name: Upload wheel
+        uses: actions/upload-artifact@v4
+        with:
+          path: dist
+          name: pyauditor-wheels-linux-3.9
+          
+  release-pyauditor:
+    needs: build-pyauditor
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: write
+    steps:
+      - name: Download pyauditor wheels
+        uses: actions/download-artifact@v4
+        with:
+          pattern: pyauditor-wheels-*
+          path: dist
+          merge-multiple: true
+
+      - name: Setup python
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.9
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/
+          attestations: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+### Added
+- CI: Add workflow to test publishing to the PyPI test repo ([@dirksammel](https://github.com/dirksammel))
+
 ### Changed
 - Auditor Docker container: Switch from fixed to latest Rust version ([@dirksammel](https://github.com/dirksammel))
 - Dependencies: Update crate-ci/typos from 1.26.8 to 1.27.2 ([@dirksammel](https://github.com/dirksammel))


### PR DESCRIPTION
This PR adds a workflow that tests the release pipeline for the Python packages. The workflow has to be triggered manually and publishes `pyauditor` to the PyPI test repo.