### PR TITLE
add benchmark type to report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Security
 
 ### Added
+- Apel plugin: Add `benchmark_type` to config ([@dirksammel](https://github.com/dirksammel))
 
 ### Changed
 - Dependencies: Update pyyaml from 6.0.2 to 6.0.3 ([@dirksammel](https://github.com/dirksammel))

--- a/media/website/content/_index.md
+++ b/media/website/content/_index.md
@@ -1067,6 +1067,7 @@ site:
       - site_id_2
     SITE_B: 
       - site_id_3
+  benchmark_type: HEPscore23
 
 messaging:
   host: msg.argo.grnet.gr
@@ -1134,6 +1135,7 @@ The individual parameters in the config file are:
 | `plugin`    | `time_json_path`   | Path of the `time.json` file. The JSON file should be located at a persistent path and stores the stop times of the latest reported job per site, and the time of the latest report to APEL. |
 | `plugin`    | `report_interval`  | Time in seconds between reports to APEL.                                                                                                                                                     |
 | `site`      | `sites_to_report`  | Dictionary of the sites that will be reported. The keys are the names of the sites in the GOCDB, the values are lists of the corresponding site names in the AUDITOR records.                |
+| `site`      | `benchmark_type`   | The name of the benchmark that you report. Possible values are `si2k`, `hepspec` and `HEPscore23`. The default value is `HEPscore23`.                                                        |
 | `messaging` | `host`             | Host address of the AMS service.                                                                                                                                                             |
 | `messaging` | `port`             | Port of the AMS host.                                                                                                                                                                        |
 | `messaging` | `client_cert`      | Path of the host certificate.                                                                                                                                                                |

--- a/plugins/apel/configs/auditor_apel_plugin_template.yml
+++ b/plugins/apel/configs/auditor_apel_plugin_template.yml
@@ -16,6 +16,7 @@
 #       - site_id_2
 #     SITE_B:
 #       - site_id_3
+#   benchmark_type: HEPscore23
 
 # messaging:
 #   host: msg.argo.grnet.gr

--- a/plugins/apel/src/auditor_apel_plugin/config.py
+++ b/plugins/apel/src/auditor_apel_plugin/config.py
@@ -26,6 +26,20 @@ class MessageType(Enum):
         return cls.summaries
 
 
+class BenchmarkType(Enum):
+    hepspec = "hepspec"
+    HEPscore23 = "HEPscore23"
+    si2k = "si2k"
+
+    @classmethod
+    def _missing_(cls, value):
+        if isinstance(value, str):
+            value_lower = value.lower()
+            for member in cls:
+                if value_lower == member.name.lower():
+                    return member
+
+
 class Configurable(BaseModel):
     @classmethod
     def from_yaml(cls, loader: yaml.SafeLoader, node: yaml.nodes.MappingNode):
@@ -49,6 +63,7 @@ class PluginConfig(Configurable):
 
 class SiteConfig(Configurable):
     sites_to_report: Dict[str, List[str]]
+    benchmark_type: BenchmarkType = BenchmarkType.HEPscore23
 
 
 class AuditorConfig(Configurable):

--- a/plugins/apel/src/auditor_apel_plugin/core.py
+++ b/plugins/apel/src/auditor_apel_plugin/core.py
@@ -17,7 +17,7 @@ from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.serialization import pkcs7
 from pyauditor import MetaOperator, MetaQuery, Operator, QueryBuilder, Record, Value
 
-from auditor_apel_plugin.config import Config, Field, MessageType
+from auditor_apel_plugin.config import BenchmarkType, Config, Field, MessageType
 from auditor_apel_plugin.message import (
     Message,
     PluginMessage,
@@ -379,7 +379,9 @@ def create_dict(
 
 
 def create_message(
-    message_type: MessageType, aggr_dict: Dict[str, Dict[str, Union[str, int]]]
+    message_type: MessageType,
+    aggr_dict: Dict[str, Dict[str, Union[str, int]]],
+    benchmark_type: BenchmarkType = BenchmarkType.HEPscore23,
 ) -> str:
     message = Message()
 
@@ -393,6 +395,8 @@ def create_message(
 
     for group in aggr_dict.values():
         for k, v in group.items():
+            if "Norm" in k:
+                v = f"{{{benchmark_type.value}: {v}}}"
             message_list.append(f"{k}: {v}\n")
 
         message_list.append("%%\n")

--- a/plugins/apel/src/auditor_apel_plugin/message.py
+++ b/plugins/apel/src/auditor_apel_plugin/message.py
@@ -18,7 +18,7 @@ class Message(BaseModel):
 
 
 class SummaryMessage(Message):
-    message_header: str = "APEL-summary-job-message: v0.3\n"
+    message_header: str = "APEL-normalised-summary-message: v0.4\n"
 
     create_sql: List[str] = [
         "Site TEXT NOT NULL",

--- a/plugins/apel/src/auditor_apel_plugin/publish.py
+++ b/plugins/apel/src/auditor_apel_plugin/publish.py
@@ -39,6 +39,7 @@ TRACE = logging.DEBUG - 5
 def run(logger: Logger, config: Config, client, args):
     report_interval = config.plugin.report_interval
     sites_to_report = config.site.sites_to_report
+    benchmark_type = config.site.benchmark_type
     field_dict = config.get_all_fields()
     optional_fields = config.get_optional_fields()
     dry_run = args.dry_run
@@ -135,7 +136,9 @@ def run(logger: Logger, config: Config, client, args):
                 post_sync = send_payload(config, payload_sync)
                 logger.info(f"Sync message sent to server, response:\n{post_sync}")
 
-            message = create_message(MessageType.summaries, message_dict)
+            message = create_message(
+                MessageType.summaries, message_dict, benchmark_type
+            )
             logger.log(TRACE, f"Message:\n{message}")
             signed_message = sign_msg(config, message)
             logger.log(TRACE, f"Signed message:\n{signed_message}")

--- a/plugins/apel/src/auditor_apel_plugin/republish.py
+++ b/plugins/apel/src/auditor_apel_plugin/republish.py
@@ -33,6 +33,7 @@ def run(logger: Logger, config: Config, client, args):
     dry_run = args.dry_run
 
     sites_to_report = config.site.sites_to_report
+    benchmark_type = config.site.benchmark_type
     field_dict = config.get_all_fields()
     optional_fields = config.get_optional_fields()
 
@@ -97,7 +98,7 @@ def run(logger: Logger, config: Config, client, args):
         logger.warning(f"No records for site {site} in this month")
         quit()
 
-    message = create_message(MessageType.summaries, message_dict)
+    message = create_message(MessageType.summaries, message_dict, benchmark_type)
     logger.log(TRACE, f"Message:\n{message}")
     signed_message = sign_msg(config, message)
     logger.log(TRACE, f"Signed message:\n{signed_message}")

--- a/plugins/apel/tests/test_config.py
+++ b/plugins/apel/tests/test_config.py
@@ -18,6 +18,7 @@ from auditor_apel_plugin.config import (
     PluginConfig,
     RecordField,
     ScoreField,
+    SiteConfig,
     get_loaders,
 )
 
@@ -442,3 +443,35 @@ class TestConfig:
         value = config.summary_fields.mandatory["VO"].get_value(record)
 
         assert value == "None"
+
+    def test_benchmark_config(self):
+        sites_to_report = {"test": ["test"]}
+
+        siteconfig = SiteConfig(sites_to_report=sites_to_report)
+
+        assert siteconfig.benchmark_type.value == "HEPscore23"
+
+        benchmark_type = "HEPscore23"
+
+        siteconfig = SiteConfig(
+            sites_to_report=sites_to_report, benchmark_type=benchmark_type
+        )
+
+        assert siteconfig.benchmark_type.value == "HEPscore23"
+
+        benchmark_type = "HEPSPEC"
+
+        siteconfig = SiteConfig(
+            sites_to_report=sites_to_report, benchmark_type=benchmark_type
+        )
+
+        assert siteconfig.benchmark_type.value == "hepspec"
+
+        benchmark_type = "hepspec23"
+
+        with pytest.raises(Exception) as pytest_error:
+            siteconfig = SiteConfig(
+                sites_to_report=sites_to_report, benchmark_type=benchmark_type
+            )
+
+        assert pytest_error.type is ValidationError


### PR DESCRIPTION
This PR adds the benchmark type to the APEL report. For this, we need to change the message type from "APEL-summary-job-message: v0.3" to "APEL-normalised-summary-message: v0.4".