### PR TITLE
remove opentelemetry_api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Apel plugin: Update timestamp JSON atomically ([@maxfischer2781](https://github.com/maxfischer2781))
 
 ### Removed
+- Dependencies: Remove opentelemetry_api (replaced by opentelemetry) ([@dirksammel](https://github.com/dirksammel))
 
 ## [0.6.3] - 2024-10-30
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,6 @@ num-traits = "0.2.19"
 once_cell = "1.19.0"
 opentelemetry = "0.23.0"
 opentelemetry-prometheus = "0.16.0"
-opentelemetry_api = "0.20.0"
 opentelemetry_sdk = "0.23.0"
 prometheus = "0.13.4"
 pyo3 = { version = "0.20.3", features = ["chrono", "extension-module", "anyhow"] }

--- a/auditor/Cargo.toml
+++ b/auditor/Cargo.toml
@@ -45,7 +45,6 @@ itertools.workspace = true
 num-traits.workspace = true
 opentelemetry-prometheus.workspace = true
 opentelemetry.workspace = true
-opentelemetry_api.workspace = true
 opentelemetry_sdk.workspace = true
 prometheus.workspace = true
 rand.workspace = true

--- a/plugins/priority/Cargo.toml
+++ b/plugins/priority/Cargo.toml
@@ -40,7 +40,6 @@ config.workspace = true
 num-traits.workspace = true
 opentelemetry-prometheus.workspace = true
 opentelemetry.workspace = true
-opentelemetry_api.workspace = true
 opentelemetry_sdk.workspace = true
 prometheus.workspace = true
 serde-aux.workspace = true


### PR DESCRIPTION
This PR removes `opentelemetry_api`, since it's no longer maintained and is now included in `opentelemetry`.
Closes #1049.