### PR TITLE
remove decoding from APEL plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Breaking changes
-- AUDITOR: Remove forbidden characters ([@raghuvar-vijay](https://github.com/raghuvar-vijay))
+- AUDITOR, plugins and collectors: Remove forbidden characters ([@raghuvar-vijay](https://github.com/raghuvar-vijay)), ([@dirksammel](https://github.com/dirksammel))
 - pyauditor + Apel plugin + HTCondor collector: drop support for Python 3.8 ([@dirksammel](https://github.com/dirksammel))
 - AUDITOR, plugins and collectors: parameter use_tls has to be added to config files ([@raghuvar-vijay](https://github.com/raghuvar-vijay)), ([@dirksammel](https://github.com/dirksammel))
 

--- a/plugins/apel/src/auditor_apel_plugin/core.py
+++ b/plugins/apel/src/auditor_apel_plugin/core.py
@@ -7,7 +7,6 @@ import json
 import logging
 import sqlite3
 import sys
-import urllib
 from datetime import datetime, time, timedelta, timezone
 from sqlite3 import Error
 from time import sleep
@@ -167,12 +166,6 @@ def update_time_json(config, time_dict, site, stop_time, report_time):
         raise
 
 
-def replace_record_string(string):
-    updated_string = urllib.parse.unquote(string)
-
-    return updated_string
-
-
 def get_site_id(config, record):
     meta_key_site = config["auditor"]["meta_key_site"]
 
@@ -192,7 +185,7 @@ def get_voms_info(config, record):
     voms_dict = {}
 
     try:
-        voms_string = replace_record_string(record.meta.get(meta_key_voms)[0])
+        voms_string = record.meta.get(meta_key_voms)[0]
     except TypeError:
         logger.warning(
             f"No VOMS information found in {record.record_id}, "
@@ -356,7 +349,7 @@ def get_data_tuple(
         year = record.stop_time.replace(tzinfo=timezone.utc).year
         submithost_field = config.get_optional_fields().get("SubmitHost")
         if submithost_field is not None:
-            submithost = replace_record_string(submithost_field.get_value(record))
+            submithost = submithost_field.get_value(record)
         else:
             submithost = "None"
 
@@ -366,10 +359,6 @@ def get_data_tuple(
 
     for v in fields_dict.values():
         value = v.get_value(record)
-
-        if isinstance(value, str):
-            value = replace_record_string(value)
-
         value_list.append(value)
 
     data_tuple = tuple(value_list)

--- a/plugins/apel/tests/test_auditor_apel_plugin.py
+++ b/plugins/apel/tests/test_auditor_apel_plugin.py
@@ -22,7 +22,6 @@ from auditor_apel_plugin.core import (
     get_start_time,
     get_time_json,
     get_voms_info,
-    replace_record_string,
     sign_msg,
     update_time_json,
 )
@@ -627,9 +626,9 @@ class TestAuditorApelPlugin:
             "tot_cpu": 15520000,
             "n_nodes": 1,
             "site": "test-site-1",
-            "submit_host": "https:%2F%2Ftest1.submit_host.de:1234%2Fxxx",
-            "user_name": "%2FDC=ch%2FDC=cern%2FOU=Users%2FCN=test1: test1",
-            "voms": "%2Fatlas%2FRole=production",
+            "submit_host": "https://test1.submit_host.de:1234/xxx",
+            "user_name": "/DC=ch/DC=cern/OU=Users/CN=test1: test1",
+            "voms": "/atlas/Role=production",
         }
 
         rec_2_values = {
@@ -641,9 +640,9 @@ class TestAuditorApelPlugin:
             "tot_cpu": 12234325,
             "n_nodes": 2,
             "site": "test-site-2",
-            "submit_host": "https:%2F%2Ftest2.submit_host.de:1234%2Fxxx",
-            "user_name": "%2FDC=ch%2FDC=cern%2FOU=Users%2FCN=test2: test2",
-            "voms": "%2Fatlas",
+            "submit_host": "https://test2.submit_host.de:1234/xxx",
+            "user_name": "/DC=ch/DC=cern/OU=Users/CN=test2: test2",
+            "voms": "/atlas",
         }
 
         rec_3_values = {
@@ -657,8 +656,8 @@ class TestAuditorApelPlugin:
             "site": "test-site-2",
             "user": "second_user",
             "submit_host": None,
-            "user_name": "%2FDC=ch%2FDC=cern%2FOU=Users%2FCN=test2: test2",
-            "voms": "%2Fatlas%2Fde%2FRole=production",
+            "user_name": "/DC=ch/DC=cern/OU=Users/CN=test2: test2",
+            "voms": "/atlas/de/Role=production",
         }
 
         rec_4_values = {
@@ -672,8 +671,8 @@ class TestAuditorApelPlugin:
             "site": "test-site-2",
             "user": "second_user",
             "submit_host": None,
-            "user_name": "%2FDC=ch%2FDC=cern%2FOU=Users%2FCN=test2: test2",
-            "voms": "%2Fatlas%2Fde",
+            "user_name": "/DC=ch/DC=cern/OU=Users/CN=test2: test2",
+            "voms": "/atlas/de",
         }
 
         rec_5_values = {
@@ -687,7 +686,7 @@ class TestAuditorApelPlugin:
             "site": "test-site-2",
             "user": "second_user",
             "submit_host": None,
-            "user_name": "%2FDC=ch%2FDC=cern%2FOU=Users%2FCN=test2: test2",
+            "user_name": "/DC=ch/DC=cern/OU=Users/CN=test2: test2",
             "voms": None,
         }
 
@@ -702,7 +701,7 @@ class TestAuditorApelPlugin:
             "site": "test-site-2",
             "user": "second_user",
             "submit_host": None,
-            "user_name": "%2FDC=ch%2FDC=cern%2FOU=Users%2FCN=test2: test2",
+            "user_name": "/DC=ch/DC=cern/OU=Users/CN=test2: test2",
             "voms": "atlas",
         }
 
@@ -754,20 +753,6 @@ class TestAuditorApelPlugin:
         assert result["vo"] is None
         assert result["vogroup"] is None
         assert result["vorole"] is None
-
-    def test_replace_record_string(self):
-        test_str_1 = "abcd"
-        test_str_2 = "%2Fa%2Fb%2Fc%2Fd%2F"
-        test_str_3 = "El%20Ni%C3%B1o"
-
-        result = replace_record_string(test_str_1)
-        assert result == "abcd"
-
-        result = replace_record_string(test_str_2)
-        assert result == "/a/b/c/d/"
-
-        result = replace_record_string(test_str_3)
-        assert result == "El Niño"
 
     def test_get_records(self):
         with open(Path.joinpath(test_dir, "test_config.yml"), "r") as f:
@@ -853,9 +838,9 @@ class TestAuditorApelPlugin:
             "tot_cpu": 15520000,
             "n_nodes": 1,
             "site": "test-site-1",
-            "submit_host": "https:%2F%2Ftest1.submit_host.de:1234%2Fxxx",
-            "user_name": "%2FDC=ch%2FDC=cern%2FOU=Users%2FCN=test1: test1",
-            "voms": "%2Fatlas%2Fde",
+            "submit_host": "https://test1.submit_host.de:1234/xxx",
+            "user_name": "/DC=ch/DC=cern/OU=Users/CN=test1: test1",
+            "voms": "/atlas/de",
         }
 
         rec_2_values = {
@@ -867,9 +852,9 @@ class TestAuditorApelPlugin:
             "tot_cpu": 12234325,
             "n_nodes": 2,
             "site": "test-site-2",
-            "submit_host": "https:%2F%2Ftest2.submit_host.de:1234%2Fxxx",
-            "user_name": "%2FDC=ch%2FDC=cern%2FOU=Users%2FCN=test2: test2",
-            "voms": "%2Fatlas%2Fde",
+            "submit_host": "https://test2.submit_host.de:1234/xxx",
+            "user_name": "/DC=ch/DC=cern/OU=Users/CN=test2: test2",
+            "voms": "/atlas/de",
         }
 
         rec_1 = create_rec(rec_1_values, conf["auditor"])
@@ -922,9 +907,9 @@ class TestAuditorApelPlugin:
             "tot_cpu": 15520000,
             "n_nodes": 1,
             "site": None,
-            "submit_host": "https:%2F%2Ftest1.submit_host.de:1234%2Fxxx",
-            "user_name": "%2FDC=ch%2FDC=cern%2FOU=Users%2FCN=test1: test1",
-            "voms": "%2Fatlas%2Fde",
+            "submit_host": "https://test1.submit_host.de:1234/xxx",
+            "user_name": "/DC=ch/DC=cern/OU=Users/CN=test1: test1",
+            "voms": "/atlas/de",
         }
 
         rec_2_values = {
@@ -936,9 +921,9 @@ class TestAuditorApelPlugin:
             "tot_cpu": 12234325,
             "n_nodes": 2,
             "site": "test-site-2",
-            "submit_host": "https:%2F%2Ftest2.submit_host.de:1234%2Fxxx",
-            "user_name": "%2FDC=ch%2FDC=cern%2FOU=Users%2FCN=test2: test2",
-            "voms": "%2Fatlas%2Fde",
+            "submit_host": "https://test2.submit_host.de:1234/xxx",
+            "user_name": "/DC=ch/DC=cern/OU=Users/CN=test2: test2",
+            "voms": "/atlas/de",
         }
 
         rec_1 = create_rec(rec_1_values, conf["auditor"])
@@ -1030,9 +1015,9 @@ class TestAuditorApelPlugin:
             "tot_cpu": 15520000,
             "n_nodes": 1,
             "site": "test-site-1",
-            "submit_host": "https:%2F%2Ftest1.submit_host.de:1234%2Fxxx",
-            "user_name": "%2FDC=ch%2FDC=cern%2FOU=Users%2FCN=test1: test1",
-            "voms": "%2Fatlas%2Fde",
+            "submit_host": "https://test1.submit_host.de:1234/xxx",
+            "user_name": "/DC=ch/DC=cern/OU=Users/CN=test1: test1",
+            "voms": "/atlas/de",
         }
 
         rec_2_values = {
@@ -1044,9 +1029,9 @@ class TestAuditorApelPlugin:
             "tot_cpu": 12234325,
             "n_nodes": 2,
             "site": "test-site-2",
-            "submit_host": "https:%2F%2Ftest2.submit_host.de:1234%2Fxxx",
-            "user_name": "%2FDC=ch%2FDC=cern%2FOU=Users%2FCN=test2: test2",
-            "voms": "%2Fatlas%2Fde",
+            "submit_host": "https://test2.submit_host.de:1234/xxx",
+            "user_name": "/DC=ch/DC=cern/OU=Users/CN=test2: test2",
+            "voms": "/atlas/de",
         }
 
         rec_value_list = [rec_1_values, rec_2_values]


### PR DESCRIPTION
This PR removes the decoding of values from the APEL plugin since encoding will be removed from the AUDITOR records.