### PR TITLE
use proper relative path for .env

### DIFF
--- a/auditor/scripts/revert_encoding/revert_encodings.py
+++ b/auditor/scripts/revert_encoding/revert_encodings.py
@@ -1,12 +1,13 @@
 import json
 import os
 from json.decoder import JSONDecodeError
+from pathlib import Path
 from urllib.parse import unquote
 
 import psycopg2
 from dotenv import load_dotenv
 
-load_dotenv(dotenv_path="auditor/scripts/revert_encoding/.env")
+load_dotenv(dotenv_path=Path(__file__).parent / ".env")
 
 
 DB_CONFIG = {


### PR DESCRIPTION
This PR changes how the path of the `revert_encoding.py` `.env` is computed so that it can be used standalone.

---

The intention seems to be to load the `.env` file which is "right next to" the `revert_encoding.py` script. However, the previous implementation assumed that the script was in a specific subfolder of the `auditor` repo *and* the CWD was at the root of the repo. Notably, since a relative path was used this could end up in a wrong place if the CWD wasn't correct. When using the script standalone (e.g. `wget`'ed from github) one had to create a `auditor/scripts/revert_encoding` hierarchy and place the `.env` there.

This PR computes the `.env` path absolutely in relation to the `revert_encoding.py` run. This should preserve the original intention, but be more robust as well as more flexible for usage.

-------

This is still compatible with the old usage and rather one-off for most users. I don't think updating the docs or changelog is needed.