### PR TITLE
show error information from APEL token endpoint

### DIFF
--- a/plugins/apel/src/auditor_apel_plugin/core.py
+++ b/plugins/apel/src/auditor_apel_plugin/core.py
@@ -466,10 +466,15 @@ def get_token(config):
     except requests.Timeout:
         logger.critical("Timeout while getting token")
         raise
-
-    token = response.json()["token"]
-
-    return token
+    try:
+        return response.json()["token"]
+    except KeyError:
+        if error_message := response.json().get("error", {}).get("message"):
+            raise RuntimeError(
+                f"could not get authentication token: {error_message} [{response.status_code} {response.reason}]"
+            )
+        response.raise_for_status()
+        raise
 
 
 def sign_msg(config, msg):


### PR DESCRIPTION
This PR improves the information provided when getting the security token from APEL fails. Since this usually ties into an issue with third-party configuration (namely missing GOCDB entry) just having a bare `KeyError` when the response contains no token is arcane.

The change tries to format APEL server response and failing that formats the bare HTTP response code/message.

The new error looks like this:
```
Traceback (most recent call last):
  File "/opt/auditor/venv/lib64/python3.11/site-packages/auditor_apel_plugin/core.py", line 469, in get_token
    return response.json()["token"]
           ~~~~~~~~~~~~~~~^^^^^^^^^
KeyError: 'token'
During handling of the above exception, another exception occurred:
Traceback (most recent call last):
  File "/opt/auditor/venv/bin/auditor-apel-publish", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File "/opt/auditor/venv/lib64/python3.11/site-packages/auditor_apel_plugin/publish.py", line 164, in main
    run(logger, config, client)
  File "/opt/auditor/venv/lib64/python3.11/site-packages/auditor_apel_plugin/publish.py", line 45, in run
    token = get_token(config)
            ^^^^^^^^^^^^^^^^^
  File "/opt/auditor/venv/lib64/python3.11/site-packages/auditor_apel_plugin/core.py", line 472, in get_token
    raise RuntimeError(
RuntimeError: could not get authentication token: Binding was not found [404 Not Found]
```
The previous error was just the bit up to `KeyError: 'token'`.