### PR TITLE
Add option to set number of actix workers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Apel plugin: Add --dry-run option to publish- and republish commands ([@dirksammel](https://github.com/dirksammel))
+- Auditor: Add option to set the amount of workers to use for the web server ([@rkleinem](https://github.com/rkleinem))
 
 ### Changed
 - Dependencies: Update config from 0.13.4 to 0.15.9 ([@dirksammel](https://github.com/dirksammel))

--- a/auditor/src/configuration.rs
+++ b/auditor/src/configuration.rs
@@ -89,11 +89,10 @@ fn default_addr() -> Vec<String> {
 }
 
 fn default_workers() -> usize {
-    // Emulate default behaviour of actix-web
     if let Ok(num) = std::thread::available_parallelism() {
-        num.get()
+        std::cmp::min(num.get(), 4)
     } else {
-        tracing::warn!("Cannot determine how many workers to use. Fall back to 2.");
+        tracing::warn!("Cannot determine how many web workers to use. Fall back to 2.");
         2
     }
 }

--- a/auditor/src/main.rs
+++ b/auditor/src/main.rs
@@ -101,6 +101,7 @@ async fn main() -> Result<(), anyhow::Error> {
             run(
                 configuration.application.addr,
                 configuration.application.port,
+                configuration.application.web_workers,
                 connection_pool,
                 db_metrics_watcher,
                 Some(tls_params),
@@ -111,6 +112,7 @@ async fn main() -> Result<(), anyhow::Error> {
             run(
                 configuration.application.addr,
                 configuration.application.port,
+                configuration.application.web_workers,
                 connection_pool,
                 db_metrics_watcher,
                 None,
@@ -122,6 +124,7 @@ async fn main() -> Result<(), anyhow::Error> {
         run(
             configuration.application.addr,
             configuration.application.port,
+            configuration.application.web_workers,
             connection_pool,
             db_metrics_watcher,
             None,

--- a/auditor/src/startup.rs
+++ b/auditor/src/startup.rs
@@ -59,8 +59,7 @@ pub fn run(
             .app_data(db_pool.clone())
     };
 
-    let mut server = HttpServer::new(app_config)
-        .workers(web_workers);
+    let mut server = HttpServer::new(app_config).workers(web_workers);
 
     for addr in &addrs {
         let address = format!("{}:{}", addr, port);

--- a/auditor/src/startup.rs
+++ b/auditor/src/startup.rs
@@ -19,6 +19,7 @@ use tracing_actix_web::TracingLogger;
 pub fn run(
     addrs: Vec<String>,
     port: u16,
+    web_workers: usize,
     db_pool: PgPool,
     db_watcher: DatabaseMetricsWatcher,
     tls_params: Option<TLSParams>,
@@ -58,7 +59,8 @@ pub fn run(
             .app_data(db_pool.clone())
     };
 
-    let mut server = HttpServer::new(app_config);
+    let mut server = HttpServer::new(app_config)
+        .workers(web_workers);
 
     for addr in &addrs {
         let address = format!("{}:{}", addr, port);

--- a/auditor/tests/api/helpers.rs
+++ b/auditor/tests/api/helpers.rs
@@ -132,6 +132,7 @@ pub async fn spawn_app() -> TestApp {
     let server = auditor::startup::run(
         vec!["127.0.0.1".to_string()],
         port,
+        4,
         connection_pool.clone(),
         db_watcher,
         None,

--- a/media/website/content/_index.md
+++ b/media/website/content/_index.md
@@ -208,6 +208,7 @@ application:
   addr: 
     - 0.0.0.0
   port: 8000
+  web_workers: 4    # Number of workers to use for the web server. Optional
 database:
   host: "localhost"
   port: 5432


### PR DESCRIPTION
Hi,

so, I fired up valgrind and discovered that the main reason for the high memory consumption lies in `actix-web` (see e.g. https://github.com/actix/actix-web/issues/1943)
It's not really an error in `actix-web` but probably the memory allocator doesn't return memory because of fragmentation.

Long story short, it can help a lot to start less workers for the web server (by default it will start as many workers as there are logical cores...), thus this PR.
In the long run, streaming will probably help a lot.

Cheers