### PR TITLE
switch to argo AMS library for messaging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Breaking changes
+- Apel plugin: `authentication` part of the config is now `messaging` and has different content ([@dirksammel](https://github.com/dirksammel))
 
 ### Security
 
 ### Added
 
 ### Changed
+- Apel plugin: Switch to the Argo AMS library for messaging ([@dirksammel](https://github.com/dirksammel))
 - Dependencies: Update ruff from 0.9.7 to 0.9.8 ([@dirksammel](https://github.com/dirksammel))
 
 ### Removed

--- a/codecov.yaml
+++ b/codecov.yaml
@@ -23,6 +23,10 @@ component_management:
       name: slurm_epilog_collector
       paths:
         - collectors/slurm-epilog/**
+    - component_id: module_kubernetes_collector
+      name: kubernetes_collector
+      paths:
+        - collectors/kubernetes/**
     - component_id: module_htcondor_collector
       name: htcondor_collector
       paths:

--- a/media/website/content/_index.md
+++ b/media/website/content/_index.md
@@ -800,7 +800,11 @@ options:
                         Path to the config file
 ```
 
-The config file is written in YAML format and has the main sections `plugin`, `site`, `authentication`, `auditor`, and at least one of `summary_fields` or `individual_job_fields`.
+The config file is written in YAML format and has the main sections `plugin`, `site`, `messaging`, `auditor`, and one of `summary_fields` or `individual_job_fields`.
+
+Please note that the example config below is not ready for usage! Make sure that all values (file paths, URLS, IPs, ports, etc.) correspond to your setup, especially the names of the AUDITOR record fields you want to access. 
+
+You only need the `summary_fields` OR the `individual_job_fields` section, depending on the value for `message_type` in the `plugin` section.
 
 Example config:
 
@@ -818,13 +822,15 @@ site:
     SITE_A: ["site_id_1", "site_id_2"]
     SITE_B: ["site_id_3"]
 
-authentication:
-  auth_url: https://msg.argo.grnet.gr:8443/v1/service-types/ams/hosts/msg.argo.grnet.gr:authx509
-  ams_url: https://msg-devel.argo.grnet.gr:443/v1/projects/accounting/topics/gLite-APEL:publish?key=
+messaging:
+  host: msg.argo.grnet.gr
+  port: 8443
   client_cert: /etc/grid-security/hostcert.pem
   client_key: /etc/grid-security/hostkey.pem
-  ca_path: /etc/grid-security/certificates
-  verify_ca: True
+  project: accounting
+  topic: gLite-APEL
+  timeout: 10
+  retry: 3
 
 auditor:
   ip: 127.0.0.1
@@ -916,28 +922,30 @@ individual_job_fields:
 
 The individual parameters in the config file are:
 
-| Section          | Parameter          | Description                                                                                                                                                                                                                                         |
-|------------------|--------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `plugin`         | `log_level`        | Can be set to `TRACE`, `DEBUG`, `INFO`, `WARNING`, `ERROR`, or `CRITICAL` (with decreasing verbosity). `TRACE` might produce a lot of output if `message_type` is set to `individual_jobs`, since the message that will be sent to APEL is printed. |
-| `plugin`         | `time_json_path`   | Path of the `time.json` file. The JSON file should be located at a persistent path and stores the stop times of the latest reported job per site, and the time of the latest report to APEL.                                                        |
-| `plugin`         | `report_interval`  | Time in seconds between reports to APEL.                                                                                                                                                                                                            |
-| `plugin`         | `message_type`     | Type of message to create. Can be set to `summaries` or `individual_jobs`.                                                                                                                                                                          |
-| `site`           | `publish_since`    | Date and time in ISO 8601 format (in UTC, hence add +00:00) after which jobs will be published. Only relevant for first run when no `time.json` is present yet.                                                                                     |
-| `site`           | `sites_to_report`  | Dictionary of the sites that will be reported. The keys are the names of the sites in the GOCDB, the values are lists of the corresponding site names in the AUDITOR records.                                                                       |
-| `authentication` | `auth_url`         | URL from which the APEL authentication token is received.                                                                                                                                                                                           |
-| `authentication` | `ams_url`          | URL to which the reports are sent.                                                                                                                                                                                                                  |
-| `authentication` | `client_cert`      | Path of the host certificate.                                                                                                                                                                                                                       |
-| `authentication` | `client_key`       | Path of the host key.                                                                                                                                                                                                                               |
-| `authentication` | `ca_path`          | Path of the local certificate folder.                                                                                                                                                                                                               |
-| `authentication` | `verify_ca`        | Controls the verification of the certificate of the APEL server. Can be set to `True` or `False` (the latter might be necessary for local test setups).                                                                                             |
-| `auditor`        | `ip`               | IP of the AUDITOR instance.                                                                                                                                                                                                                         |
-| `auditor`        | `port`             | Port of the AUDITOR instance.                                                                                                                                                                                                                       |
-| `auditor`        | `timeout`          | Time in seconds after which the connection to the AUDITOR instance times out.                                                                                                                                                                       |
-| `auditor`        | `site_meta_field`  | Name of the field that stores the name of the site in the AUDITOR records.                                                                                                                                                                          |
-| `auditor`        | `use_tls`          | Specifies whether TLS is enabled (`True`) or disabled (`False`).                                                                                                                                                                                    |
-| `auditor`        | `ca_cert_path`     | Path to the root Certificate Authority (CA) certificate for validating certificates. Only needed if `use_tls` is True.                                                                                                                              |
-| `auditor`        | `client_cert_path` | Path to the client's TLS certificate, used for mutual TLS (mTLS) authentication. Only needed if `use_tls` is True.                                                                                                                                  |
-| `auditor`        | `client_key_path`  | Path to the client's private key used for TLS. Only needed if `use_tls` is True.                                                                                                                                                                    |
+| Section     | Parameter          | Description                                                                                                                                                                                                                                         |
+|-------------|--------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `plugin`    | `log_level`        | Can be set to `TRACE`, `DEBUG`, `INFO`, `WARNING`, `ERROR`, or `CRITICAL` (with decreasing verbosity). `TRACE` might produce a lot of output if `message_type` is set to `individual_jobs`, since the message that will be sent to APEL is printed. |
+| `plugin`    | `time_json_path`   | Path of the `time.json` file. The JSON file should be located at a persistent path and stores the stop times of the latest reported job per site, and the time of the latest report to APEL.                                                        |
+| `plugin`    | `report_interval`  | Time in seconds between reports to APEL.                                                                                                                                                                                                            |
+| `plugin`    | `message_type`     | Type of message to create. Can be set to `summaries` or `individual_jobs`.                                                                                                                                                                          |
+| `site`      | `publish_since`    | Date and time in ISO 8601 format (in UTC, hence add +00:00) after which jobs will be published. Only relevant for first run when no `time.json` is present yet.                                                                                     |
+| `site`      | `sites_to_report`  | Dictionary of the sites that will be reported. The keys are the names of the sites in the GOCDB, the values are lists of the corresponding site names in the AUDITOR records.                                                                       |
+| `messaging` | `host`             | Host address of the AMS service.                                                                                                                                                                                                                    |
+| `messaging` | `port`             | Port of the AMS host.                                                                                                                                                                                                                               |
+| `messaging` | `client_cert`      | Path of the host certificate.                                                                                                                                                                                                                       |
+| `messaging` | `client_key`       | Path of the host key.                                                                                                                                                                                                                               |
+| `messaging` | `project`          | Name of the project registered in the AMS service.                                                                                                                                                                                                  |
+| `messaging` | `topic`            | Name of the topic to publish the message.                                                                                                                                                                                                           |
+| `messaging` | `timeout`          | Timeout in seconds for sending the message to APEL.                                                                                                                                                                                                 |
+| `messaging` | `retry`            | Number of retries for sending the message to APEL.                                                                                                                                                                                                  |
+| `auditor`   | `ip`               | IP of the AUDITOR instance.                                                                                                                                                                                                                         |
+| `auditor`   | `port`             | Port of the AUDITOR instance.                                                                                                                                                                                                                       |
+| `auditor`   | `timeout`          | Time in seconds after which the connection to the AUDITOR instance times out.                                                                                                                                                                       |
+| `auditor`   | `site_meta_field`  | Name of the field that stores the name of the site in the AUDITOR records.                                                                                                                                                                          |
+| `auditor`   | `use_tls`          | Specifies whether TLS is enabled (`True`) or disabled (`False`).                                                                                                                                                                                    |
+| `auditor`   | `ca_cert_path`     | Path to the root Certificate Authority (CA) certificate for validating certificates. Only needed if `use_tls` is True.                                                                                                                              |
+| `auditor`   | `client_cert_path` | Path to the client's TLS certificate, used for mutual TLS (mTLS) authentication. Only needed if `use_tls` is True.                                                                                                                                  |
+| `auditor`   | `client_key_path`  | Path to the client's private key used for TLS. Only needed if `use_tls` is True.                                                                                                                                                                    |
 
 The main sections `summary_fields` and `individual_job_fields` have the subsections `mandatory` and `optional`. `mandatory` contains the fields that have to be present in the APEL message, therefore the plugin needs to know how to get the information from the AUDITOR records. The mandatory fields are:
 
@@ -970,7 +978,7 @@ There are actually more mandatory fields, but they are handled internally and do
 
 The information about the possible fields, their required data types, and what is mandatory or optional, is taken from [https://github.com/apel/apel/tree/master/apel/db/records](https://github.com/apel/apel/tree/master/apel/db/records).
 
-Please make sure that the information you extract from the AUDITOR records has the correct data type as expected by APEL!
+Please make sure that the information you extract from the AUDITOR records has the correct data type as expected by APEL! This is documented here: [https://docs.egi.eu/internal/accounting/record-and-message-formats/grid-accounting/](https://docs.egi.eu/internal/accounting/record-and-message-formats/grid-accounting/).
 
 Different field types are available, depending on the source of the value that is needed: `ComponentField`, `MetaField`, `ConstantField`, `ScoreField`, `NormalisedField`, and `NormalisedWallDurationField`. The type to be used is indicated after the name of the field with a leading exclamation mark, e.g. `Processors: !ComponentField`.
 

--- a/media/website/content/migration.md
+++ b/media/website/content/migration.md
@@ -6,6 +6,10 @@ weight = 3
 
 # From 0.7.1 to unreleased
 
+## Apel plugin
+
+Due to the switch to the ARGO AMS library, the config file has to be adjusted. The `authentication` section needs to be replaced with the new `messaging` section. Please have a look at the example config in the [documentation](https://alu-schumacher.github.io/AUDITOR/latest/#apel-plugin).
+
 # From 0.7.0 to 0.7.1
 
 Please backup your db before proceeding with any changes that are listed below.
@@ -65,7 +69,7 @@ An example config is provided at the following directory in the github repositor
 | `ca_cert_path`       | String          | Path to the root Certificate Authority (CA) certificate for validating server certificates. | `/path/rootCA.pem`             | Yes                              |
 | `client_cert_path`   | String          | Path to the client's TLS certificate.                                                       | `/path/client-cert.pem`        | Yes                              |
 | `client_key_path`    | String          | Path to the client's private key used for TLS.                                              | `/path/client-key.pem`         | Yes                              |
-Please have a look at the AUDITOR documentation for the new changes in the config files for [collectors](https://alu-schumacher.github.io/AUDITOR/latest/#collectors) and [plugins](https://alu-schumacher.github.io/AUDITOR/latest/#plugins)
+Please have a look at the AUDITOR documentation for the new changes in the config files for [collectors](https://alu-schumacher.github.io/AUDITOR/latest/#collectors) and [plugins](https://alu-schumacher.github.io/AUDITOR/latest/#plugins).
 
 # From 0.6.2 to 0.6.3
 
@@ -77,7 +81,7 @@ Use this command to update the sqlx-cli to 0.8.2
 
 ## Auditor DB:
 - WARNING: Please create a backup of the database before running the migration script.
-- AUDITOR db should be migrated to use the new schema. Run `sqlx migrate run --source migration` from the AUDITOR home directory. It is also possible using the container which can be found here [Documentation](../#migrating-the-database)
+- AUDITOR db should be migrated to use the new schema. Run `sqlx migrate run --source migration` from the AUDITOR home directory. It is also possible using the container which can be found here [Documentation](../#migrating-the-database).
 
 ## Apel plugin
 

--- a/plugins/apel/pyproject.toml
+++ b/plugins/apel/pyproject.toml
@@ -8,10 +8,10 @@ version = "0.7.1"
 requires-python = ">=3.9"
 dependencies = [
 	     "python-auditor==0.7.1",
-	     "requests==2.32.3",
 	     "cryptography==44.0.1",
 	     "pyyaml==6.0.2",
 	     "pydantic==2.10.6",
+	     "argo-ams-library==0.6.2",
 ]
 description = "AUDITOR plugin for sending accounting data to APEL"
 readme = "README.md"
@@ -26,7 +26,6 @@ tests = [
       "pytest-cov==6.0.0",
       "mypy==1.15.0",	
       "types-pyyaml==6.0.12.20241230",
-      "types-requests==2.32.0.20241016",
 ]
 build = [
       "build==1.2.2.post1",
@@ -57,7 +56,7 @@ testpaths = ["tests"]
 filterwarnings = ["ignore::DeprecationWarning"]
 
 [[tool.mypy.overrides]]
-module = "pyauditor"
+module = ["pyauditor", "argo_ams_library"]
 ignore_missing_imports = true
 
 [tool.ruff.lint]

--- a/plugins/apel/src/auditor_apel_plugin/config.py
+++ b/plugins/apel/src/auditor_apel_plugin/config.py
@@ -80,13 +80,15 @@ class AuditorConfig(Configurable):
         return self
 
 
-class AuthConfig(Configurable):
-    auth_url: str
-    ams_url: str
+class MessageConfig(Configurable):
+    host: str
+    port: int
     client_cert: str
     client_key: str
-    ca_path: str
-    verify_ca: bool
+    project: str
+    topic: str
+    timeout: int
+    retry: int
 
 
 class Field(Configurable):
@@ -259,7 +261,7 @@ class Config(Configurable):
     plugin: PluginConfig
     site: SiteConfig
     auditor: AuditorConfig
-    authentication: AuthConfig
+    messaging: MessageConfig
     summary_fields: Optional[FieldConfig] = None
     individual_job_fields: Optional[FieldConfig] = None
 

--- a/plugins/apel/src/auditor_apel_plugin/publish.py
+++ b/plugins/apel/src/auditor_apel_plugin/publish.py
@@ -4,7 +4,6 @@
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 
 import argparse
-import base64
 import logging
 from datetime import datetime, timedelta, timezone
 from logging import Logger
@@ -25,7 +24,6 @@ from auditor_apel_plugin.core import (
     get_report_time,
     get_start_time,
     get_time_json,
-    get_token,
     group_db,
     send_payload,
     sign_msg,
@@ -41,9 +39,6 @@ def run(logger: Logger, config: Config, client):
     message_type = config.plugin.message_type
     field_dict = config.get_all_fields()
     optional_fields = config.get_optional_fields()
-
-    token = get_token(config)
-    logger.debug(token)
 
     while True:
         time_dict = get_time_json(config)
@@ -82,12 +77,10 @@ def run(logger: Logger, config: Config, client):
             logger.debug(sync_message)
             signed_sync = sign_msg(config, sync_message)
             logger.debug(signed_sync)
-            encoded_sync = base64.b64encode(signed_sync).decode("utf-8")
-            logger.debug(encoded_sync)
-            payload_sync = build_payload(encoded_sync)
+            payload_sync = build_payload(signed_sync)
             logger.debug(payload_sync)
-            post_sync = send_payload(config, token, payload_sync)
-            logger.debug(post_sync.status_code)
+            post_sync = send_payload(config, payload_sync)
+            logger.debug(post_sync)
 
             if message_type == MessageType.individual_jobs:
                 start_time = get_start_time(config, time_dict, site)
@@ -109,12 +102,10 @@ def run(logger: Logger, config: Config, client):
             logger.log(TRACE, message)
             signed_message = sign_msg(config, message)
             logger.log(TRACE, signed_message)
-            encoded_message = base64.b64encode(signed_message).decode("utf-8")
-            logger.log(TRACE, encoded_message)
-            payload_message = build_payload(encoded_message)
+            payload_message = build_payload(signed_message)
             logger.log(TRACE, payload_message)
-            post_message = send_payload(config, token, payload_message)
-            logger.debug(post_message.status_code)
+            post_message = send_payload(config, payload_message)
+            logger.debug(post_message)
 
             latest_report_time = datetime.now()
             update_time_json(

--- a/plugins/apel/src/auditor_apel_plugin/republish.py
+++ b/plugins/apel/src/auditor_apel_plugin/republish.py
@@ -4,7 +4,6 @@
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 
 import argparse
-import base64
 import logging
 import sys
 from datetime import datetime
@@ -20,7 +19,6 @@ from auditor_apel_plugin.core import (
     create_message,
     fill_db,
     get_records,
-    get_token,
     group_db,
     send_payload,
     sign_msg,
@@ -45,9 +43,6 @@ def run(logger: Logger, config, client, args):
         logger.critical("No records found!")
         sys.exit(1)
 
-    token = get_token(config)
-    logger.debug(token)
-
     db = create_db(field_dict, message_type)
     filled_db = fill_db(config, db, message_type, field_dict, site, records)
     grouped_db = group_db(filled_db, message_type, optional_fields)
@@ -55,12 +50,10 @@ def run(logger: Logger, config, client, args):
     logger.log(TRACE, message)
     signed_message = sign_msg(config, message)
     logger.log(TRACE, signed_message)
-    encoded_message = base64.b64encode(signed_message).decode("utf-8")
-    logger.log(TRACE, encoded_message)
-    payload_message = build_payload(encoded_message)
+    payload_message = build_payload(signed_message)
     logger.log(TRACE, payload_message)
-    post_message = send_payload(config, token, payload_message)
-    logger.debug(post_message.status_code)
+    post_message = send_payload(config, payload_message)
+    logger.debug(post_message)
 
 
 def main():

--- a/plugins/apel/tests/test_auditor_apel_plugin.py
+++ b/plugins/apel/tests/test_auditor_apel_plugin.py
@@ -154,8 +154,8 @@ class TestAuditorApelPlugin:
         with open(Path.joinpath(test_dir, "test_config.yml"), "r") as f:
             config: Config = yaml.load(f, Loader=get_loaders())
 
-        config.authentication.client_cert = Path.joinpath(test_dir, "test_cert.cert")
-        config.authentication.client_key = Path.joinpath(test_dir, "test_key.key")
+        config.messaging.client_cert = Path.joinpath(test_dir, "test_cert.cert")
+        config.messaging.client_key = Path.joinpath(test_dir, "test_key.key")
 
         result = sign_msg(config, "test")
 
@@ -174,18 +174,16 @@ class TestAuditorApelPlugin:
         with open(Path.joinpath(test_dir, "test_config.yml"), "r") as f:
             config: Config = yaml.load(f, Loader=get_loaders())
 
-        config.authentication.client_cert = "tests/nodir/test_cert.cert"
-        config.authentication.client_key = "tests/no/dir/test_key.key"
+        config.messaging.client_cert = "tests/nodir/test_cert.cert"
+        config.messaging.client_key = "tests/no/dir/test_key.key"
 
         with pytest.raises(Exception) as pytest_error:
             sign_msg(config, "test")
 
         assert pytest_error.type is FileNotFoundError
 
-        config.authentication.client_cert = str(
-            Path.joinpath(test_dir, "test_cert.cert")
-        )
-        config.authentication.client_key = str(Path.joinpath(test_dir, "test_key.key"))
+        config.messaging.client_cert = str(Path.joinpath(test_dir, "test_cert.cert"))
+        config.messaging.client_key = str(Path.joinpath(test_dir, "test_key.key"))
 
         result = sign_msg(config, "test")
 

--- a/plugins/apel/tests/test_config.yml
+++ b/plugins/apel/tests/test_config.yml
@@ -10,13 +10,15 @@ site:
   sites_to_report:
     TEST-SITE: ["test"]
 
-authentication:
-  auth_url: test_auth_url
-  ams_url: test_ams_url
+messaging:
+  host: test_host
+  port: 1337
   client_cert: test_client_cert
   client_key: test_client_key
-  ca_path: test_ca_path
-  verify_ca: False
+  project: test_project
+  topic: test_topic
+  timeout: 10
+  retry: 3
 
 auditor:
   ip: 127.0.0.1


### PR DESCRIPTION
This PR implements the argo AMS library for messaging instead of http requests.
Closes #1136.