### PR TITLE
Prevent archiver from blocking startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - AUDITOR: Fix clippy and cargo deny issues ([@dirksammel](https://github.com/dirksammel))
+- AUDITOR: Prevent the archive service from blocking server startup ([@rkleinem](https://github.com/rkleinem))
 - Archival: Fix validation query logic ([@raghuvar-vijay](https://github.com/raghuvar-vijay))
 - CI/CD: Switch to official ruff git action ([@dirksammel](https://github.com/dirksammel))
 - CI/CD: Catch error when killing processes in tests ([@dirksammel](https://github.com/dirksammel))


### PR DESCRIPTION
During `auditor::startup::run`, we create and start the `ArchiveService`.

This will register a cron job but also runs the archiver once on startup in a dedicated block.
This is not run in a dedicated task, but in the same task that sets up the webserver.

This can block the startup of AUDITOR for hours (if there are many records to delete), keeping it completely unresponsive.
I changed this from a block to a one-shot job, since this will run in a dedicated task.

Also on the subject: Is there a reason why you delete only 10 records at a time? I got a huge speedup by setting that to 1000. (Even higher would probably be better)