### PR TITLE
Reduce memory consumption of APEL plugin

### DIFF
--- a/.github/workflows/build_python_rpms.yml
+++ b/.github/workflows/build_python_rpms.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   build-apel-plugin-rpm:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     defaults:
       run:
         working-directory: ./plugins/apel
@@ -44,7 +44,7 @@ jobs:
           name: apel-plugin-rpm
 
   build-htcondor-collector-rpm:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     defaults:
       run:
         working-directory: ./collectors/htcondor

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,12 +13,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Changed
+- APEL plugin: Reduce memory consumption ([@dirksammel](https://github.com/dirksammel))
 - Dependencies: Update cryptography from 44.0.2 to 44.0.3 ([@dirksammel](https://github.com/dirksammel))
 - Dependencies: Update pydantic from 2.11.3 to 2.11.4 ([@dirksammel](https://github.com/dirksammel))
 - Dependencies: Update ruff from 0.11.4 to 0.11.9 ([@dirksammel](https://github.com/dirksammel))
 - Dependencies: Update setuptools from 78.1.0 to 80.4.0 ([@dirksammel](https://github.com/dirksammel))
 
 ### Removed
+- APEL plugin: Remove option to report individual jobs ([@dirksammel](https://github.com/dirksammel))
 
 ## [0.9.2] 2025-04-10
 

--- a/plugins/apel/configs/auditor_apel_plugin_template.yml
+++ b/plugins/apel/configs/auditor_apel_plugin_template.yml
@@ -1,7 +1,6 @@
 # This is just an example config and not ready for usage!
 # You can find information about the options in the documentation: https://alu-schumacher.github.io/AUDITOR/latest/#apel-plugin
 # Please make sure that all values (file paths, URLS, IPs, ports, etc.) correspond to your setup, especially the names of the AUDITOR record fields you want to access.
-# You only need the summary_fields OR the individual_job_fields section, depending on the value for message_type in the plugin section.
 
 # !Config
 # plugin:
@@ -9,10 +8,8 @@
 #   log_file: /var/log/auditor_apel_plugin.log
 #   time_json_path: /etc/auditor_apel_plugin/time.json
 #   report_interval: 86400
-#   message_type: summaries
   
 # site:
-#   publish_since: 2025-01-01 00:00:00+00:00
 #   sites_to_report:
 #     SITE_A: ["site_id_1", "site_id_2"]
 #     SITE_B: ["site_id_3"]
@@ -37,7 +34,6 @@
 #   client_cert_path: /path/client-cert.pem
 #   client_key_path: /path/client-key.pem
 
-# Use this section if message_type: summaries
 # summary_fields:
 #   mandatory:
 #     NormalisedWallDuration: !NormalisedWallDurationField
@@ -75,42 +71,3 @@
 #       name: NNodes
 #     Processors: !ComponentField
 #       name: Cores
-
-# Use this section if message_type: individual_jobs
-# individual_job_fields:
-#   mandatory:
-#     CpuDuration: !ComponentField
-#       name: TotalCPU
-#       divide_by: 1000
-
-#   optional:
-#     GlobalUserName: !MetaField
-#       name: subject
-#     VO: !MetaField
-#       name: voms
-#       regex: (?<=/).*?(?=/|$)
-#     VOGroup: !MetaField
-#       name: voms
-#       regex: (?<=/).*?(?=/Role|$)
-#     VORole: !MetaField
-#       name: voms
-#       regex: '(?=Role).*?(?=/|$)'
-#     SubmitHost: !MetaField
-#       name: headnode
-#     InfrastructureType: !ConstantField
-#       value: grid
-#     NodeCount: !ComponentField
-#       name: NNodes
-#     Processors: !ComponentField
-#       name: Cores
-#     LocalUserId: !MetaField
-#       name: user_id
-#     FQAN: !MetaField
-#       name: voms
-#     InfrastructureDescription: !ConstantField
-#       value: AUDITOR-ARC-SLURM
-#     ServiceLevel: !ScoreField
-#       name: hepscore23
-#       component_name: Cores
-#     ServiceLevelType: !ConstantField
-#       value: hepscore23

--- a/plugins/apel/src/auditor_apel_plugin/message.py
+++ b/plugins/apel/src/auditor_apel_plugin/message.py
@@ -14,6 +14,7 @@ class Message(BaseModel):
     group_by: List[str] = []
     store_as: List[str] = []
     message_fields: List[str] = []
+    aggr_fields: List[str] = []
 
 
 class SummaryMessage(Message):
@@ -61,52 +62,12 @@ class SummaryMessage(Message):
         "NumberOfJobs",
     ]
 
-
-class SingleJobMessage(Message):
-    message_header: str = "APEL-individual-job-message: v0.3\n"
-
-    create_sql: List[str] = [
-        "Site TEXT NOT NULL",
-        "LocalJobId TEXT UNIQUE NOT NULL",
-        "WallDuration INT NOT NULL",
-        "StartTime INT NOT NULL",
-        "EndTime INT NOT NULL",
-    ]
-
-    group_by: List[str] = [
-        "Site",
-        "LocalJobId",
+    aggr_fields: List[str] = [
         "WallDuration",
         "CpuDuration",
-        "StartTime",
-    ]
-
-    store_as: List[str] = ["EndTime as EndTime"]
-
-    message_fields: List[str] = [
-        "Site",
-        "SubmitHost",
-        "MachineName",
-        "Queue",
-        "LocalJobId",
-        "LocalUserId",
-        "GlobalUserName",
-        "FQAN",
-        "VO",
-        "VOGroup",
-        "VORole",
-        "WallDuration",
-        "CpuDuration",
-        "Processors",
-        "NodeCount",
-        "StartTime",
-        "EndTime",
-        "InfrastructureDescription",
-        "InfrastructureType",
-        "MemoryReal",
-        "MemoryVirtual",
-        "ServiceLevelType",
-        "ServiceLevel",
+        "NormalisedWallDuration",
+        "NormalisedCpuDuration",
+        "NumberOfJobs",
     ]
 
 
@@ -127,14 +88,16 @@ class SyncMessage(Message):
 
     message_fields: List[str] = ["Site", "SubmitHost", "NumberOfJobs", "Month", "Year"]
 
+    aggr_fields: List[str] = ["NumberOfJobs"]
+
 
 class PluginMessage(Message):
     group_by: List[str] = ["Site", "Month", "Year"]
 
-    store_as: List[str] = [
-        "COUNT(RecordID) as NumberOfJobs",
-        "SUM(WallDuration) as WallDuration",
-        "SUM(NormalisedWallDuration) as NormalisedWallDuration",
-        "SUM(CpuDuration) as CpuDuration",
-        "SUM(NormalisedCpuDuration) as NormalisedCpuDuration",
+    aggr_fields: List[str] = [
+        "NumberOfJobs",
+        "WallDuration",
+        "CpuDuration",
+        "NormalisedWallDuration",
+        "NormalisedCpuDuration",
     ]

--- a/plugins/apel/src/auditor_apel_plugin/republish.py
+++ b/plugins/apel/src/auditor_apel_plugin/republish.py
@@ -6,16 +6,18 @@
 import argparse
 import logging
 import sys
-from datetime import datetime
+from datetime import datetime, timedelta, timezone
 from logging import Logger
+from typing import Dict, Union
 
 import yaml
 from pyauditor import AuditorClientBuilder
 
-from auditor_apel_plugin.config import Config, get_loaders
+from auditor_apel_plugin.config import Config, MessageType, get_loaders
 from auditor_apel_plugin.core import (
     build_payload,
     create_db,
+    create_dict,
     create_message,
     fill_db,
     get_records,
@@ -27,37 +29,72 @@ from auditor_apel_plugin.core import (
 TRACE = logging.DEBUG - 5
 
 
-def run(logger: Logger, config, client, args):
+def run(logger: Logger, config: Config, client, args):
     site = args.site
     dry_run = args.dry_run
 
-    message_type = config.plugin.message_type
+    sites_to_report = config.site.sites_to_report
     field_dict = config.get_all_fields()
     optional_fields = config.get_optional_fields()
 
     begin_date = datetime.fromisoformat(args.begin_date)
     end_date = datetime.fromisoformat(args.end_date)
 
+    if end_date < begin_date:
+        logger.critical("end_date has to be later than begin_date!")
+        sys.exit(1)
+
     if dry_run:
         logger.info("Starting one-shot dry-run, nothing will be sent to APEL!")
 
-    records = get_records(config, client, begin_date, 30, site, end_date)
+    aggr_summary_dict: Dict[str, Dict[str, Union[str, int]]] = {}
+    loop_day = begin_date
 
-    if len(records) == 0:
-        logger.critical("No records found!")
-        sys.exit(1)
+    while end_date.replace(tzinfo=timezone.utc) > loop_day.replace(tzinfo=timezone.utc):
+        next_day = loop_day + timedelta(days=1)
 
-    db = create_db(field_dict, message_type)
-    filled_db = fill_db(config, db, message_type, field_dict, site, records)
-    del records
-    grouped_db = group_db(filled_db, message_type, optional_fields)
-    filled_db.close()
-    message = create_message(message_type, grouped_db)
+        logger.info(
+            f"Getting records for {loop_day.date()} for site {site} "
+            f"with site_ids: {sites_to_report[site]}"
+        )
+
+        if next_day > end_date:
+            next_day = end_date
+
+        records = get_records(config, client, loop_day, site, next_day)
+
+        loop_day = next_day
+
+        if len(records) == 0:
+            logger.warning("No records found!")
+            continue
+
+        latest_stop_time = records[-1].stop_time.replace(tzinfo=timezone.utc)
+        logger.debug(f"Latest stop time is {latest_stop_time}")
+
+        db = create_db(field_dict, MessageType.summaries)
+        filled_db = fill_db(
+            config,
+            db,
+            MessageType.summaries,
+            field_dict,
+            site,
+            records,
+        )
+        del records
+        grouped_db = group_db(filled_db, MessageType.summaries, optional_fields)
+        filled_db.close()
+        message_dict = create_dict(
+            MessageType.summaries, grouped_db, optional_fields, aggr_summary_dict
+        )
+
+    message = create_message(MessageType.summaries, message_dict)
     logger.log(TRACE, f"Message:\n{message}")
     signed_message = sign_msg(config, message)
     logger.log(TRACE, f"Signed message:\n{signed_message}")
     payload_message = build_payload(signed_message)
     logger.log(TRACE, f"Payload message:\n{payload_message}")
+
     if not dry_run:
         post_message = send_payload(config, payload_message)
         logger.info(f"Message sent to server, response:\n{post_message}")

--- a/plugins/apel/tests/test_config.py
+++ b/plugins/apel/tests/test_config.py
@@ -13,7 +13,6 @@ from auditor_apel_plugin.config import (
     ConstantField,
     Field,
     Function,
-    MessageType,
     MetaField,
     NormalisedField,
     PluginConfig,
@@ -37,21 +36,18 @@ class TestConfig:
         log_file = "/var/log/test.log"
         time_json_path = "time.json"
         report_interval = 10
-        message_type = "summaries"
 
         plugin = PluginConfig(
             log_level=log_level,
             log_file=log_file,
             time_json_path=time_json_path,
             report_interval=report_interval,
-            message_type=message_type,
         )
 
         assert plugin.log_level == "DEBUG"
         assert plugin.log_file == "/var/log/test.log"
         assert plugin.time_json_path == "time.json"
         assert plugin.report_interval == 10
-        assert plugin.message_type is MessageType("summaries")
 
         field_config = config.get_field_config()
 
@@ -80,18 +76,6 @@ class TestConfig:
         value = all_fields["CpuDuration"].name
 
         assert value == "TotalCPU"
-
-        message_type = "something_else"
-
-        with pytest.raises(Exception) as pytest_error:
-            plugin = PluginConfig(
-                log_level=log_level,
-                time_json_path=time_json_path,
-                report_interval=report_interval,
-                message_type=message_type,
-            )
-
-        assert pytest_error.type is ValidationError
 
         ip = "127.0.0.1"
         port = 8000

--- a/plugins/apel/tests/test_config.yml
+++ b/plugins/apel/tests/test_config.yml
@@ -3,10 +3,8 @@ plugin:
   log_level: test_level
   time_json_path: test_path
   report_interval: 20
-  message_type: summaries
   
 site:
-  publish_since: 2000-01-01 00:00:00+00:00
   sites_to_report:
     TEST-SITE: ["test"]
 
@@ -64,44 +62,6 @@ summary_fields:
     SubmitHost: !MetaField
       name: headnode
     Infrastructure: !ConstantField
-      value: grid
-    NodeCount: !ComponentField
-      name: NNodes
-    Processors: !ComponentField
-      name: Cores
-
-individual_job_fields:
-  mandatory:
-    NormalisedWallDuration: !NormalisedField
-      score:
-        name: hepscore23
-        component_name: Cores
-    CpuDuration: !ComponentField
-      name: TotalCPU
-      divide_by: 1000
-    NormalisedCpuDuration: !NormalisedField
-      base_value: !ComponentField
-        name: TotalCPU
-        divide_by: 1000
-      score:
-        name: hepscore23
-        component_name: Cores
-    
-  optional:
-    GlobalUserName: !MetaField
-      name: subject
-    VO: !MetaField
-      name: voms
-      regex: (?<=%2F).*?\S(?=%2F)
-    VOGroup: !MetaField
-      name: voms
-      regex: (?=%2F).*?\S(?=%2F)
-    VORole: !MetaField
-      name: voms
-      regex: (?=Role).*
-    SubmitHost: !MetaField
-      name: headnode
-    InfrastructureType: !ConstantField
       value: grid
     NodeCount: !ComponentField
       name: NNodes


### PR DESCRIPTION
This PR solves high memory consumption of the APEL plugin when a large number of records are queried. The message to APEL is now constructed in a aggregated way by processing only records of 1 day at once.
This PR also removes the option to submit individual job records, since this wasn't used by anyone and won't be feasible in the future for large numbers of records.