### PR TITLE
feat: Change auditor application address config to a list for dualstack support

### DIFF
--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -256,5 +256,5 @@ jobs:
       - name: Run TLS tests
         run: ./scripts/test_mtls.sh
 
-      -name: Run Dualstack tests
-        run: ./scripts/dualstack.sh
+      - name: Run Dualstack tests
+        run: ./scripts/test_dualstack.sh

--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -255,3 +255,6 @@ jobs:
 
       - name: Run TLS tests
         run: ./scripts/test_mtls.sh
+
+      -name: Run Dualstack tests
+        run: ./scripts/dualstack.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Breaking changes
+- AUDITOR: Auditor application config field `addr` is changed to a list for supporting IPv4/IPv6 dualstack operation ([@raghuvar-vijay](https://github.com/raghuvar-vijay))
 
 ### Security
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3016,7 +3016,7 @@ dependencies = [
 
 [[package]]
 name = "python-auditor"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "auditor",

--- a/auditor/configuration/dualstack.yaml
+++ b/auditor/configuration/dualstack.yaml
@@ -1,0 +1,24 @@
+application:
+  addr:
+    - 0.0.0.0
+    - ::1
+  port: 8000
+database:
+  host: "localhost"
+  port: 5432
+  username: "postgres"
+  password: "password"
+  database_name: "auditor"
+metrics:
+  database:
+    frequency: 30
+    metrics:
+      - RecordCount
+      - RecordCountPerSite
+      - RecordCountPerGroup
+      - RecordCountPerUser
+tls_config:
+  use_tls: false
+  ca_cert_path: "/path/rootCA.pem"
+  server_cert_path: "/path/server-cert.pem"
+  server_key_path: "/path/server-key.pem"

--- a/auditor/configuration/local.yaml
+++ b/auditor/configuration/local.yaml
@@ -1,4 +1,5 @@
 application:
-  addr: 127.0.0.1
+  addr:
+    - 127.0.0.1
 database:
   require_ssl: false

--- a/auditor/configuration/production.yaml
+++ b/auditor/configuration/production.yaml
@@ -1,4 +1,5 @@
 application:
-  addr: 0.0.0.0
+  addr: 
+    - 0.0.0.0
 database:
   require_ssl: true

--- a/auditor/src/configuration.rs
+++ b/auditor/src/configuration.rs
@@ -12,10 +12,6 @@ use serde_aux::field_attributes::deserialize_number_from_string;
 use sqlx::ConnectOptions;
 use sqlx::postgres::{PgConnectOptions, PgSslMode};
 use tracing_subscriber::filter::LevelFilter;
-use serde::{Deserializer, Deserialize};
-
-use serde::de::{self, Visitor};
-use std::fmt;
 
 #[derive(serde::Deserialize, Debug)]
 pub struct Settings {
@@ -33,7 +29,6 @@ pub struct Settings {
 #[derive(serde::Deserialize, Debug)]
 pub struct TLSConfig {
     pub use_tls: bool,
-    #[serde(default, deserialize_with = "deserialize_optional_addr")]
     pub https_addr: Option<Vec<String>>,
     #[serde(default = "default_https_port")]
     pub https_port: u16,
@@ -78,7 +73,6 @@ fn default_log_level() -> LevelFilter {
 
 #[derive(serde::Deserialize, Debug)]
 pub struct AuditorSettings {
-    #[serde(deserialize_with = "deserialize_addr")]
     #[serde(default = "default_addr")]
     pub addr: Vec<String>,
     #[serde(deserialize_with = "deserialize_number_from_string")]
@@ -87,69 +81,6 @@ pub struct AuditorSettings {
 
 fn default_addr() -> Vec<String> {
     vec!["127.0.0.1".to_string()]
-}
-
-fn deserialize_addr<'de, D>(deserializer: D) -> Result<Vec<String>, D::Error>
-where
-    D: Deserializer<'de>,
-{
-    struct StringOrVec;
-
-    impl<'de> Visitor<'de> for StringOrVec {
-        type Value = Vec<String>;
-
-        fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-            formatter.write_str("a string (comma-separated) or a list of strings")
-        }
-
-        fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
-        where
-            E: de::Error,
-        {
-            Ok(value.split(',').map(|s| s.trim().to_string()).collect())
-        }
-
-        fn visit_seq<A>(self, seq: A) -> Result<Self::Value, A::Error>
-        where
-            A: serde::de::SeqAccess<'de>,
-        {
-            Deserialize::deserialize(serde::de::value::SeqAccessDeserializer::new(seq))
-        }
-    }
-
-    deserializer.deserialize_any(StringOrVec)
-}
-
-fn deserialize_optional_addr<'de, D>(deserializer: D) -> Result<Option<Vec<String>>, D::Error>
-where
-    D: Deserializer<'de>,
-{
-    struct StringOrVec;
-
-    impl<'de> Visitor<'de> for StringOrVec {
-        type Value = Vec<String>;
-
-        fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-            formatter.write_str("a string (comma-separated) or a list of strings")
-        }
-
-        fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
-        where
-            E: de::Error,
-        {
-            Ok(value.split(',').map(|s| s.trim().to_string()).collect())
-        }
-
-        fn visit_seq<A>(self, seq: A) -> Result<Self::Value, A::Error>
-        where
-            A: serde::de::SeqAccess<'de>,
-        {
-            Deserialize::deserialize(serde::de::value::SeqAccessDeserializer::new(seq))
-        }
-    }
-
-    let parsed_value = deserializer.deserialize_any(StringOrVec);
-    parsed_value.map(Some).or(Ok(None)) // Convert `Err` to `None`
 }
 
 #[derive(serde::Deserialize, Debug)]
@@ -250,7 +181,10 @@ pub fn get_configuration() -> Result<Settings, config::ConfigError> {
     let settings = settings.add_source(
         config::Environment::with_prefix("AUDITOR")
             .separator("__")
-            .prefix_separator("_"),
+            .prefix_separator("_")
+            .list_separator(",")
+            .with_list_parse_key("application.addr")
+            .try_parsing(true),
     );
 
     settings.build()?.try_deserialize()

--- a/auditor/tests/api/helpers.rs
+++ b/auditor/tests/api/helpers.rs
@@ -130,7 +130,7 @@ pub async fn spawn_app() -> TestApp {
     let connection_pool = configure_database(&configuration.database).await;
     let db_watcher = DatabaseMetricsWatcher::new(connection_pool.clone(), &configuration).unwrap();
     let server = auditor::startup::run(
-        "127.0.0.1".to_string(),
+        vec!["127.0.0.1".to_string()],
         port,
         connection_pool.clone(),
         db_watcher,

--- a/media/website/content/_index.md
+++ b/media/website/content/_index.md
@@ -163,23 +163,23 @@ After installing PostgreSQL, the database needs to be migrated with `sqlx`.
 
 AUDITORs configuration can be adapted with environment variables.
 
-| Variable                              | Description                                                                                               |
-| ------------------------------------- | --------------------------------------------------------------------------------------------------------- |
-| `AUDITOR_APPLICATION__ADDR`           | Address to bind to (default `0.0.0.0`). Supports both IPv4 and IPv6                                       |
-| `AUDITOR_APPLICATION__PORT`           | Port to bind to (default `8000`)                                                                          |
-| `AUDITOR_DATABASE__HOST`              | Host address of PostgreSQL database (default `localhost`)                                                 |
-| `AUDITOR_DATABASE__PORT`              | Port of PostgreSQL database (default `5432`)                                                              |
-| `AUDITOR_DATABASE__USERNAME`          | PostgreSQL database username (default `postgres`)                                                         |
-| `AUDITOR_DATABASE__PASSWORD`          | PostgreSQL database password (default `password`)                                                         |
-| `AUDITOR_DATABASE__DATABASE_NAME`     | Name of the PostgreSQL database (default `auditor`)                                                       |
-| `AUDITOR_DATABASE__REQUIRE_SSL`       | Whether or not to use SSL (default `true`)                                                                |
-| `AUDITOR_LOG_LEVEL`                   | Set the verbosity of logging. Possible values: `trace`, `debug`, `info`, `warn`, `error` (default `info`) |
-| `AUDITOR_TLS_CONFIG__USE_TLS`         | Specifies whether TLS is enabled (`true`) or disabled (`false`).                                          |
-| `AUDITOR_TLS_CONFIG__HTTPS_ADDR`      | The HTTPS address where the server will listen. Defaults to a pre-configured value if not set.            |
-| `AUDITOR_TLS_CONFIG__HTTPS_PORT`      | The HTTPS port where the server will listen. (default `8443`). Supports both IPv4 and IPv6                |
-| `AUDITOR_TLS_CONFIG__CA_CERT_PATH`    | Path to the root Certificate Authority (CA) certificate for validating client certificates.               |
-| `AUDITOR_TLS_CONFIG__SERVER_CERT_PATH`| Path to the server's TLS certificate.                                                                     |
-| `AUDITOR_TLS_CONFIG__SERVER_KEY_PATH` | Path to the server's private key used for TLS.                                                            |
+| Variable                              | Description                                                                                                     |
+| ------------------------------------- | ----------------------------------------------------------------------------------------------------------------|
+| `AUDITOR_APPLICATION__ADDR`           | Address to bind to (default `0.0.0.0`). Supports (dualstack) IPv4 and IPv6 addresses as comma separated values  |
+| `AUDITOR_APPLICATION__PORT`           | Port to bind to (default `8000`)                                                                                |
+| `AUDITOR_DATABASE__HOST`              | Host address of PostgreSQL database (default `localhost`)                                                       |
+| `AUDITOR_DATABASE__PORT`              | Port of PostgreSQL database (default `5432`)                                                                    |
+| `AUDITOR_DATABASE__USERNAME`          | PostgreSQL database username (default `postgres`)                                                               |
+| `AUDITOR_DATABASE__PASSWORD`          | PostgreSQL database password (default `password`)                                                               |
+| `AUDITOR_DATABASE__DATABASE_NAME`     | Name of the PostgreSQL database (default `auditor`)                                                             |
+| `AUDITOR_DATABASE__REQUIRE_SSL`       | Whether or not to use SSL (default `true`)                                                                      |
+| `AUDITOR_LOG_LEVEL`                   | Set the verbosity of logging. Possible values: `trace`, `debug`, `info`, `warn`, `error` (default `info`)       |
+| `AUDITOR_TLS_CONFIG__USE_TLS`         | Specifies whether TLS is enabled (`true`) or disabled (`false`).                                                |
+| `AUDITOR_TLS_CONFIG__HTTPS_ADDR`      | The HTTPS address where the server will listen. Defaults to `AUDITOR_APPLICATION__ADDR` value if not set.       |
+| `AUDITOR_TLS_CONFIG__HTTPS_PORT`      | The HTTPS port where the server will listen. (default `8443`).                                                  |
+| `AUDITOR_TLS_CONFIG__CA_CERT_PATH`    | Path to the root Certificate Authority (CA) certificate for validating client certificates.                     |
+| `AUDITOR_TLS_CONFIG__SERVER_CERT_PATH`| Path to the server's TLS certificate.                                                                           |
+| `AUDITOR_TLS_CONFIG__SERVER_KEY_PATH` | Path to the server's private key used for TLS.                                                                  |
 
 
 Use `docker run` to execute Auditor:
@@ -205,7 +205,8 @@ Without TLS
 
 ```yaml
 application:
-  addr: 0.0.0.0
+  addr: 
+    - 0.0.0.0
   port: 8000
 database:
   host: "localhost"
@@ -229,7 +230,7 @@ tls_config:
 
 To enable the TLS for the above config, you can set the tls_config to `true` and add the cert paths as shown below.
 
-```
+```yaml
 tls_config:
   use_tls: true
   ca_cert_path: "/path/rootCA.pem"
@@ -237,6 +238,22 @@ tls_config:
   server_key_path: "/path/server-key.pem"
   https_port: 8005
 ```
+
+For dualstack operation, you can set the IPv4 and IPv6 addresses as a list in the auditor config file as shown below.
+
+```yaml
+application:
+  addr: 
+    - 0.0.0.0
+    - ::1
+```
+
+IPv4 and IPv6 addresses can also be specified as an ENV variable
+
+```bash
+AUDITOR_APPLICATION__ADDR=127.0.0.1,::1
+```
+
 
 This configuration file can be passed to Auditor and will overwrite the default configuration.
 

--- a/media/website/content/migration.md
+++ b/media/website/content/migration.md
@@ -8,7 +8,7 @@ weight = 3
 
 ## Auditor
 
-- `AUDITOR_APPLICATION__ADDR` is modified to be a list of addresses for IPv4/IPv6 dualstack support. Please have a look at the example config in the [documentation](https://alu-schumacher.github.io/AUDITOR//v0.8.0/#configuration-files)
+- `AUDITOR_APPLICATION__ADDR` is modified to be a list of addresses for IPv4/IPv6 dualstack support. Please have a look at the example config in the [documentation](https://alu-schumacher.github.io/AUDITOR/latest/#configuration-files)
 
 # From 0.7.1 to 0.8.0
 

--- a/media/website/content/migration.md
+++ b/media/website/content/migration.md
@@ -6,6 +6,10 @@ weight = 3
 
 # From 0.8.0 to unreleased
 
+## Auditor
+
+- `AUDITOR_APPLICATION__ADDR` is modified to be a list of addresses for IPv4/IPv6 dualstack support. Please have a look at the example config in the [documentation](https://alu-schumacher.github.io/AUDITOR//v0.8.0/#configuration-files)
+
 # From 0.7.1 to 0.8.0
 
 ## Apel plugin

--- a/scripts/test_dualstack.sh
+++ b/scripts/test_dualstack.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+set -x
+set -eo pipefail
+
+RELEASE_MODE=${RELEASE_MODE:=false}
+ENV_DIR=${ENV_DIR:=".env_test"}
+
+function compile_auditor() {
+  if [ "$RELEASE_MODE" = true ]; then
+    cargo build --bin auditor --release
+  else
+    cargo build --bin auditor
+  fi
+}
+
+function start_auditor_with_env() {
+  if [[ -z "${SKIP_COMPILATION}" ]]
+  then
+    compile_auditor
+  fi
+  if [ "$RELEASE_MODE" = true ]; then
+    AUDITOR_APPLICATION__ADDR=0.0.0.0,::1 AUDITOR_DATABASE__DATABASE_NAME=$DB_NAME ./target/release/auditor auditor/configuration/base.yaml &
+  else
+    AUDITOR_APPLICATION__ADDR=0.0.0.0,::1 AUDITOR_DATABASE__DATABASE_NAME=$DB_NAME ./target/debug/auditor auditor/configuration/base.yaml &
+  fi
+  AUDITOR_SERVER_PID=$!
+  COUNTER=0
+  until curl http://localhost:8000/health_check; do
+    >&2 echo "Auditor is still unavailable - sleeping"
+    let COUNTER=COUNTER+1
+    if [ "$COUNTER" -gt "30" ]; then
+      echo >&2 "Auditor did not come up in time."
+      stop_auditor $AUDITOR_SERVER_PID
+      echo >&2 "Exiting."
+      exit 1
+    fi
+    sleep 1
+  done
+}
+
+function start_auditor_with_config() {
+  if [[ -z "${SKIP_COMPILATION}" ]]
+  then
+    compile_auditor
+  fi
+  if [ "$RELEASE_MODE" = true ]; then
+    AUDITOR_DATABASE__DATABASE_NAME=$DB_NAME ./target/release/auditor auditor/configuration/dualstack.yaml &
+  else
+    AUDITOR_DATABASE__DATABASE_NAME=$DB_NAME ./target/debug/auditor auditor/configuration/dualstack.yaml &
+  fi
+  AUDITOR_SERVER_PID=$!
+  COUNTER=0
+  until curl http://localhost:8000/health_check; do
+    >&2 echo "Auditor is still unavailable - sleeping"
+    let COUNTER=COUNTER+1
+    if [ "$COUNTER" -gt "30" ]; then
+      echo >&2 "Auditor did not come up in time."
+      stop_auditor $AUDITOR_SERVER_PID
+      echo >&2 "Exiting."
+      exit 1
+    fi
+    sleep 1
+  done
+}
+
+function stop_auditor() {
+  echo >&2 "Stopping Auditor"
+  kill $AUDITOR_SERVER_PID
+  wait $AUDITOR_SERVER_PID
+}
+
+function check_tcp_connection() {
+  if [ "$#" -ne 3 ]; then
+    echo "Usage: $0 <IPv4_address> <IPv6_address> <port>"
+    exit 1
+fi
+
+IPv4_ADDRESS=$1
+IPv6_ADDRESS=$2
+
+PORT=$3
+
+# Check IPv4 connection
+echo "Checking TCP connection to IPv4 address $IPv4_ADDRESS on port $PORT..."
+nc -zv -w 3 $IPv4_ADDRESS $PORT
+if [ $? -eq 0 ]; then
+    echo "IPv4 connection to $IPv4_ADDRESS:$PORT is successful."
+else
+    echo "IPv4 connection to $IPv4_ADDRESS:$PORT failed."
+fi
+
+# Check IPv6 connection
+echo "Checking TCP connection to IPv6 address $IPv6_ADDRESS on port $PORT..."
+nc -zv -w 3 -6 $IPv6_ADDRESS $PORT
+if [ $? -eq 0 ]; then
+    echo "IPv6 connection to $IPv6_ADDRESS:$PORT is successful."
+else
+    echo "IPv6 connection to $IPv6_ADDRESS:$PORT failed."
+fi
+}
+
+cleanup_exit() {
+  setsid nohup bash -c "
+  kill $AUDITOR_SERVER_PID
+  if [[ -z \"${SKIP_PYAUDITOR_COMPILATION}\" ]]; then rm -rf $ENV_DIR; fi
+  "
+}
+trap "cleanup_exit" SIGINT SIGQUIT SIGTERM EXIT
+
+start_auditor_with_env
+
+check_tcp_connection "0.0.0.0" "::1" "8000"
+
+stop_auditor
+
+sleep 2
+
+start_auditor_with_config
+
+check_tcp_connection "0.0.0.0" "::1" "8000"
+

--- a/scripts/test_tls_priority_plugin.sh
+++ b/scripts/test_tls_priority_plugin.sh
@@ -162,9 +162,9 @@ function start_auditor() {
     compile_auditor
   fi
   if [ "$RELEASE_MODE" = true ]; then
-    AUDITOR_APPLICATION__ADDR=0.0.0.0 AUDITOR_TLS_CONFIG__HTTPS_ADDR=0.0.0.0 AUDITOR_DATABASE__DATABASE_NAME=$DB_NAME ./target/release/auditor auditor/configuration/tls_config.yaml &
+    AUDITOR_APPLICATION__ADDR=0.0.0.0 AUDITOR_DATABASE__DATABASE_NAME=$DB_NAME ./target/release/auditor auditor/configuration/tls_config.yaml &
   else
-    AUDITOR_APPLICATION__ADDR=0.0.0.0 AUDITOR_TLS_CONFIG__HTTPS_ADDR=0.0.0.0 AUDITOR_DATABASE__DATABASE_NAME=$DB_NAME ./target/debug/auditor auditor/configuration/tls_config.yaml &
+    AUDITOR_APPLICATION__ADDR=0.0.0.0 AUDITOR_DATABASE__DATABASE_NAME=$DB_NAME ./target/debug/auditor auditor/configuration/tls_config.yaml &
   fi
   AUDITOR_SERVER_PID=$!
   COUNTER=0

--- a/scripts/test_tls_pyauditor.sh
+++ b/scripts/test_tls_pyauditor.sh
@@ -32,9 +32,9 @@ function start_auditor() {
     compile_auditor
   fi
   if [ "$RELEASE_MODE" = true ]; then
-    AUDITOR_APPLICATION__ADDR=0.0.0.0 AUDITOR_TLS_CONFIG__HTTPS_ADDR=0.0.0.0 AUDITOR_DATABASE__DATABASE_NAME=$DB_NAME ./target/release/auditor auditor/configuration/tls_config.yaml &
+    AUDITOR_APPLICATION__ADDR=0.0.0.0 AUDITOR_DATABASE__DATABASE_NAME=$DB_NAME ./target/release/auditor auditor/configuration/tls_config.yaml &
   else
-    AUDITOR_APPLICATION__ADDR=0.0.0.0 AUDITOR_TLS_CONFIG__HTTPS_ADDR=0.0.0.0 AUDITOR_DATABASE__DATABASE_NAME=$DB_NAME ./target/debug/auditor auditor/configuration/tls_config.yaml &
+    AUDITOR_APPLICATION__ADDR=0.0.0.0 AUDITOR_DATABASE__DATABASE_NAME=$DB_NAME ./target/debug/auditor auditor/configuration/tls_config.yaml &
   fi
   AUDITOR_SERVER_PID=$!
   COUNTER=0

--- a/scripts/test_tls_slurm_collector.sh
+++ b/scripts/test_tls_slurm_collector.sh
@@ -112,9 +112,9 @@ function start_auditor() {
 		compile_auditor
 	fi
 	if [ "$RELEASE_MODE" = true ]; then
-		AUDITOR_APPLICATION__ADDR=0.0.0.0 AUDITOR_TLS_CONFIG__HTTPS_ADDR=0.0.0.0 AUDITOR_DATABASE__DATABASE_NAME=$DB_NAME ./target/release/auditor auditor/configuration/tls_config.yaml &
+		AUDITOR_APPLICATION__ADDR=0.0.0.0 AUDITOR_DATABASE__DATABASE_NAME=$DB_NAME ./target/release/auditor auditor/configuration/tls_config.yaml &
 	else
-		AUDITOR_APPLICATION__ADDR=0.0.0.0 AUDITOR_TLS_CONFIG__HTTPS_ADDR=0.0.0.0 AUDITOR_DATABASE__DATABASE_NAME=$DB_NAME ./target/debug/auditor auditor/configuration/tls_config.yaml &
+		AUDITOR_APPLICATION__ADDR=0.0.0.0 AUDITOR_DATABASE__DATABASE_NAME=$DB_NAME ./target/debug/auditor auditor/configuration/tls_config.yaml &
 	fi
 	AUDITOR_SERVER_PID=$!
 	COUNTER=0

--- a/scripts/test_tls_slurm_epilog_collector.sh
+++ b/scripts/test_tls_slurm_epilog_collector.sh
@@ -114,9 +114,9 @@ function start_auditor() {
 		compile_auditor
 	fi
 	if [ "$RELEASE_MODE" = true ]; then
-		AUDITOR_APPLICATION__ADDR=0.0.0.0 AUDITOR_TLS_CONFIG__HTTPS_ADDR=0.0.0.0 AUDITOR_DATABASE__DATABASE_NAME=$DB_NAME ./target/release/auditor auditor/configuration/tls_config.yaml &
+		AUDITOR_APPLICATION__ADDR=0.0.0.0 AUDITOR_DATABASE__DATABASE_NAME=$DB_NAME ./target/release/auditor auditor/configuration/tls_config.yaml &
 	else
-		AUDITOR_APPLICATION__ADDR=0.0.0.0 AUDITOR_TLS_CONFIG__HTTPS_ADDR=0.0.0.0 AUDITOR_DATABASE__DATABASE_NAME=$DB_NAME ./target/debug/auditor auditor/configuration/tls_config.yaml &
+		AUDITOR_APPLICATION__ADDR=0.0.0.0 AUDITOR_DATABASE__DATABASE_NAME=$DB_NAME ./target/debug/auditor auditor/configuration/tls_config.yaml &
 	fi
 	AUDITOR_SERVER_PID=$!
 	COUNTER=0


### PR DESCRIPTION
- Modify the 'addr' config field to be a list of addresses.
- Enables dualstack support (IPv4/IPv6).