### PR TITLE
improve RPM pipeline for the python packages

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -18,14 +18,14 @@ jobs:
   sqlx:
     uses: ./.github/workflows/sqlx.yml
 
+  build-pyauditor-source:
+    uses: ./.github/workflows/build_pyauditor_source.yml
+
   build-python-rpms:
     needs: prepare-input-parameters
     uses: ./.github/workflows/build_python_rpms.yml
     with:
       python-version: ${{ needs.prepare-input-parameters.outputs.python_version }}
-
-  build-pyauditor-source:
-    uses: ./.github/workflows/build_pyauditor_source.yml
 
   test-pyauditor-source:
     needs: [build-pyauditor-source, prepare-input-parameters]

--- a/.github/workflows/build_python_rpms.yml
+++ b/.github/workflows/build_python_rpms.yml
@@ -26,11 +26,15 @@ jobs:
         run: |
           pip install --upgrade pip
           pip install uv rpmvenv
-
+          
       - name: Build RPM
         run: |
+          ABSOLUTE_PATH=$(realpath ../../pyauditor)
+          ESCAPED_PATH=$(echo "$ABSOLUTE_PATH" | sed 's/[\/&]/\\&/g')
           uv pip compile pyproject.toml -o requirements.txt
+          sed -i "s/.*python-auditor.*/$ESCAPED_PATH/" requirements.txt
           echo "." >> requirements.txt
+          cat requirements.txt
           QA_SKIP_BUILD_ROOT=1 rpmvenv --verbose rpm_config.json
 
       - name: Upload RPM
@@ -60,8 +64,12 @@ jobs:
 
       - name: Build RPM
         run: |
+          ABSOLUTE_PATH=$(realpath ../../pyauditor)
+          ESCAPED_PATH=$(echo "$ABSOLUTE_PATH" | sed 's/[\/&]/\\&/g')
           uv pip compile pyproject.toml -o requirements.txt
+          sed -i "s/.*python-auditor.*/$ESCAPED_PATH/" requirements.txt
           echo "." >> requirements.txt
+          cat requirements.txt
           QA_SKIP_BUILD_ROOT=1 rpmvenv --verbose rpm_config.json
 
       - name: Upload RPM

--- a/.github/workflows/release_python_packages.yml
+++ b/.github/workflows/release_python_packages.yml
@@ -35,11 +35,14 @@ jobs:
           packages-dir: plugins/apel/dist/
           attestations: false
       - name: Build RPM
-        run: |
-          sleep 60
-          uv pip compile pyproject.toml -o requirements.txt
-          echo "." >> requirements.txt
-          QA_SKIP_BUILD_ROOT=1 rpmvenv --verbose rpm_config.json
+        uses: nick-fields/retry@v3
+        with:
+          max_attempts: 100
+          command: |
+            uv pip compile pyproject.toml -o requirements.txt
+            echo "." >> requirements.txt
+            QA_SKIP_BUILD_ROOT=1 rpmvenv --verbose rpm_config.json
+          new_command_on_retry: QA_SKIP_BUILD_ROOT=1 rpmvenv --verbose rpm_config.json
       - name: Publish to GitHub
         uses: softprops/action-gh-release@v2
         with:
@@ -74,11 +77,14 @@ jobs:
           packages-dir: collectors/htcondor/dist/
           attestations: false
       - name: Build RPM
-        run: |
-          sleep 60
-          uv pip compile pyproject.toml -o requirements.txt
-          echo "." >> requirements.txt
-          QA_SKIP_BUILD_ROOT=1 rpmvenv --verbose rpm_config.json
+        uses: nick-fields/retry@v3
+        with:
+          max_attempts: 100
+          command: |
+            uv pip compile pyproject.toml -o requirements.txt
+            echo "." >> requirements.txt
+            QA_SKIP_BUILD_ROOT=1 rpmvenv --verbose rpm_config.json
+          new_command_on_retry: QA_SKIP_BUILD_ROOT=1 rpmvenv --verbose rpm_config.json
       - name: Publish to GitHub
         uses: softprops/action-gh-release@v2
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Apel plugin: Delete `records` when no longer needed ([@dirksammel](https://github.com/dirksammel))
+- CI: improve workflow of RPM creation for Apel plugin and HTCondor collector ([@dirksammel](https://github.com/dirksammel))
 - Dependencies: Update config from 0.13.4 to 0.15.9 ([@dirksammel](https://github.com/dirksammel))
 - Dependencies: Update cryptography from 44.0.1 to 44.0.2 ([@dirksammel](https://github.com/dirksammel))
 - Dependencies: Update pytest from 8.3.4 to 8.3.5 ([@dirksammel](https://github.com/dirksammel))


### PR DESCRIPTION
This PR improves the RPM pipeline for the python packages. For testing, the current dev. version of pyauditor is used. For release, `retry` is added to the building step to make sure that the new pyauditor version is already downloadable from PyPI.