### PR TITLE
using JSON internally to avoid comma as separator

### DIFF
--- a/collectors/htcondor/src/auditor_htcondor_collector/collector.py
+++ b/collectors/htcondor/src/auditor_htcondor_collector/collector.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python3
 
+import json
 import logging
+import re
 from asyncio import create_subprocess_exec, create_subprocess_shell
 from asyncio.subprocess import PIPE
 from datetime import datetime as dt
@@ -19,7 +21,23 @@ from pyauditor import (
 from .config import Config
 from .exceptions import RecordGenerationException
 from .state_db import StateDB
-from .utils import get_value, maybe_convert
+from .utils import get_value
+
+# A bare ClassAd attribute name (used to tell attribute keys from expressions).
+_BARE_ATTR_RE = re.compile(r"\A[A-Za-z_][A-Za-z0-9_]*\Z")
+# Any attribute name occurring inside an expression.
+_ATTR_RE = re.compile(r"[A-Za-z_][A-Za-z0-9_]*")
+# A sum/difference of attributes and numeric literals, e.g. "A+B-3".
+_SUM_EXPR_RE = re.compile(r"\A[A-Za-z0-9_.]+(?:[+-][A-Za-z0-9_.]+)*\Z")
+
+
+def _is_valid_job_id(job_id) -> bool:
+    """True iff `job_id` is a (cluster, proc) pair of plain ints (not bools)."""
+    return (
+        isinstance(job_id, tuple)
+        and len(job_id) == 2
+        and all(isinstance(v, int) and not isinstance(v, bool) for v in job_id)
+    )
 
 
 class CondorHistoryCollector(object):
@@ -117,7 +135,9 @@ class CondorHistoryCollector(object):
             except RecordGenerationException as e:
                 failed += 1
                 self.logger.debug(e.args[0])
-            self.set_last_job(schedd_name, (job["ClusterId"], job["ProcId"]))
+            self.set_last_job(
+                schedd_name, (job.get("ClusterId"), job.get("ProcId"))
+            )
         self.logger.info(
             f"Added {added} records."
             f"{f' Failed to generate {failed} records.' if failed else ''}"
@@ -132,10 +152,28 @@ class CondorHistoryCollector(object):
                 f"prefix {self.config.record_prefix!r}. Starting from timestamp."
             )
             return None
+        if not _is_valid_job_id(job):
+            # A previously stored checkpoint may be corrupt (e.g. written by an
+            # older version that mis-parsed `condor_history` output). Do not let
+            # it crash the collector; ignore it and resume from the timestamp.
+            self.logger.warning(
+                f"Stored checkpoint {job!r} for schedd {schedd_name!r} and record "
+                f"prefix {self.config.record_prefix!r} is not a valid (int, int) "
+                f"job id. Ignoring it and starting from timestamp."
+            )
+            return None
         return job
 
     def set_last_job(self, schedd_name: str, job_id: Tuple[int, int]):
         """Sets the last job id that was processed for a given schedd and prefix."""
+        if not _is_valid_job_id(job_id):
+            # Never persist a non-integer job id: that would crash the next run
+            # on read. Leave the previous checkpoint in place instead.
+            self.logger.warning(
+                f"Refusing to store invalid job id {job_id!r} for schedd "
+                f"{schedd_name!r}; keeping the previous checkpoint."
+            )
+            return
         self.state_db.set(schedd_name, self.config.record_prefix, *job_id)
         self.logger.debug(f"Set last job id to {job_id} for schedd {schedd_name!r}.")
 
@@ -143,9 +181,13 @@ class CondorHistoryCollector(object):
         self, schedd_name: str, job: Optional[Tuple[int, int]]
     ) -> List[dict]:
         """Queries HTCondor history for jobs with a given schedd name and job id."""
-        if job is not None:
-            assert type(job) is tuple and len(job) == 2, "Invalid job id"
-            assert isinstance(job[0], int) and isinstance(job[1], int), "Invalid job id"
+        if job is not None and not _is_valid_job_id(job):
+            # Be defensive rather than fatal: a malformed job id must not abort
+            # the whole collector run. Fall back to the timestamp-based query.
+            self.logger.warning(
+                f"Ignoring invalid job id {job!r}; starting from timestamp."
+            )
+            job = None
 
         def escape(arg: str) -> str:
             """Escape a CLI argument to avoid interpretation for the chosen execution type"""
@@ -178,8 +220,9 @@ class CondorHistoryCollector(object):
             schedd_name,
             "-since",
             escape(since),
-            "-af:,",
-            *self.config.class_ads,
+            "-json",
+            "-attributes",
+            escape(",".join(self._projection_attributes())),
         ]
         if self.config.get("pool"):
             cmd.extend(["-pool", self.config.pool])
@@ -204,12 +247,99 @@ class CondorHistoryCollector(object):
         if err:
             self.logger.error(f"Error querying HTCondor history:\n{err}")
 
-        jobs = [
-            map(maybe_convert, map(str.strip, job.decode("utf-8").split(",")))
-            for job in output.strip().splitlines()
-        ]
+        return self._parse_history(output)
 
-        return [dict(zip(self.config.class_ads, job)) for job in jobs]
+    def _projection_attributes(self) -> List[str]:
+        """Plain ClassAd attribute names to request from `condor_history`.
+
+        `condor_history` only projects attribute *names* (not expressions) in
+        `-json` mode, so for expression keys such as
+        ``RemoteUserCpu+RemoteSysCpu`` the referenced attribute names are
+        requested and the expression is evaluated locally (see
+        `_eval_expression`).
+        """
+        attrs: "dict[str, None]" = {}
+        for class_ad in self.config.class_ads:
+            if _BARE_ATTR_RE.match(class_ad):
+                attrs[class_ad] = None
+            else:
+                for name in _ATTR_RE.findall(class_ad):
+                    attrs[name] = None
+        return list(attrs)
+
+    def _parse_history(self, output: bytes) -> List[dict]:
+        """Parse `condor_history -json` output into a list of job dicts.
+
+        Parsing structured JSON instead of comma-separated autoformat avoids
+        column misalignment when a ClassAd value contains a comma (e.g. an
+        X.509 subject with ``O=Fermi Forward Discovery Group, LLC``). JSON also
+        yields correctly typed values, so ``ClusterId``/``ProcId`` are real
+        ints. Undefined/null attributes are dropped so downstream lookups see
+        them as missing, and expression keys are evaluated locally.
+        """
+        text = output.decode("utf-8").strip()
+        if not text:
+            return []
+        try:
+            ads = json.loads(text)
+        except json.JSONDecodeError:
+            # Tolerate JSON-lines output (`-jsonl`): one JSON object per line.
+            ads = []
+            for line in text.splitlines():
+                line = line.strip().rstrip(",")
+                if not line or line in ("[", "]"):
+                    continue
+                try:
+                    ads.append(json.loads(line))
+                except json.JSONDecodeError as e:
+                    self.logger.warning(f"Skipping unparseable history line: {e}")
+
+        jobs = []
+        for ad in ads:
+            job = {
+                key: value
+                for key, value in ad.items()
+                if value is not None and value != "undefined"
+            }
+            self._add_expression_values(job)
+            jobs.append(job)
+        return jobs
+
+    def _add_expression_values(self, job: dict) -> None:
+        """Populate expression-valued class_ads (e.g. CPU-time sums) in-place."""
+        for class_ad in self.config.class_ads:
+            if class_ad in job or _BARE_ATTR_RE.match(class_ad):
+                continue
+            value = self._eval_expression(class_ad, job)
+            if value is not None:
+                job[class_ad] = value
+
+    def _eval_expression(self, expr: str, job: dict):
+        """Safely evaluate a sum/difference of attributes and numeric literals.
+
+        Supports the documented case of combining CPU times, e.g.
+        ``RemoteUserCpu+RemoteSysCpu``. Anything beyond ``+``/``-`` of
+        attributes or numbers is not evaluated and returns ``None``.
+        """
+        compact = expr.replace(" ", "")
+        if not _SUM_EXPR_RE.match(compact):
+            self.logger.warning(
+                f"Unsupported expression class_ad {expr!r}; only sums/differences "
+                f"of attributes and numbers are evaluated. Skipping."
+            )
+            return None
+        total = 0.0
+        for term in re.findall(r"[+-]?[A-Za-z0-9_.]+", compact):
+            sign = -1.0 if term[0] == "-" else 1.0
+            name = term.lstrip("+-")
+            if re.fullmatch(r"\d+(?:\.\d+)?", name):
+                total += sign * float(name)
+            else:
+                value = job.get(name)
+                if not isinstance(value, (int, float)) or isinstance(value, bool):
+                    return None
+                total += sign * float(value)
+        return int(total) if total.is_integer() else total
 
     def _generate_components(self, job: dict) -> List[Component]:
         components = []

--- a/collectors/htcondor/src/auditor_htcondor_collector/config.py
+++ b/collectors/htcondor/src/auditor_htcondor_collector/config.py
@@ -29,16 +29,14 @@ class Config(object):
         "history_file": None,
         "earliest_datetime": date.today().isoformat(),
         "query_type": "shell",
-        "class_ads": frozenset(
-            (
-                "GlobalJobId",
-                "ClusterId",
-                "ProcId",
-                "LastMatchTime",
-                "EnteredCurrentStatus",
-                "CompletionDate",
-                "EpochWriteDate",
-            )
+        "class_ads": (
+            "GlobalJobId",
+            "ClusterId",
+            "ProcId",
+            "LastMatchTime",
+            "EnteredCurrentStatus",
+            "CompletionDate",
+            "EpochWriteDate",
         ),
     }
 
@@ -51,10 +49,19 @@ class Config(object):
         self._config.update(file_config)
         self._config.update({k: v for k, v in args.__dict__.items() if v is not None})
 
-        self._config["class_ads"] = self._config["class_ads"].union(
-            extract_values("key", file_config["components"]),
-            extract_values("key", file_config["meta"]),
-        )
+        # Extend the (ordered) class_ads with the attribute keys referenced by
+        # the components and meta sections, preserving order and de-duplicating.
+        # A dict is used as an order-preserving set so the resulting attribute
+        # set is deterministic (independent of PYTHONHASHSEED), which keeps the
+        # `condor_history` projection stable across runs and hosts.
+        ordered: "dict[str, None]" = {}
+        for attr in (
+            *self._config["class_ads"],
+            *extract_values("key", file_config["components"]),
+            *extract_values("key", file_config["meta"]),
+        ):
+            ordered[attr] = None
+        self._config["class_ads"] = tuple(ordered)
         self._verify()
         self._config["condor_timestamp"] = int(
             dt.fromisoformat(self.earliest_datetime).timestamp()

--- a/collectors/htcondor/src/auditor_htcondor_collector/utils.py
+++ b/collectors/htcondor/src/auditor_htcondor_collector/utils.py
@@ -87,7 +87,7 @@ def get_value(config_entry: T_Config, job: dict):
 
     if "matches" in config_entry:
         pattern = re.compile(config_entry["matches"])
-        match = pattern.search(val)
+        match = pattern.search(str(val))
         if match:
             if pattern.groups > 0:
                 val = match.group(1)
@@ -97,8 +97,14 @@ def get_value(config_entry: T_Config, job: dict):
             return None
 
     if "only_if" in config_entry:
+        only_if_key = config_entry["only_if"]["key"]
+        if only_if_key not in job:
+            # The condition attribute is undefined for this job (and therefore
+            # absent from the parsed ad), so the condition cannot match.
+            return None
         cond = re.search(
-            config_entry["only_if"]["matches"], job[config_entry["only_if"]["key"]]
+            config_entry["only_if"]["matches"],
+            str(job[only_if_key]),
         )
         return val if cond else None
     else:

--- a/collectors/htcondor/tests/test_json_parsing.py
+++ b/collectors/htcondor/tests/test_json_parsing.py
@@ -1,0 +1,217 @@
+"""Tests for the JSON-based `condor_history` parsing and checkpoint handling.
+
+These tests cover the fix for the comma-delimited autoformat parsing bug:
+a ClassAd value containing a comma (e.g. an X.509 subject with
+``O=Fermi Forward Discovery Group, LLC``) must no longer shift columns and
+corrupt ``ProcId``/the stored checkpoint.
+
+`pyauditor` is a compiled dependency that is not needed for the parsing logic,
+so it is stubbed out before importing the collector module.
+"""
+
+import json
+import sys
+import types
+from argparse import Namespace
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Stub out pyauditor so collector.py can be imported without the compiled dep.
+# ---------------------------------------------------------------------------
+_pyauditor = types.ModuleType("pyauditor")
+for _name in (
+    "AuditorClient",
+    "AuditorClientBuilder",
+    "Component",
+    "Meta",
+    "Record",
+    "Score",
+):
+    setattr(_pyauditor, _name, type(_name, (), {}))
+sys.modules.setdefault("pyauditor", _pyauditor)
+
+from auditor_htcondor_collector.collector import (  # noqa: E402
+    CondorHistoryCollector,
+    _is_valid_job_id,
+)
+from auditor_htcondor_collector.config import Config  # noqa: E402
+
+# A real subject DN that nonetheless contains a literal comma in the O= value.
+FERMI_DN = (
+    "/DC=org/DC=incommon/C=US/ST=Illinois/"
+    "O=Fermi Forward Discovery Group, LLC/CN=pilot-cmssrv2426.fnal.gov"
+)
+
+CONFIG_YAML = f"""
+state_db: "{{state_db}}"
+record_prefix: htcondor-test
+schedd_names:
+  - schedd@test
+meta:
+  user:
+    key: Owner
+  subject:
+    key: x509UserProxySubject
+  voms:
+    key: x509UserProxyFirstFQAN
+  site:
+    - name: "TEST-SITE"
+components:
+  - name: "Cores"
+    key: "CpusProvisioned"
+  - name: "CPUTime"
+    key: "RemoteUserCpu+RemoteSysCpu"   # expression key (DESY style)
+tls_config:
+  use_tls: False
+"""
+
+
+@pytest.fixture
+def collector(tmp_path):
+    cfg_file = tmp_path / "config.yaml"
+    cfg_file.write_text(CONFIG_YAML.format(state_db=str(tmp_path / "state.db")))
+    config = Config(Namespace(config=str(cfg_file)))
+    # Bypass __init__ (which builds the auditor client); we only need parsing.
+    c = CondorHistoryCollector.__new__(CondorHistoryCollector)
+    c.config = config
+    import logging
+
+    c.logger = logging.getLogger("test")
+    return c
+
+
+def _hist_json(*ads):
+    """Render ads as `condor_history -json` would (a JSON array)."""
+    return json.dumps(list(ads)).encode("utf-8")
+
+
+def test_comma_in_subject_does_not_shift_columns(collector):
+    ad = {
+        "GlobalJobId": "ce05#20096.0#1700000000",
+        "ClusterId": 20096,
+        "ProcId": 0,
+        "Owner": "cms001",
+        "x509UserProxySubject": FERMI_DN,
+        "x509UserProxyFirstFQAN": "/cms/Role=pilot/Capability=NULL",
+        "CpusProvisioned": 1,
+        "RemoteUserCpu": 100,
+        "RemoteSysCpu": 23,
+    }
+    jobs = collector._parse_history(_hist_json(ad))
+    assert len(jobs) == 1
+    job = jobs[0]
+    # The whole point: ProcId stays an int, and the comma-bearing DN is intact.
+    assert job["ClusterId"] == 20096 and isinstance(job["ClusterId"], int)
+    assert job["ProcId"] == 0 and isinstance(job["ProcId"], int)
+    assert job["x509UserProxySubject"] == FERMI_DN
+    assert job["x509UserProxyFirstFQAN"] == "/cms/Role=pilot/Capability=NULL"
+
+
+def test_expression_key_is_evaluated(collector):
+    ad = {
+        "GlobalJobId": "ce05#1.0#1",
+        "ClusterId": 1,
+        "ProcId": 0,
+        "RemoteUserCpu": 100,
+        "RemoteSysCpu": 23,
+    }
+    job = collector._parse_history(_hist_json(ad))[0]
+    assert job["RemoteUserCpu+RemoteSysCpu"] == 123
+
+
+def test_undefined_attributes_are_dropped(collector):
+    ad = {
+        "GlobalJobId": "ce05#2.0#2",
+        "ClusterId": 2,
+        "ProcId": 0,
+        "Owner": "undefined",
+        "x509UserProxySubject": None,
+    }
+    job = collector._parse_history(_hist_json(ad))[0]
+    assert "Owner" not in job
+    assert "x509UserProxySubject" not in job
+
+
+def test_jsonl_output_is_tolerated(collector):
+    ad1 = {"GlobalJobId": "a#1.0#1", "ClusterId": 1, "ProcId": 0}
+    ad2 = {"GlobalJobId": "b#2.0#2", "ClusterId": 2, "ProcId": 1}
+    jsonl = (json.dumps(ad1) + "\n" + json.dumps(ad2)).encode("utf-8")
+    jobs = collector._parse_history(jsonl)
+    assert [j["ClusterId"] for j in jobs] == [1, 2]
+
+
+def test_empty_output(collector):
+    assert collector._parse_history(b"") == []
+    assert collector._parse_history(b"  \n ") == []
+
+
+def test_projection_expands_expressions_to_atoms(collector):
+    proj = collector._projection_attributes()
+    # bare keys present
+    assert "CpusProvisioned" in proj and "Owner" in proj
+    # expression atoms present, expression string itself absent
+    assert "RemoteUserCpu" in proj and "RemoteSysCpu" in proj
+    assert "RemoteUserCpu+RemoteSysCpu" not in proj
+    # no duplicates, deterministic order (it is a list built from an ordered set)
+    assert len(proj) == len(set(proj))
+
+
+def test_is_valid_job_id():
+    assert _is_valid_job_id((20096, 0))
+    assert not _is_valid_job_id((20096, "/cms/Role=pilot/Capability=NULL"))
+    assert not _is_valid_job_id((10800002, 14.5089285714286))
+    assert not _is_valid_job_id((1,))
+    assert not _is_valid_job_id(None)
+    assert not _is_valid_job_id((True, 0))  # bools are not valid ids
+
+
+class _FakeStateDB:
+    def __init__(self, value):
+        self._value = value
+        self.set_calls = []
+
+    def get(self, schedd, prefix):
+        return self._value
+
+    def set(self, schedd, prefix, cluster, proc):
+        self.set_calls.append((cluster, proc))
+
+
+def test_get_last_job_ignores_corrupt_checkpoint(collector):
+    # Mirrors the production ce05 corruption: proc holds a string.
+    collector.state_db = _FakeStateDB((20096, "/cms/Role=pilot/Capability=NULL"))
+    assert collector.get_last_job("schedd@test") is None  # self-heals -> timestamp
+
+
+def test_get_last_job_returns_valid_checkpoint(collector):
+    collector.state_db = _FakeStateDB((20096, 0))
+    assert collector.get_last_job("schedd@test") == (20096, 0)
+
+
+def test_set_last_job_refuses_non_integer(collector):
+    db = _FakeStateDB(None)
+    collector.state_db = db
+    collector.set_last_job("schedd@test", (10800002, 14.5089285714286))
+    assert db.set_calls == []  # nothing persisted
+
+
+def test_set_last_job_stores_valid(collector):
+    db = _FakeStateDB(None)
+    collector.state_db = db
+    collector.set_last_job("schedd@test", (123, 4))
+    assert db.set_calls == [(123, 4)]
+
+
+def test_get_value_only_if_missing_key_returns_none():
+    """only_if must not KeyError when its key is undefined (absent from the ad)."""
+    from auditor_htcondor_collector.utils import get_value
+
+    entry = {
+        "name": "HEPSPEC",
+        "key": "MachineAttrApelSpecs0",
+        "matches": r"HEPSPEC\D+(\d+(\.\d+)?)",
+        "only_if": {"key": "LastRemoteHost", "matches": r"^slot.+@execute$"},
+    }
+    job = {"MachineAttrApelSpecs0": "HEPSPEC 123"}  # LastRemoteHost absent
+    assert get_value(entry, job) is None


### PR DESCRIPTION
# Fix: parse `condor_history` JSON instead of comma-separated autoformat (comma-safe), and make the state checkpoint robust

## Problem

The HTCondor collector queries `condor_history` with a comma separator
(`-af:,`) and parses the result with `str.split(",")`, re-pairing fields
against `class_ads` positionally. Any ClassAd value containing a comma shifts
every following column, so the wrong field is assigned to each attribute.

The most common trigger is a comma **inside an RDN value** of
`x509UserProxySubject`, e.g. InCommon/Fermilab CMS pilot certificates:

```
/DC=org/DC=incommon/C=US/ST=Illinois/O=Fermi Forward Discovery Group, LLC/CN=pilot-cmssrv2426.fnal.gov
```

Consequences:
1. **Silent record corruption / loss** — affected jobs get mis-mapped fields and
   are usually dropped (`RecordGenerationException`), so they go unaccounted.
2. **Crash-loop** — the shifted `ProcId`/`ClusterId` is persisted to the state
   DB unvalidated; the next run aborts on
   `assert isinstance(job[0], int) and isinstance(job[1], int)` →
   `AssertionError: Invalid job id`, and (under systemd `Restart=always`) the
   collector fails forever until the state DB is hand-edited.

Because `class_ads` is a `frozenset`, the column→attribute order is
hash-seeded, so the same misalignment corrupts a different attribute on each
host.

## Fix

**1. Parse structured JSON instead of comma-separated autoformat.**
`query_htcondor_history` now runs `condor_history … -json -attributes <names>`
and parses the result with `json.loads`. A comma inside a value is now safely
contained in a JSON string, and values arrive correctly typed (so `ClusterId`/
`ProcId` are real ints). JSON-Lines (`-jsonl`) output is also tolerated.
(`-json`, `-jsonl` and `-attributes` are available on HTCondor 9.0+.)

**2. Keep expression keys working without server-side eval.**
`condor_history` JSON modes project attribute *names*, not expressions, so
expression keys such as `RemoteUserCpu+RemoteSysCpu` (documented for combining
CPU times) are resolved locally: the referenced attribute names are added to
the projection, and the value is computed by a small, safe evaluator that
supports only `+`/`-` of attributes and numeric literals (no `eval`). Anything
more complex is skipped with a warning.

**3. Deterministic attribute set.**
`class_ads` becomes an ordered, de-duplicated tuple instead of a `frozenset`,
so the projection is stable across runs and hosts (independent of
`PYTHONHASHSEED`).

**4. Never persist a bad checkpoint; never crash on one.**
- `set_last_job` refuses to store a non-`(int, int)` job id (warns, keeps the
  previous checkpoint).
- `get_last_job` validates the stored checkpoint and, if it is corrupt, ignores
  it and resumes from the timestamp — so existing corrupted state DBs
  self-heal on the next run with no manual sqlite surgery.
- The fatal `assert` in `query_htcondor_history` is downgraded to a non-fatal
  fallback.

**5. Minor robustness.**
`utils.get_value` now applies `matches`/`only_if` regexes to `str(value)`, since
JSON yields real ints/floats where autoformat previously yielded strings.

## Behaviour preserved

- Undefined attributes (previously the string `"undefined"`) are now absent from
  the JSON ad; all existing `key in job` / `== "undefined"` checks already treat
  that as missing, so meta/component resolution is unchanged.
- `set_last_job` is still called for every job (including failed records).
- `query_type` (`shell`/`exec`), constraints, `-pool`, `-file`, `-since` and
  reverse iteration are unchanged.

## Tests

`tests/test_json_parsing.py` (new) covers:
- a comma-bearing Fermilab subject DN no longer shifts `ProcId` (the core bug);
- expression key `RemoteUserCpu+RemoteSysCpu` is evaluated;
- undefined/null attributes are dropped; `-jsonl` and empty output are handled;
- projection expands expressions to atoms and de-duplicates;
- `get_last_job` self-heals from a corrupt checkpoint; `set_last_job` refuses to
  persist a non-integer id; valid ids round-trip.

## Notes / possible follow-ups

- `utils.maybe_convert` is now unused by the collector but left in place (public
  helper); can be removed separately if desired.
- Minimum supported HTCondor for the collector should be documented as ≥ 9.0
  given `-json`/`-attributes`.
- Projection keeps output lean; alternatively `-jsonl` without `-attributes`
  (full ads) would remove the projection step at the cost of larger output.
- refactoring towards using Python bindings might be feasible with reasonable effort
