### PR TITLE
Slurm collector: Speed up parsing of time values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Changed
+- Slurm collector: Speed up parsing of `sacct` output ([@rkleinem](https://github.com/rkleinem))
 
 ### Removed
 


### PR DESCRIPTION
Hey there,

as mentioned earlier, the slurm collector will re-compile regexes on each time-field encountered in the sacct output.
With this, compilation will only happen one time.

Cheers