### PR TITLE
catch error during process killing in tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - CI/CD: Switch to official ruff git action ([@dirksammel](https://github.com/dirksammel))
+- CI/CD: Catch error when killing processes in tests ([@dirksammel](https://github.com/dirksammel))
 - Dependencies: Update black from 25.9.0 to 25.11.0 ([@dirksammel](https://github.com/dirksammel))
 - Dependencies: Update crate-ci/typos from 1.38.1 to 1.39.1 ([@dirksammel](https://github.com/dirksammel))
 - Dependencies: Update pydantic from 2.12.3 to 2.12.4 ([@dirksammel](https://github.com/dirksammel))

--- a/scripts/test_priority_plugin_prometheus_exporter.sh
+++ b/scripts/test_priority_plugin_prometheus_exporter.sh
@@ -89,8 +89,12 @@ function start_priority_plugin() {
 
 function stop_priority_plugin() {
   echo >&2 "Stopping Priority plugin"
-  kill -2 "$PRIORITY_PLUGIN"
-  wait "$PRIORITY_PLUGIN"
+  if kill -0 "$PRIORITY_PLUGIN" 2>/dev/null; then
+      kill -2 "$PRIORITY_PLUGIN"
+      wait "$PRIORITY_PLUGIN"
+  else
+      echo >&2 "Process $PRIORITY_PLUGIN does not exist. Nothing to stop."
+  fi
 }
 
 function test_priority_plugin_prometheus_exporter() {


### PR DESCRIPTION
This PR catches an error that often happens in the workflows when a process can't be killed.