### PR TITLE
Show error if sacct is not successful

### DIFF
--- a/collectors/slurm/src/sacctcaller.rs
+++ b/collectors/slurm/src/sacctcaller.rs
@@ -149,6 +149,10 @@ async fn get_job_info(database: &Database) -> Result<Vec<RecordAdd>> {
 
     let cmd_out = Command::new(binary).args(&args).output().await?;
 
+    if !cmd_out.status.success() {
+        return Err(eyre!("sacct error: {:?}", cmd_out.stderr));
+    };
+
     let cmd_out = std::str::from_utf8(&cmd_out.stdout)?;
     tracing::debug!("Got: {}", cmd_out);
 


### PR DESCRIPTION
Hi,

the slurm collector will silently fail if the sacct call is not successful because it does not check the exit code.

I added an error message.

But maybe we should think about when the collector should shut down because of errors?
Some error message in a log is easy to miss, but when a systemd service fails you can get notified...
Do we have any policy at all here?