### PR TITLE
disable automatic rebasing of dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,21 +6,25 @@ updates:
     schedule:
       interval: "daily"
     open-pull-requests-limit: 50
+    rebase-strategy: "disabled"
   # APEL plugin
   - package-ecosystem: "pip"
     directory: "/plugins/apel"
     schedule:
       interval: "daily"
     open-pull-requests-limit: 50
+    rebase-strategy: "disabled"
   # HTCondor collector
   - package-ecosystem: "pip"
     directory: "/collectors/htcondor"
     schedule:
       interval: "daily"
-    open-pull-requests-limit: 50      
+    open-pull-requests-limit: 50
+    rebase-strategy: "disabled"
   # GitHub action
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "daily"
     open-pull-requests-limit: 50
+    rebase-strategy: "disabled"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Apel plugin: Fix error in template config ([@dirksammel](https://github.com/dirksammel))
 - CI/CD: Switch from `--bin` to `-p` for `cargo build` ([@dirksammel](https://github.com/dirksammel))
+- CI/CD: Disable automatic rebasing of dependabot PRs ([@dirksammel](https://github.com/dirksammel))
 - Pyauditor: Fix tls params order ([@raghuvar-vijay](https://github.com/raghuvar-vijay))
 - Dependencies: Update cryptography from 45.0.5 to 46.0.3 ([@raghuvar-vijay](https://github.com/raghuvar-vijay))
 - Dependencies: Update pytest from 8.4.1 to 8.4.2 ([@dirksammel](https://github.com/dirksammel))


### PR DESCRIPTION
This PR disables automatic rebasing of dependabot PRs and will reduce the number of running workflows.