### PR TITLE
cast class ad values to string for meta fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Apel plugin: Switch to the Argo AMS library for messaging ([@dirksammel](https://github.com/dirksammel))
+- HTCondor collector: Numbers from class ads can now be inserted in Meta fields ([@dirksammel](https://github.com/dirksammel))
 - Dependencies: Update ruff from 0.9.7 to 0.9.8 ([@dirksammel](https://github.com/dirksammel))
 
 ### Removed

--- a/collectors/htcondor/src/auditor_htcondor_collector/collector.py
+++ b/collectors/htcondor/src/auditor_htcondor_collector/collector.py
@@ -230,7 +230,7 @@ class CondorHistoryCollector(object):
             for item in entry if isinstance(entry, list) else [entry]:
                 value = get_value(item, job)
                 if value is not None:
-                    values.append(value)
+                    values.append(str(value))
                     if key == "site":  # site is a special case
                         break
             if values:


### PR DESCRIPTION
This PR enables the insertion of numbers from class ads in Meta fields by casting them to str.