### PR TITLE
re-enable PyPI publishing

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -96,14 +96,14 @@ jobs:
     with:
       python-version: ${{ needs.prepare-input-parameters.outputs.python_version }}
 
-  # release-pyauditor:
-  #   if: "startsWith(github.ref, 'refs/tags/')"
-  #   needs: [build-pyauditor-source, test-pyauditor-source, pyauditor-integration-tests, build-pyauditor-linux, build-pyauditor-windows, build-pyauditor-macos, prepare-input-parameters]
-  #   uses: ./.github/workflows/release_pyauditor.yml
-  #   with:
-  #     python-version: ${{ needs.prepare-input-parameters.outputs.python_version }}
+  release-pyauditor:
+    if: "startsWith(github.ref, 'refs/tags/')"
+    needs: [build-pyauditor-source, test-pyauditor-source, pyauditor-integration-tests, build-pyauditor-linux, build-pyauditor-windows, build-pyauditor-macos, prepare-input-parameters]
+    uses: ./.github/workflows/release_pyauditor.yml
+    with:
+      python-version: ${{ needs.prepare-input-parameters.outputs.python_version }}
 
   release-python-packages:
     if: "startsWith(github.ref, 'refs/tags/')"
-    # needs: release-pyauditor
+    needs: release-pyauditor
     uses: ./.github/workflows/release_python_packages.yml

--- a/.github/workflows/release_python_packages.yml
+++ b/.github/workflows/release_python_packages.yml
@@ -38,11 +38,11 @@ jobs:
         with:
           path: ./plugins/apel/dist
           name: apel-plugin-release
-      # - name: Publish to PyPI
-      #   uses: pypa/gh-action-pypi-publish@release/v1
-      #   with:
-      #     packages-dir: plugins/apel/dist/
-      #     attestations: false
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: plugins/apel/dist/
+          attestations: false
       - name: Publish to GitHub
         uses: softprops/action-gh-release@v3
         with:
@@ -112,11 +112,11 @@ jobs:
         with:
           path: ./collectors/htcondor/dist
           name: htcondor-collector-release
-      # - name: Publish to PyPI
-      #   uses: pypa/gh-action-pypi-publish@release/v1
-      #   with:
-      #     packages-dir: collectors/htcondor/dist/
-      #     attestations: false
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: collectors/htcondor/dist/
+          attestations: false
       - name: Publish to GitHub
         uses: softprops/action-gh-release@v3
         with:
@@ -186,11 +186,11 @@ jobs:
         with:
           path: ./plugins/utilization_tool/dist
           name: utilization-plugin-release
-      # - name: Publish to PyPI
-      #   uses: pypa/gh-action-pypi-publish@release/v1
-      #   with:
-      #     packages-dir: plugins/utilization_tool/dist/
-      #     attestations: false
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: plugins/utilization_tool/dist/
+          attestations: false
       - name: Publish to GitHub
         uses: softprops/action-gh-release@v3
         with:


### PR DESCRIPTION
This PR re-enables publishing to PyPI. Was disabled due to some problems with the last release.