### PR TITLE
[HTCondor Collector] Fix stop_time derivation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - AUDITOR-Client: Add linebreak to concatenate client cert and client key ([@raghuvar-vijay](https://github.com/raghuvar-vijay))
 - Certs: Update tls integration test certs ([@raghuvar-vijay](https://github.com/raghuvar-vijay))
+- HTCondor collector: Fix a bug for detection stop time of some cancelled jobs ([@maxfischer2781](https://github.com/maxfischer2781))
 - Dependencies: Update actix-http from 3.12.0 to 3.12.1 ([@dirksammel](https://github.com/dirksammel))
 - Dependencies: Update ad-m/github-push-action from 1.0.0 to 1.1.0 ([@dirksammel](https://github.com/dirksammel))
 - Dependencies: Update build from 1.4.0 to 1.4.4 ([@dirksammel](https://github.com/dirksammel))

--- a/collectors/htcondor/src/auditor_htcondor_collector/collector.py
+++ b/collectors/htcondor/src/auditor_htcondor_collector/collector.py
@@ -277,7 +277,7 @@ class CondorHistoryCollector(object):
 
         # Get the stop time of the job
         stop_time = None
-        for key in ["CompletionDate", "EnteredCurrentStatus"]:
+        for key in ["CompletionDate", "EpochWriteDate", "EnteredCurrentStatus"]:
             if key in job and job[key] not in ("undefined", 0):
                 stop_time = job[key]
                 break

--- a/collectors/htcondor/src/auditor_htcondor_collector/collector.py
+++ b/collectors/htcondor/src/auditor_htcondor_collector/collector.py
@@ -278,7 +278,7 @@ class CondorHistoryCollector(object):
         # Get the stop time of the job
         stop_time = None
         for key in ["CompletionDate", "EnteredCurrentStatus"]:
-            if key in job and job[key] != "undefined":
+            if key in job and job[key] not in ("undefined", 0):
                 stop_time = job[key]
                 break
         if stop_time is None:

--- a/collectors/htcondor/src/auditor_htcondor_collector/config.py
+++ b/collectors/htcondor/src/auditor_htcondor_collector/config.py
@@ -37,6 +37,7 @@ class Config(object):
                 "LastMatchTime",
                 "EnteredCurrentStatus",
                 "CompletionDate",
+                "EpochWriteDate",
             )
         ),
     }


### PR DESCRIPTION
This MR adjusts the handling of job attributes to determine the job `stop_time`.

- Reject any time-like attribute with the default value `0` of the epoch itself. See also #1310.
- Try the `EpochWriteDate` attribute. This isn't *strictly* needed yet, as it applies only for the currently unused `condor_history … -epochs` switch. Since this a) is cheap compared to everything else, b) seems feasible in the future and c) this PR is needed because the connection between history query and parsing wasn't made last time either… better do it now.

Closes #1755.