### PR TITLE
add option for log file to APEL plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Apel plugin: Add --dry-run option to publish- and republish commands ([@dirksammel](https://github.com/dirksammel))
 - Apel plugin: Add information about total reported numbers of run to log ([@dirksammel](https://github.com/dirksammel))
+- Apel plugin: Add option to use log file ([@dirksammel](https://github.com/dirksammel))
 - AUDITOR: Implement streaming of records for advanced queries ([@raghuvar-vijay](https://github.com/raghuvar-vijay))
 - AUDITOR: Add strict deserialization to make the query fail if the query string contains unknown fields ([@raghuvar-vijay](https://github.com/raghuvar-vijay))
 - AUDITOR: Improve error messages for invalid query parameters ([@raghuvar-vijay](https://github.com/raghuvar-vijay))

--- a/media/website/content/_index.md
+++ b/media/website/content/_index.md
@@ -893,6 +893,7 @@ Example config:
 !Config
 plugin:
   log_level: INFO
+  log_file: /var/log/auditor_apel_plugin.log
   time_json_path: /etc/auditor_apel_plugin/time.json
   report_interval: 86400
   message_type: summaries
@@ -1006,6 +1007,7 @@ The individual parameters in the config file are:
 | Section     | Parameter          | Description                                                                                                                                                                                                                                         |
 |-------------|--------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `plugin`    | `log_level`        | Can be set to `TRACE`, `DEBUG`, `INFO`, `WARNING`, `ERROR`, or `CRITICAL` (with decreasing verbosity). `TRACE` might produce a lot of output if `message_type` is set to `individual_jobs`, since the message that will be sent to APEL is printed. |
+| `plugin`    | `log_file`         | Path of the log file. This parameter is optional, the default value is `None`.                                                                                                                                                                      |
 | `plugin`    | `time_json_path`   | Path of the `time.json` file. The JSON file should be located at a persistent path and stores the stop times of the latest reported job per site, and the time of the latest report to APEL.                                                        |
 | `plugin`    | `report_interval`  | Time in seconds between reports to APEL.                                                                                                                                                                                                            |
 | `plugin`    | `message_type`     | Type of message to create. Can be set to `summaries` or `individual_jobs`.                                                                                                                                                                          |

--- a/plugins/apel/configs/auditor_apel_plugin_template.yml
+++ b/plugins/apel/configs/auditor_apel_plugin_template.yml
@@ -6,6 +6,7 @@
 # !Config
 # plugin:
 #   log_level: INFO
+#   log_file: /var/log/auditor_apel_plugin.log
 #   time_json_path: /etc/auditor_apel_plugin/time.json
 #   report_interval: 86400
 #   message_type: summaries

--- a/plugins/apel/src/auditor_apel_plugin/config.py
+++ b/plugins/apel/src/auditor_apel_plugin/config.py
@@ -40,6 +40,7 @@ class Function(Configurable):
 
 class PluginConfig(Configurable):
     log_level: str
+    log_file: Optional[str] = None
     time_json_path: str
     report_interval: int
     message_type: MessageType

--- a/plugins/apel/tests/test_config.py
+++ b/plugins/apel/tests/test_config.py
@@ -30,19 +30,25 @@ class TestConfig:
         with open(Path.joinpath(test_dir, "test_config.yml"), "r") as f:
             config: Config = yaml.load(f, Loader=get_loaders())
 
+        log_file = config.plugin.log_file
+        assert log_file is None
+
         log_level = "DEBUG"
+        log_file = "/var/log/test.log"
         time_json_path = "time.json"
         report_interval = 10
         message_type = "summaries"
 
         plugin = PluginConfig(
             log_level=log_level,
+            log_file=log_file,
             time_json_path=time_json_path,
             report_interval=report_interval,
             message_type=message_type,
         )
 
         assert plugin.log_level == "DEBUG"
+        assert plugin.log_file == "/var/log/test.log"
         assert plugin.time_json_path == "time.json"
         assert plugin.report_interval == 10
         assert plugin.message_type is MessageType("summaries")


### PR DESCRIPTION
This PR adds the option for a (rotating) log file. If the option is not found in the config file, it is set to `None`.