### PR TITLE
remove undefined fields from message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Changed
+- Apel plugin: Undefined (optional) fields will not be included in the message to APEL ([@dirksammel](https://github.com/dirksammel))
 - Dependencies: Update ruff from 0.11.4 to 0.11.5 ([@dirksammel](https://github.com/dirksammel))
 
 ### Removed

--- a/plugins/apel/src/auditor_apel_plugin/core.py
+++ b/plugins/apel/src/auditor_apel_plugin/core.py
@@ -411,7 +411,7 @@ def create_message(message_type: MessageType, grouped_sql: List[sqlite3.Row]) ->
             if field in keys:
                 field_list.append(f"{field}: {entry[field]}\n")
             else:
-                field_list.append(f"{field}: None\n")
+                logger.debug(f"Field {field} not defined in config, skipping")
 
         field_list.append("%%\n")
 


### PR DESCRIPTION
This PR removes undefined fields from the message to APEL.
There was a problem with a wrong default value for one field. Fixing that in a correct way for all possible fields would take more time than this fix.