### PR TITLE
fix clippy issues, update pyo3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Dependencies: Update cryptography from 44.0.0 to 44.0.1 ([@dirksammel](https://github.com/dirksammel))
 - Dependencies: Update mypy from 1.14.1 to 1.15.0 ([@dirksammel](https://github.com/dirksammel))
 - Dependencies: Update once_cell from 1.20.2 to 1.20.3 ([@dirksammel](https://github.com/dirksammel))
+- Dependencies: Update pyo3 from 0.22.5 to 0.23.4 ([@dirksammel](https://github.com/dirksammel))
+- Dependencies: Update pyo3-async-runtimes from 0.22.0 to 0.23.0 ([@dirksammel](https://github.com/dirksammel))
 - Dependencies: Update ruff from 0.9.3 to 0.9.6 ([@dirksammel](https://github.com/dirksammel))
 - Dependencies: Update rustls from 0.23.21 to 0.23.23 ([@dirksammel](https://github.com/dirksammel))
 - Dependencies: Update serde-aux from 4.5.0 to 4.6.0 ([@dirksammel](https://github.com/dirksammel))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2917,9 +2917,9 @@ checksum = "106dd99e98437432fed6519dedecfade6a06a73bb7b2a1e019fdd2bee5778d94"
 
 [[package]]
 name = "pyo3"
-version = "0.22.6"
+version = "0.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f402062616ab18202ae8319da13fa4279883a2b8a9d9f83f20dbade813ce1884"
+checksum = "57fe09249128b3173d092de9523eaa75136bf7ba85e0d69eca241c7939c933cc"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -2937,9 +2937,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-async-runtimes"
-version = "0.22.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2529f0be73ffd2be0cc43c013a640796558aa12d7ca0aab5cc14f375b4733031"
+checksum = "977dc837525cfd22919ba6a831413854beb7c99a256c03bf8624ad707e45810e"
 dependencies = [
  "futures",
  "once_cell",
@@ -2951,9 +2951,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-async-runtimes-macros"
-version = "0.22.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22c26fd8e9fc19f53f0c1e00bf61471de6789f7eb263056f7f944a9cceb5823e"
+checksum = "b2df2884957d2476731f987673befac5d521dff10abb0a7cbe12015bc7702fe9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2962,9 +2962,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.22.6"
+version = "0.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b14b5775b5ff446dd1056212d778012cbe8a0fbffd368029fd9e25b514479c38"
+checksum = "1cd3927b5a78757a0d71aa9dff669f903b1eb64b54142a9bd9f757f8fde65fd7"
 dependencies = [
  "once_cell",
  "target-lexicon",
@@ -2972,9 +2972,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.22.6"
+version = "0.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ab5bcf04a2cdcbb50c7d6105de943f543f9ed92af55818fd17b660390fc8636"
+checksum = "dab6bb2102bd8f991e7749f130a70d05dd557613e39ed2deeee8e9ca0c4d548d"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -2982,9 +2982,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.22.6"
+version = "0.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fd24d897903a9e6d80b968368a34e1525aeb719d568dba8b3d4bfa5dc67d453"
+checksum = "91871864b353fd5ffcb3f91f2f703a22a9797c91b9ab497b1acac7b07ae509c7"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -2994,9 +2994,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.22.6"
+version = "0.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36c011a03ba1e50152b4b394b479826cad97e7a21eb52df179cd91ac411cbfbe"
+checksum = "43abc3b80bc20f3facd86cd3c60beed58c3e2aa26213f3cda368de39c60a27e4"
 dependencies = [
  "heck",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,8 +38,8 @@ opentelemetry-prometheus = "0.16.0"
 opentelemetry_sdk = "0.23.0"
 prometheus = "0.13.4"
 prometheus-http-query = { version = "0.8.0", default-features = false }
-pyo3 = { version = "0.22.5", features = ["chrono", "extension-module", "anyhow"] }
-pyo3-async-runtimes = { version = "0.22.0", features = ["attributes", "tokio-runtime"] }
+pyo3 = { version = "0.23.4", features = ["chrono", "extension-module", "anyhow"] }
+pyo3-async-runtimes = { version = "0.23.0", features = ["attributes", "tokio-runtime"] }
 quickcheck = "1.0.3"
 quickcheck_macros = "1.0.0"
 rand = "0.8.5"

--- a/auditor-client/src/database.rs
+++ b/auditor-client/src/database.rs
@@ -354,7 +354,7 @@ mod tests {
         for r in recs.iter() {
             db.update(r).await.unwrap()
         }
-        let rowid = db.get_last_update_rowid().await.unwrap().take().unwrap();
+        let rowid = db.get_last_update_rowid().await.unwrap().unwrap();
 
         assert_eq!(rowid, 10);
     }

--- a/pyauditor/src/client.rs
+++ b/pyauditor/src/client.rs
@@ -8,8 +8,10 @@
 use crate::domain::Record;
 use anyhow::Error;
 use chrono::{DateTime, Utc};
+use pyo3::ffi::c_str;
 use pyo3::prelude::*;
 use pyo3::types::PyDateTime;
+use pyo3::IntoPyObjectExt;
 use std::collections::HashMap;
 
 /// The `QueryBuilder` is used to construct `QueryParameters` using the builder pattern.
@@ -589,7 +591,7 @@ impl QueryBuilder {
     /// Builds the query string for the given query parameters
     fn build(self_: PyRef<Self>, py: Python) -> Py<PyAny> {
         let query_string: String = self_.inner.clone().build();
-        query_string.into_py(py)
+        query_string.into_py_any(py).unwrap()
     }
 }
 
@@ -657,8 +659,8 @@ impl AuditorClient {
         timestamp: &Bound<'_, PyDateTime>,
         py: Python<'a>,
     ) -> PyResult<Bound<'a, PyAny>> {
-        let message = py.get_type_bound::<pyo3::exceptions::PyDeprecationWarning>();
-        PyErr::warn_bound(py, &message, "get_started_since is depreciated", 0)?;
+        let message = py.get_type::<pyo3::exceptions::PyDeprecationWarning>();
+        PyErr::warn(py, &message, c_str!("get_started_since is depreciated"), 0)?;
 
         let since: DateTime<Utc> = timestamp.extract()?;
         let inner = self_.inner.clone();
@@ -705,8 +707,8 @@ impl AuditorClient {
         timestamp: &Bound<'_, PyDateTime>,
         py: Python<'a>,
     ) -> PyResult<Bound<'a, PyAny>> {
-        let message = py.get_type_bound::<pyo3::exceptions::PyDeprecationWarning>();
-        PyErr::warn_bound(py, &message, "get_stopped_since_since is depreciated", 0)?;
+        let message = py.get_type::<pyo3::exceptions::PyDeprecationWarning>();
+        PyErr::warn(py, &message, c_str!("get_stopped_since is depreciated"), 0)?;
 
         let since: DateTime<Utc> = timestamp.extract()?;
         let inner = self_.inner.clone();

--- a/pyauditor/src/domain/component.rs
+++ b/pyauditor/src/domain/component.rs
@@ -8,6 +8,7 @@
 use crate::domain::Score;
 use pyo3::class::basic::CompareOp;
 use pyo3::prelude::*;
+use pyo3::IntoPyObjectExt;
 
 /// Component(name: str, amount: int)
 /// A component represents a single component which is to be accounted for. It consists at least
@@ -65,8 +66,8 @@ impl Component {
     fn __richcmp__(&self, other: PyRef<Component>, op: CompareOp) -> Py<PyAny> {
         let py = other.py();
         match op {
-            CompareOp::Eq => (self.inner == other.inner).into_py(py),
-            CompareOp::Ne => (self.inner != other.inner).into_py(py),
+            CompareOp::Eq => (self.inner == other.inner).into_py_any(py).unwrap(),
+            CompareOp::Ne => (self.inner != other.inner).into_py_any(py).unwrap(),
             _ => py.NotImplemented(),
         }
     }

--- a/pyauditor/src/domain/meta.rs
+++ b/pyauditor/src/domain/meta.rs
@@ -7,6 +7,7 @@
 
 use pyo3::class::basic::CompareOp;
 use pyo3::prelude::*;
+use pyo3::IntoPyObjectExt;
 
 /// Meta()
 ///
@@ -53,8 +54,8 @@ impl Meta {
     fn __richcmp__(&self, other: PyRef<Meta>, op: CompareOp) -> Py<PyAny> {
         let py = other.py();
         match op {
-            CompareOp::Eq => (self.inner == other.inner).into_py(py),
-            CompareOp::Ne => (self.inner != other.inner).into_py(py),
+            CompareOp::Eq => (self.inner == other.inner).into_py_any(py).unwrap(),
+            CompareOp::Ne => (self.inner != other.inner).into_py_any(py).unwrap(),
             _ => py.NotImplemented(),
         }
     }

--- a/pyauditor/src/domain/record.rs
+++ b/pyauditor/src/domain/record.rs
@@ -14,6 +14,7 @@ use chrono::{DateTime, Utc};
 use pyo3::class::basic::CompareOp;
 use pyo3::prelude::*;
 use pyo3::types::PyDateTime;
+use pyo3::IntoPyObjectExt;
 
 /// Record(record_id: str, start_time: datetime.datetime)
 /// A Record represents a single accountable unit. It consists of meta information such as
@@ -147,7 +148,7 @@ impl Record {
         self.inner
             .start_time
             .as_ref()
-            .map(|start_time| start_time.naive_utc().into_py(py))
+            .map(|start_time| start_time.naive_utc().into_py_any(py).unwrap())
     }
 
     /// Returns the stop_time
@@ -156,7 +157,7 @@ impl Record {
         self.inner
             .stop_time
             .as_ref()
-            .map(|stop_time| stop_time.naive_utc().into_py(py))
+            .map(|stop_time| stop_time.naive_utc().into_py_any(py).unwrap())
     }
 
     /// Returns the runtime of a record.
@@ -173,8 +174,8 @@ impl Record {
     fn __richcmp__(&self, other: PyRef<Record>, op: CompareOp) -> Py<PyAny> {
         let py = other.py();
         match op {
-            CompareOp::Eq => (self.inner == other.inner).into_py(py),
-            CompareOp::Ne => (self.inner != other.inner).into_py(py),
+            CompareOp::Eq => (self.inner == other.inner).into_py_any(py).unwrap(),
+            CompareOp::Ne => (self.inner != other.inner).into_py_any(py).unwrap(),
             _ => py.NotImplemented(),
         }
     }

--- a/pyauditor/src/domain/score.rs
+++ b/pyauditor/src/domain/score.rs
@@ -7,6 +7,7 @@
 
 use pyo3::class::basic::CompareOp;
 use pyo3::prelude::*;
+use pyo3::IntoPyObjectExt;
 
 /// Score(name: str, value: float)
 /// An individual score which consists of a ``name`` (str) and a ``value`` (float).
@@ -57,8 +58,8 @@ impl Score {
     fn __richcmp__(&self, other: PyRef<Score>, op: CompareOp) -> Py<PyAny> {
         let py = other.py();
         match op {
-            CompareOp::Eq => (self.inner == other.inner).into_py(py),
-            CompareOp::Ne => (self.inner != other.inner).into_py(py),
+            CompareOp::Eq => (self.inner == other.inner).into_py_any(py).unwrap(),
+            CompareOp::Ne => (self.inner != other.inner).into_py_any(py).unwrap(),
             _ => py.NotImplemented(),
         }
     }

--- a/pyauditor/src/queued_client.rs
+++ b/pyauditor/src/queued_client.rs
@@ -7,6 +7,7 @@
 
 use crate::domain::Record;
 use chrono::{DateTime, Utc};
+use pyo3::ffi::c_str;
 use pyo3::prelude::*;
 use pyo3::types::PyDateTime;
 
@@ -91,8 +92,8 @@ impl QueuedAuditorClient {
         timestamp: &Bound<'_, PyDateTime>,
         py: Python<'a>,
     ) -> PyResult<Bound<'a, PyAny>> {
-        let message = py.get_type_bound::<pyo3::exceptions::PyDeprecationWarning>();
-        PyErr::warn_bound(py, &message, "get_started_since is depreciated", 0)?;
+        let message = py.get_type::<pyo3::exceptions::PyDeprecationWarning>();
+        PyErr::warn(py, &message, c_str!("get_started_since is depreciated"), 0)?;
 
         let since: DateTime<Utc> = timestamp.extract()?;
         let inner = self_.inner.clone();
@@ -139,8 +140,8 @@ impl QueuedAuditorClient {
         timestamp: &Bound<'_, PyDateTime>,
         py: Python<'a>,
     ) -> PyResult<Bound<'a, PyAny>> {
-        let message = py.get_type_bound::<pyo3::exceptions::PyDeprecationWarning>();
-        PyErr::warn_bound(py, &message, "get_stopped_since_since is depreciated", 0)?;
+        let message = py.get_type::<pyo3::exceptions::PyDeprecationWarning>();
+        PyErr::warn(py, &message, c_str!("get_stopped_since is depreciated"), 0)?;
 
         let since: DateTime<Utc> = timestamp.extract()?;
         let inner = self_.inner.clone();


### PR DESCRIPTION
This PR fixes Clippy errors due to the new Rust version. pyo3 had to be updated, this resulted in some changes due to deprecated things.