### PR TITLE
APEL plugin code cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - AUDITOR: Fix clippy and cargo deny issues ([@dirksammel](https://github.com/dirksammel))
 - AUDITOR: Prevent the archive service from blocking server startup ([@rkleinem](https://github.com/rkleinem))
 - Archival: Fix validation query logic ([@raghuvar-vijay](https://github.com/raghuvar-vijay))
+- Apel plugin: Remove `MessageType` enum ([@dirksammel](https://github.com/dirksammel))
 - CI/CD: Switch to official ruff git action ([@dirksammel](https://github.com/dirksammel))
 - CI/CD: Catch error when killing processes in tests ([@dirksammel](https://github.com/dirksammel))
 - CI/CD: Improve htcondor-collector workflow ([@dirksammel](https://github.com/dirksammel))

--- a/plugins/apel/src/auditor_apel_plugin/config.py
+++ b/plugins/apel/src/auditor_apel_plugin/config.py
@@ -6,7 +6,7 @@
 import logging
 import re
 from enum import Enum
-from typing import Any, Callable, Dict, List, Optional, Union
+from typing import Any, Callable, Optional, Union
 
 import yaml
 from pyauditor import Record
@@ -15,15 +15,6 @@ from pydantic import BaseModel, model_validator
 from .utility import vo_mapping
 
 logger = logging.getLogger("apel_plugin")
-
-
-class MessageType(Enum):
-    summaries = "summaries"
-    sync = "sync"
-
-    @classmethod
-    def _missing_(cls, value):
-        return cls.summaries
 
 
 class BenchmarkType(Enum):
@@ -62,7 +53,7 @@ class PluginConfig(Configurable):
 
 
 class SiteConfig(Configurable):
-    sites_to_report: Dict[str, List[str]]
+    sites_to_report: dict[str, list[str]]
     benchmark_type: BenchmarkType = BenchmarkType.HEPscore23
 
 
@@ -70,7 +61,7 @@ class AuditorConfig(Configurable):
     ip: str
     port: int
     timeout: int
-    site_meta_field: Union[str, List[str]]
+    site_meta_field: Union[str, list[str]]
     use_tls: bool
     ca_cert_path: Optional[str] = None
     client_cert_path: Optional[str] = None
@@ -113,8 +104,8 @@ class Field(Configurable):
 
 
 class FieldConfig(Configurable):
-    mandatory: Dict[str, Field]
-    optional: Dict[str, Field] = {}
+    mandatory: dict[str, Field]
+    optional: dict[str, Field] = {}
 
     @model_validator(mode="after")
     def check_mandatory_fields(self):
@@ -168,7 +159,7 @@ class MetaField(Field):
     function: Optional[Function] = None
 
     def get_value(self, record: Record) -> Union[str, int, float]:
-        function_dict: Dict[str, Callable[[str, Any], Union[str, int, float]]] = {
+        function_dict: dict[str, Callable[[str, Any], Union[str, int, float]]] = {
             "vo_mapping": vo_mapping
         }
 
@@ -305,13 +296,13 @@ class Config(Configurable):
 
         return field_config
 
-    def get_mandatory_fields(self) -> Dict[str, Field]:
+    def get_mandatory_fields(self) -> dict[str, Field]:
         return self.get_field_config().mandatory
 
-    def get_optional_fields(self) -> Dict[str, Field]:
+    def get_optional_fields(self) -> dict[str, Field]:
         return self.get_field_config().optional
 
-    def get_all_fields(self) -> Dict[str, Field]:
+    def get_all_fields(self) -> dict[str, Field]:
         mandatory_dict = self.get_mandatory_fields()
         optional_dict = self.get_optional_fields()
 

--- a/plugins/apel/src/auditor_apel_plugin/message.py
+++ b/plugins/apel/src/auditor_apel_plugin/message.py
@@ -3,24 +3,22 @@
 # SPDX-FileCopyrightText: © 2024 Dirk Sammel <dirk.sammel@gmail.com>
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 
-from typing import List
-
 from pydantic import BaseModel
 
 
 class Message(BaseModel):
     message_header: str = ""
-    create_sql: List[str] = []
-    group_by: List[str] = []
-    store_as: List[str] = []
-    message_fields: List[str] = []
-    aggr_fields: List[str] = []
+    create_sql: list[str] = []
+    group_by: list[str] = []
+    store_as: list[str] = []
+    message_fields: list[str] = []
+    aggr_fields: list[str] = []
 
 
 class SummaryMessage(Message):
     message_header: str = "APEL-normalised-summary-message: v0.4\n"
 
-    create_sql: List[str] = [
+    create_sql: list[str] = [
         "Site TEXT NOT NULL",
         "Month INT NOT NULL",
         "Year INT NOT NULL",
@@ -29,9 +27,9 @@ class SummaryMessage(Message):
         "RecordID TEXT UNIQUE NOT NULL",
     ]
 
-    group_by: List[str] = ["Site", "Month", "Year", "VO", "SubmitHost", "Processors"]
+    group_by: list[str] = ["Site", "Month", "Year", "VO", "SubmitHost", "Processors"]
 
-    store_as: List[str] = [
+    store_as: list[str] = [
         "COUNT(RecordID) as NumberOfJobs",
         "SUM(WallDuration) as WallDuration",
         "SUM(NormalisedWallDuration) as NormalisedWallDuration",
@@ -41,7 +39,7 @@ class SummaryMessage(Message):
         "MAX(StopTime) as LatestEndTime",
     ]
 
-    message_fields: List[str] = [
+    message_fields: list[str] = [
         "Site",
         "Month",
         "Year",
@@ -62,7 +60,7 @@ class SummaryMessage(Message):
         "NumberOfJobs",
     ]
 
-    aggr_fields: List[str] = [
+    aggr_fields: list[str] = [
         "WallDuration",
         "CpuDuration",
         "NormalisedWallDuration",
@@ -74,7 +72,7 @@ class SummaryMessage(Message):
 class SyncMessage(Message):
     message_header: str = "APEL-sync-message: v0.1\n"
 
-    create_sql: List[str] = [
+    create_sql: list[str] = [
         "Site TEXT NOT NULL",
         "Month INT NOT NULL",
         "Year INT NOT NULL",
@@ -82,19 +80,19 @@ class SyncMessage(Message):
         "RecordID TEXT UNIQUE NOT NULL",
     ]
 
-    group_by: List[str] = ["Site", "Month", "Year", "SubmitHost"]
+    group_by: list[str] = ["Site", "Month", "Year", "SubmitHost"]
 
-    store_as: List[str] = ["COUNT(RecordID) as NumberOfJobs"]
+    store_as: list[str] = ["COUNT(RecordID) as NumberOfJobs"]
 
-    message_fields: List[str] = ["Site", "SubmitHost", "NumberOfJobs", "Month", "Year"]
+    message_fields: list[str] = ["Site", "SubmitHost", "NumberOfJobs", "Month", "Year"]
 
-    aggr_fields: List[str] = ["NumberOfJobs"]
+    aggr_fields: list[str] = ["NumberOfJobs"]
 
 
 class PluginMessage(Message):
-    group_by: List[str] = ["Site", "Month", "Year"]
+    group_by: list[str] = ["Site", "Month", "Year"]
 
-    aggr_fields: List[str] = [
+    aggr_fields: list[str] = [
         "NumberOfJobs",
         "WallDuration",
         "CpuDuration",

--- a/plugins/apel/src/auditor_apel_plugin/utility.py
+++ b/plugins/apel/src/auditor_apel_plugin/utility.py
@@ -1,7 +1,7 @@
 import logging
 import pathlib
-from contextlib import contextmanager
-from typing import IO, ContextManager, Dict, Literal, overload
+from contextlib import AbstractContextManager, contextmanager
+from typing import IO, Literal, overload
 
 logger = logging.getLogger("apel_plugin")
 
@@ -9,13 +9,13 @@ logger = logging.getLogger("apel_plugin")
 @overload
 def write_transaction(
     path: "str | pathlib.PurePath", mode: Literal["w"] = ..., **kwargs
-) -> ContextManager[IO[str]]: ...
+) -> AbstractContextManager[IO[str]]: ...
 
 
 @overload
 def write_transaction(
     path: "str | pathlib.PurePath", mode: Literal["wb"], **kwargs
-) -> ContextManager[IO[bytes]]: ...
+) -> AbstractContextManager[IO[bytes]]: ...
 
 
 @contextmanager
@@ -34,7 +34,7 @@ def write_transaction(
         tmp_path.rename(path)
 
 
-def vo_mapping(user: str, vo_dict: Dict[str, str]) -> str:
+def vo_mapping(user: str, vo_dict: dict[str, str]) -> str:
     for k, v in vo_dict.items():
         if user.startswith(k):
             return v

--- a/plugins/apel/tests/test_auditor_apel_plugin.py
+++ b/plugins/apel/tests/test_auditor_apel_plugin.py
@@ -2,15 +2,13 @@ import json
 import os
 import subprocess
 from datetime import datetime, timezone
-from pathlib import Path, PurePath
+from pathlib import PurePath
 
-import pyauditor
 import pytest
 import yaml
 
 from auditor_apel_plugin.config import Config, get_loaders
 from auditor_apel_plugin.core import (
-    convert_to_seconds,
     create_time_json,
     get_begin_current_month,
     get_begin_previous_month,
@@ -33,49 +31,6 @@ class FakeAuditorClient:
             return "good"
         if self.test_case == "fail":
             raise RuntimeError("RuntimeError")
-
-
-def create_rec_metaless(rec_values, conf):
-    rec = pyauditor.Record(rec_values["rec_id"], rec_values["start_time"])
-    rec.with_stop_time(rec_values["stop_time"])
-    rec.with_component(
-        pyauditor.Component(conf["cores_name"], rec_values["n_cores"]).with_score(
-            pyauditor.Score(conf["benchmark_name"], rec_values["hepscore"])
-        )
-    )
-    rec.with_component(
-        pyauditor.Component(conf["cpu_time_name"], rec_values["tot_cpu"])
-    )
-    rec.with_component(pyauditor.Component(conf["nnodes_name"], rec_values["n_nodes"]))
-
-    return rec
-
-
-def create_rec(rec_values, conf):
-    rec = pyauditor.Record(rec_values["rec_id"], rec_values["start_time"])
-    rec.with_stop_time(rec_values["stop_time"])
-    rec.with_component(
-        pyauditor.Component(conf["cores_name"], rec_values["n_cores"]).with_score(
-            pyauditor.Score(conf["benchmark_name"], rec_values["hepscore"])
-        )
-    )
-    rec.with_component(
-        pyauditor.Component(conf["cpu_time_name"], rec_values["tot_cpu"])
-    )
-    rec.with_component(pyauditor.Component(conf["nnodes_name"], rec_values["n_nodes"]))
-    meta = pyauditor.Meta()
-
-    if rec_values["submit_host"] is not None:
-        meta.insert(conf["meta_key_submithost"], [rec_values["submit_host"]])
-    if rec_values["user_name"] is not None:
-        meta.insert(conf["meta_key_username"], [rec_values["user_name"]])
-    if rec_values["voms"] is not None:
-        meta.insert(conf["meta_key_voms"], [rec_values["voms"]])
-    if rec_values["site"] is not None:
-        meta.insert(conf["meta_key_site"], [rec_values["site"]])
-    rec.with_meta(meta)
-
-    return rec
 
 
 class TestAuditorApelPlugin:
@@ -104,15 +59,13 @@ class TestAuditorApelPlugin:
 
         result = create_time_json(path)
 
-        assert result["site_end_times"] == {}
         assert result["last_report_time"] == "1970-01-01T00:00:00"
 
-        with open("/tmp/test.json", "r", encoding="utf-8") as f:
+        with open("/tmp/test.json", encoding="utf-8") as f:
             result = json.load(f)
 
         os.remove(path)
 
-        assert result["site_end_times"] == {}
         assert result["last_report_time"] == "1970-01-01T00:00:00"
 
     def test_create_time_json_fail(self):
@@ -124,7 +77,7 @@ class TestAuditorApelPlugin:
         assert pytest_error.type is FileNotFoundError
 
     def test_get_time_json(self):
-        with open(Path.joinpath(test_dir, "test_config.yml"), "r") as f:
+        with open(test_dir.joinpath("test_config.yml")) as f:
             config: Config = yaml.load(f, Loader=get_loaders())
 
         path = "/tmp/nonexistent_55_abc_time.db"
@@ -134,22 +87,20 @@ class TestAuditorApelPlugin:
         result = get_time_json(config)
         os.remove(path)
 
-        assert result["site_end_times"] == {}
         assert result["last_report_time"] == "1970-01-01T00:00:00"
 
         create_time_json(path)
         result = get_time_json(config)
         os.remove(path)
 
-        assert result["site_end_times"] == {}
         assert result["last_report_time"] == "1970-01-01T00:00:00"
 
     def test_sign_msg(self):
-        with open(Path.joinpath(test_dir, "test_config.yml"), "r") as f:
+        with open(test_dir.joinpath("test_config.yml")) as f:
             config: Config = yaml.load(f, Loader=get_loaders())
 
-        config.messaging.client_cert = Path.joinpath(test_dir, "test_cert.cert")
-        config.messaging.client_key = Path.joinpath(test_dir, "test_key.key")
+        config.messaging.client_cert = test_dir.joinpath("test_cert.cert")
+        config.messaging.client_key = test_dir.joinpath("test_key.key")
 
         result = sign_msg(config, "test")
 
@@ -165,7 +116,7 @@ class TestAuditorApelPlugin:
         assert process.returncode == 0
 
     def test_sign_msg_fail(self):
-        with open(Path.joinpath(test_dir, "test_config.yml"), "r") as f:
+        with open(test_dir.joinpath("test_config.yml")) as f:
             config: Config = yaml.load(f, Loader=get_loaders())
 
         config.messaging.client_cert = "tests/nodir/test_cert.cert"
@@ -176,8 +127,8 @@ class TestAuditorApelPlugin:
 
         assert pytest_error.type is FileNotFoundError
 
-        config.messaging.client_cert = str(Path.joinpath(test_dir, "test_cert.cert"))
-        config.messaging.client_key = str(Path.joinpath(test_dir, "test_key.key"))
+        config.messaging.client_cert = str(test_dir.joinpath("test_cert.cert"))
+        config.messaging.client_key = str(test_dir.joinpath("test_key.key"))
 
         result = sign_msg(config, "test")
 
@@ -193,7 +144,7 @@ class TestAuditorApelPlugin:
         assert process.returncode == 4
 
     def test_get_report_time(self):
-        with open(Path.joinpath(test_dir, "test_config.yml"), "r") as f:
+        with open(test_dir.joinpath("test_config.yml")) as f:
             config: Config = yaml.load(f, Loader=get_loaders())
 
         path = "/tmp/test.json"
@@ -208,13 +159,10 @@ class TestAuditorApelPlugin:
         assert result == initial_report_time
 
         new_report_time = datetime(2023, 2, 10, 11, 13, 45)
-        stop_time = datetime(2002, 12, 3, 0, 45, 0, tzinfo=timezone.utc)
 
         update_time_json(
             config,
             time_dict,
-            "TEST-2",
-            stop_time,
             new_report_time,
         )
 
@@ -223,7 +171,7 @@ class TestAuditorApelPlugin:
         assert result == new_report_time
 
     def test_update_time_json(self):
-        with open(Path.joinpath(test_dir, "test_config.yml"), "r") as f:
+        with open(test_dir.joinpath("test_config.yml")) as f:
             config: Config = yaml.load(f, Loader=get_loaders())
 
         path = "/tmp/test.json"
@@ -232,35 +180,25 @@ class TestAuditorApelPlugin:
 
         time_dict = create_time_json(path)
 
-        stop_time_list = [
-            datetime(1984, 3, 3, 0, 0, 0),
-            datetime(2022, 12, 23, 12, 44, 23),
-            datetime(1999, 10, 1, 23, 17, 45),
-        ]
         report_time_list = [
             datetime(1993, 4, 4, 0, 0, 0),
             datetime(2100, 8, 19, 14, 16, 11),
             datetime(1887, 2, 27, 0, 11, 31),
         ]
-        site_list = ["SITE_A", "SITE_B"]
 
-        for stop_time in stop_time_list:
-            for report_time in report_time_list:
-                for site in site_list:
-                    update_time_json(config, time_dict, site, stop_time, report_time)
+        for report_time in report_time_list:
+            update_time_json(config, time_dict, report_time)
 
-                    with open(path, "r", encoding="utf-8") as f:
-                        time_dict_test = json.load(f)
-                        last_end_time = time_dict_test["site_end_times"][site]
-                        last_report_time = time_dict_test["last_report_time"]
+            with open(path, encoding="utf-8") as f:
+                time_dict_test = json.load(f)
+                last_report_time = time_dict_test["last_report_time"]
 
-                    assert last_end_time == stop_time.isoformat()
-                    assert last_report_time == report_time.isoformat()
+            assert last_report_time == report_time.isoformat()
 
         os.remove(path)
 
     def test_update_time_json_fail(self):
-        with open(Path.joinpath(test_dir, "test_config.yml"), "r") as f:
+        with open(test_dir.joinpath("test_config.yml")) as f:
             config: Config = yaml.load(f, Loader=get_loaders())
 
         path = "/tmp/test.json"
@@ -269,9 +207,7 @@ class TestAuditorApelPlugin:
 
         time_dict = create_time_json(path)
 
-        stop_time = datetime(1984, 3, 3, 0, 0, 0)
         report_time = datetime(1993, 4, 4, 0, 0, 0)
-        site = "SITE_A"
 
         os.remove(path)
 
@@ -279,261 +215,12 @@ class TestAuditorApelPlugin:
         config.plugin.time_json_path = path_new
 
         with pytest.raises(Exception) as pytest_error:
-            update_time_json(config, time_dict, site, stop_time, report_time)
+            update_time_json(config, time_dict, report_time)
 
         assert pytest_error.type is FileNotFoundError
 
-    # def test_create_summary_db(self):
-    #     sites_to_report = {
-    #         "TEST_SITE_1": ["test-site-1"],
-    #         "TEST_SITE_2": ["test-site-2"],
-    #     }
-    #     default_submit_host = "https://default.submit_host.de:1234/xxx"
-    #     infrastructure_type = "grid"
-    #     benchmark_name = "hepscore"
-    #     cores_name = "Cores"
-    #     cpu_time_name = "TotalCPU"
-    #     cpu_time_unit = "seconds"
-    #     nnodes_name = "NNodes"
-    #     meta_key_site = "site_id"
-    #     meta_key_submithost = "headnode"
-    #     meta_key_voms = "voms"
-    #     meta_key_username = "subject"
-    #     benchmark_type = "hepscore23"
-
-    #     conf = {}
-    #     conf["site"] = {
-    #         "sites_to_report": sites_to_report,
-    #         "default_submit_host": default_submit_host,
-    #         "infrastructure_type": infrastructure_type,
-    #         "benchmark_type": benchmark_type,
-    #     }
-    #     conf["auditor"] = {
-    #         "benchmark_name": benchmark_name,
-    #         "cores_name": cores_name,
-    #         "cpu_time_name": cpu_time_name,
-    #         "cpu_time_unit": cpu_time_unit,
-    #         "nnodes_name": nnodes_name,
-    #         "meta_key_site": meta_key_site,
-    #         "meta_key_submithost": meta_key_submithost,
-    #         "meta_key_voms": meta_key_voms,
-    #         "meta_key_username": meta_key_username,
-    #     }
-
-    #     runtime = 55
-
-    #     rec_1_values = {
-    #         "rec_id": "test_record_1",
-    #         "start_time": datetime(1984, 3, 3, 0, 0, 0).astimezone(tz=timezone.utc),
-    #         "stop_time": datetime(1985, 3, 3, 0, 0, 0).astimezone(tz=timezone.utc),
-    #         "n_cores": 8,
-    #         "hepscore": 10.0,
-    #         "tot_cpu": 15520000,
-    #         "n_nodes": 1,
-    #         "site": "test-site-1",
-    #         "submit_host": "https:%2F%2Ftest1.submit_host.de:1234%2Fxxx",
-    #         "user_name": "%2FDC=ch%2FDC=cern%2FOU=Users%2FCN=test1: test1",
-    #         "voms": "%2Fatlas%2Fde",
-    #     }
-
-    #     rec_2_values = {
-    #         "rec_id": "test_record_2",
-    #         "start_time": datetime(2023, 1, 1, 14, 24, 11).astimezone(tz=timezone.utc),
-    #         "stop_time": datetime(2023, 1, 2, 7, 11, 45).astimezone(tz=timezone.utc),
-    #         "n_cores": 1,
-    #         "hepscore": 23.0,
-    #         "tot_cpu": 12234325,
-    #         "n_nodes": 2,
-    #         "site": "test-site-2",
-    #         "submit_host": "https:%2F%2Ftest2.submit_host.de:1234%2Fxxx",
-    #         "user_name": "%2FDC=ch%2FDC=cern%2FOU=Users%2FCN=test2: test2",
-    #         "voms": "%2Fatlas%2Fde",
-    #     }
-
-    #     rec_value_list = [rec_1_values, rec_2_values]
-    #     records = []
-
-    #     with patch(
-    #         "pyauditor.Record.runtime", new_callable=PropertyMock
-    #     ) as mocked_runtime:
-    #         mocked_runtime.return_value = runtime
-
-    #         for r_values in rec_value_list:
-    #             rec = create_rec(r_values, conf["auditor"])
-    #             records.append(rec)
-
-    #         result = create_summary_db(conf, records)
-
-    #     cur = result.cursor()
-
-    #     cur.execute("SELECT * FROM records")
-    #     content = cur.fetchall()
-
-    #     cur.close()
-    #     result.close()
-
-    #     for idx, rec_values in enumerate(rec_value_list):
-    #         assert content[idx][0] == list(sites_to_report.keys())[idx]
-    #         assert content[idx][1] == replace_record_string(rec_values["submit_host"])
-    #         assert (
-    #             content[idx][2]
-    #             == replace_record_string(rec_values["voms"]).split("/")[1]
-    #         )
-    #         assert content[idx][3] == replace_record_string(rec_values["voms"])
-    #         assert content[idx][4] is None
-    #         assert content[idx][5] == infrastructure_type
-    #         assert content[idx][6] == rec_values["stop_time"].year
-    #         assert content[idx][7] == rec_values["stop_time"].month
-    #         assert content[idx][8] == rec_values["n_cores"]
-    #         assert content[idx][9] == rec_values["n_nodes"]
-    #         assert content[idx][10] == rec_values["rec_id"]
-    #         assert content[idx][11] == runtime
-    #         assert content[idx][12] == runtime * rec_values["hepscore"]
-    #         assert content[idx][13] == rec_values["tot_cpu"]
-    #         assert content[idx][14] == rec_values["tot_cpu"] * rec_values["hepscore"]
-    #         assert (
-    #             content[idx][15]
-    #             == rec_values["start_time"].replace(tzinfo=timezone.utc).timestamp()
-    #         )
-    #         assert (
-    #             content[idx][16]
-    #             == rec_values["stop_time"].replace(tzinfo=timezone.utc).timestamp()
-    #         )
-    #         assert content[idx][17] == replace_record_string(rec_values["user_name"])
-
-    #     rec_1_values["user_name"] = None
-    #     records = []
-
-    #     with patch(
-    #         "pyauditor.Record.runtime", new_callable=PropertyMock
-    #     ) as mocked_runtime:
-    #         mocked_runtime.return_value = runtime
-
-    #         for r_values in rec_value_list:
-    #             rec = create_rec(r_values, conf["auditor"])
-    #             records.append(rec)
-
-    #         result = create_summary_db(conf, records)
-
-    #     cur = result.cursor()
-
-    #     cur.execute("SELECT * FROM records")
-    #     content = cur.fetchall()
-
-    #     assert content[0][17] is None
-
-    #     cur.close()
-    #     result.close()
-
-    # def test_create_summary_db_fail(self):
-    #     sites_to_report = {
-    #         "TEST_SITE_1": ["test-site-1"],
-    #         "TEST_SITE_2": ["test-site-2"],
-    #     }
-    #     default_submit_host = "https://default.submit_host.de:1234/xxx"
-    #     infrastructure_type = "grid"
-    #     benchmark_name = "hepscore"
-    #     cores_name = "Cores"
-    #     cpu_time_name = "TotalCPU"
-    #     cpu_time_unit = "seconds"
-    #     nnodes_name = "NNodes"
-    #     meta_key_site = "site_id"
-    #     meta_key_submithost = "headnode"
-    #     meta_key_voms = "voms"
-    #     meta_key_username = "subject"
-    #     benchmark_type = "hepscore23"
-
-    #     conf = {}
-    #     conf["site"] = {
-    #         "sites_to_report": sites_to_report,
-    #         "default_submit_host": default_submit_host,
-    #         "infrastructure_type": infrastructure_type,
-    #         "benchmark_type": benchmark_type,
-    #     }
-    #     conf["auditor"] = {
-    #         "benchmark_name": benchmark_name,
-    #         "cores_name": cores_name,
-    #         "cpu_time_name": cpu_time_name,
-    #         "cpu_time_unit": cpu_time_unit,
-    #         "nnodes_name": nnodes_name,
-    #         "meta_key_site": meta_key_site,
-    #         "meta_key_submithost": meta_key_submithost,
-    #         "meta_key_voms": meta_key_voms,
-    #         "meta_key_username": meta_key_username,
-    #     }
-
-    #     runtime = 55
-
-    #     rec_1_values = {
-    #         "rec_id": "test_record_1",
-    #         "start_time": datetime(1984, 3, 3, 0, 0, 0).astimezone(tz=timezone.utc),
-    #         "stop_time": datetime(1985, 3, 3, 0, 0, 0).astimezone(tz=timezone.utc),
-    #         "n_cores": 8,
-    #         "hepscore": 10.0,
-    #         "tot_cpu": 15520000,
-    #         "n_nodes": 1,
-    #         "site": "test-site-1",
-    #         "submit_host": "https:%2F%2Ftest1.submit_host.de:1234%2Fxxx",
-    #         "user_name": "%2FDC=ch%2FDC=cern%2FOU=Users%2FCN=test1: test1",
-    #         "voms": "%2Fatlas%2FRole=production",
-    #     }
-
-    #     rec_2_values = {
-    #         "rec_id": "test_record_2",
-    #         "start_time": datetime(2023, 1, 1, 14, 24, 11).astimezone(tz=timezone.utc),
-    #         "stop_time": datetime(2023, 1, 2, 7, 11, 45).astimezone(tz=timezone.utc),
-    #         "n_cores": 1,
-    #         "hepscore": 23.0,
-    #         "tot_cpu": 12234325,
-    #         "n_nodes": 2,
-    #         "site": "test-site-2",
-    #         "submit_host": "https:%2F%2Ftest2.submit_host.de:1234%2Fxxx",
-    #         "user_name": "%2FDC=ch%2FDC=cern%2FOU=Users%2FCN=test2: test2",
-    #         "voms": "%2Fatlas",
-    #     }
-
-    #     rec_value_list = [rec_1_values, rec_2_values]
-    #     records = []
-
-    #     with patch(
-    #         "pyauditor.Record.runtime", new_callable=PropertyMock
-    #     ) as mocked_runtime:
-    #         mocked_runtime.return_value = runtime
-
-    #         for r_values in rec_value_list:
-    #             rec = create_rec(r_values, conf["auditor"])
-    #             records.append(rec)
-
-    #         conf["auditor"]["cpu_time_name"] = "fail"
-    #         with pytest.raises(Exception) as pytest_error:
-    #             create_summary_db(conf, records)
-    #         assert pytest_error.type is KeyError
-
-    #         conf["auditor"]["cpu_time_name"] = "TotalCPU"
-    #         conf["auditor"]["nnodes_name"] = "fail"
-    #         with pytest.raises(Exception) as pytest_error:
-    #             create_summary_db(conf, records)
-    #         assert pytest_error.type is KeyError
-
-    #         conf["auditor"]["nnodes_name"] = "NNodes"
-    #         conf["auditor"]["cores_name"] = "fail"
-    #         with pytest.raises(Exception) as pytest_error:
-    #             create_summary_db(conf, records)
-    #         assert pytest_error.type is KeyError
-
-    #         conf["auditor"]["cores_name"] = "Cores"
-    #         conf["auditor"]["benchmark_name"] = "fail"
-    #         with pytest.raises(Exception) as pytest_error:
-    #             create_summary_db(conf, records)
-    #         assert pytest_error.type is KeyError
-
-    #         rec_metaless = [create_rec_metaless(rec_1_values, conf["auditor"])]
-    #         with pytest.raises(Exception) as pytest_error:
-    #             create_summary_db(conf, rec_metaless)
-    #         assert pytest_error.type is AttributeError
-
     def test_get_records(self):
-        with open(Path.joinpath(test_dir, "test_config.yml"), "r") as f:
+        with open(test_dir.joinpath("test_config.yml")) as f:
             config: Config = yaml.load(f, Loader=get_loaders())
 
         client = FakeAuditorClient("pass")
@@ -551,7 +238,7 @@ class TestAuditorApelPlugin:
         assert "".join(result) == "good"
 
     def test_get_records_fail(self):
-        with open(Path.joinpath(test_dir, "test_config.yml"), "r") as f:
+        with open(test_dir.joinpath("test_config.yml")) as f:
             config: Config = yaml.load(f, Loader=get_loaders())
 
         sites_to_report = {"TEST_SITE_1": ["test-site-1"]}
@@ -568,41 +255,3 @@ class TestAuditorApelPlugin:
         with pytest.raises(Exception) as pytest_error:
             get_records(config, client, start_time)
         assert pytest_error.type is RuntimeError
-
-    def test_convert_to_seconds(self):
-        cpu_time_name = "TotalCPU"
-        cpu_time_unit = "seconds"
-
-        conf = {}
-        conf["auditor"] = {
-            "cpu_time_name": cpu_time_name,
-            "cpu_time_unit": cpu_time_unit,
-        }
-
-        result = convert_to_seconds(conf, 1100)
-        assert result == 1100
-
-        result = convert_to_seconds(conf, 1500)
-        assert result == 1500
-
-        conf["auditor"]["cpu_time_unit"] = "milliseconds"
-
-        result = convert_to_seconds(conf, 1100)
-        assert result == 1
-
-        result = convert_to_seconds(conf, 1500)
-        assert result == 2
-
-    def test_convert_to_seconds_fail(self):
-        cpu_time_name = "TotalCPU"
-        cpu_time_unit = "hours"
-
-        conf = {}
-        conf["auditor"] = {
-            "cpu_time_name": cpu_time_name,
-            "cpu_time_unit": cpu_time_unit,
-        }
-
-        with pytest.raises(Exception) as pytest_error:
-            convert_to_seconds(conf, 1100)
-        assert pytest_error.type is ValueError

--- a/plugins/apel/tests/test_config.py
+++ b/plugins/apel/tests/test_config.py
@@ -1,5 +1,5 @@
 from datetime import datetime, timezone
-from pathlib import Path, PurePath
+from pathlib import PurePath
 
 import pyauditor
 import pytest
@@ -27,7 +27,7 @@ test_dir = PurePath(__file__).parent
 
 class TestConfig:
     def test_plugin_config(self):
-        with open(Path.joinpath(test_dir, "test_config.yml"), "r") as f:
+        with open(test_dir / "test_config.yml") as f:
             config: Config = yaml.load(f, Loader=get_loaders())
 
         log_file = config.plugin.log_file
@@ -413,7 +413,7 @@ class TestConfig:
 
         assert value == "atlas"
 
-        with open(Path.joinpath(test_dir, "test_config.yml"), "r") as f:
+        with open(test_dir / "test_config.yml") as f:
             config: Config = yaml.load(f, Loader=get_loaders())
 
         value = config.summary_fields.mandatory["VO"].get_value(record)

--- a/plugins/apel/tests/test_utility.py
+++ b/plugins/apel/tests/test_utility.py
@@ -1,5 +1,5 @@
-import pathlib
 import secrets
+from pathlib import Path
 
 import pytest
 
@@ -13,13 +13,14 @@ CONTENT = [
     secrets.token_hex(4096),
     "\n".join([secrets.token_hex(1025) for _ in range(9)]),
 ]
-# Some content is very long and randomized, parametrize over indizes to keep tests manageable
+# Some content is very long and randomized
+# Parametrize over indizes to keep tests manageable
 CONTENT_IDXS = range(len(CONTENT))
 
 
 @pytest.mark.parametrize("initial_idx", CONTENT_IDXS)
 @pytest.mark.parametrize("final_idx", CONTENT_IDXS)
-def test_write_transaction(tmp_path: pathlib.Path, initial_idx: int, final_idx: int):
+def test_write_transaction(tmp_path: Path, initial_idx: int, final_idx: int):
     initial, final = CONTENT[initial_idx], CONTENT[final_idx]
     file_path = tmp_path / "test_file.txt"
     file_path.write_text(initial)
@@ -37,7 +38,7 @@ def test_write_transaction(tmp_path: pathlib.Path, initial_idx: int, final_idx: 
     [KeyError, EOFError, IOError, GeneratorExit, SystemExit],
 )
 def test_write_transaction_failure(
-    tmp_path: pathlib.Path,
+    tmp_path: Path,
     initial_idx: int,
     final_idx: int,
     failure: "type[BaseException]",


### PR DESCRIPTION
This PR does some code cleanup for the APEL plugin. Started with removing the MessageType enum structure, since it's no longer necessary, but spotted some other things and so on, and so on.