### PR TITLE
change parameters of republish script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Breaking changes
+- Apel plugin: Change `begin_date` and `end_date` parameters of republish script to `month` and `year` ([@dirksammel](https://github.com/dirksammel))
 
 ### Security
 
@@ -26,7 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - AUDITOR: Add unit file and sql migration files to RPM ([@dirksammel](https://github.com/dirksammel))
 
 ### Changed
-- APEL plugin: Reduce memory consumption ([@dirksammel](https://github.com/dirksammel))
+- Apel plugin: Reduce memory consumption ([@dirksammel](https://github.com/dirksammel))
 - Dependencies: Update cryptography from 44.0.2 to 44.0.3 ([@dirksammel](https://github.com/dirksammel))
 - Dependencies: Update pydantic from 2.11.3 to 2.11.4 ([@dirksammel](https://github.com/dirksammel))
 - Dependencies: Update ruff from 0.11.4 to 0.11.9 ([@dirksammel](https://github.com/dirksammel))
@@ -34,7 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Dependencies: Update sqlx from 0.8.3 to 0.8.5 ([@dirksammel](https://github.com/dirksammel))
 
 ### Removed
-- APEL plugin: Remove option to report individual jobs ([@dirksammel](https://github.com/dirksammel))
+- Apel plugin: Remove option to report individual jobs ([@dirksammel](https://github.com/dirksammel))
 
 ## [0.9.2] 2025-04-10
 

--- a/media/website/content/_index.md
+++ b/media/website/content/_index.md
@@ -841,19 +841,18 @@ options:
   --dry-run            One-shot dry-run, nothing will be sent to the APEL server
 ```
 
-`auditor-apel-republish` runs once and submits a report of jobs between two dates for a given site.
+`auditor-apel-republish` runs once and submits a summary report for a given month, year, and site.
 
 ```bash
-usage: auditor-apel-republish [-h] --begin-date BEGIN_DATE --end-date END_DATE -s SITE -c CONFIG [--dry-run]
+usage: auditor-apel-republish [-h] -y YEAR -m MONTH -s SITE -c CONFIG [--dry-run]
 
 options:
-  -h, --help            show this help message and exit
-  --begin-date BEGIN_DATE
-                        Begin of republishing (UTC): yyyy-mm-dd hh:mm:ss+00:00, e.g. 2023-11-27 13:31:10+00:00
-  --end-date END_DATE   End of republishing (UTC): yyyy-mm-dd hh:mm:ss+00:00, e.g. 2023-11-29 21:10:54+00:00
-  -s, --site SITE       Site (GOCDB): UNI-FREIBURG, ...
-  -c, --config CONFIG   Path to the config file
-  --dry-run             One-shot dry-run, nothing will be sent to the APEL server
+  -h, --help           show this help message and exit
+  -y, --year YEAR      Year: 2020, 2021, ...
+  -m, --month MONTH    Month: 4, 8, 12, ...
+  -s, --site SITE      Site (GOCDB): UNI-FREIBURG, ...
+  -c, --config CONFIG  Path to the config file
+  --dry-run            One-shot dry-run, nothing will be sent to the APEL server
 ```
 
 ### pip


### PR DESCRIPTION
This PR changes the parameters of the republish script from begin date and end date to year and month.
Summaries on the APEL server get overwritten, therefore it doesn't make sense to republish just part of a month.