### PR TITLE
Fix bug with HTCondor Collector since timestamp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - AUDITOR: Change the meta query field as an array ([@raghuvar-vijay](https://github.com/raghuvar-vijay))
 - Slurm collector: Speed up parsing of `sacct` output ([@rkleinem](https://github.com/rkleinem))
 - HTCondor collector: Allow for reading history from file ([@rfvc](https://github.com/rfvc))
+- HTCondor collector: Fix bug that prevented reading old jobs on first collection ([@maxfischer2781](https://github.com/maxfischer2781))
 
 ### Removed
 

--- a/collectors/htcondor/src/auditor_htcondor_collector/collector.py
+++ b/collectors/htcondor/src/auditor_htcondor_collector/collector.py
@@ -147,7 +147,7 @@ class CondorHistoryCollector(object):
             assert type(job) is tuple and len(job) == 2, "Invalid job id"
             assert isinstance(job[0], int) and isinstance(job[1], int), "Invalid job id"
 
-        since = f"'CompletionDate<={self.config.condor_timestamp}'"
+        since = f"'CompletionDate<={self.config.condor_timestamp} && CompletionDate>0'"
         if job is None:
             self.logger.debug(
                 f"Querying HTCondor history for {schedd_name!r} starting "


### PR DESCRIPTION
This PR adds a workaround for collecting jobs via timestamps. Cancelled jobs have a `CompletionDate = 0`, so the scan for jobs after a specific date stops too early. This merely extends the scan condition to ignore such jobs for stopping.

Closes #1309.