### PR TITLE
add runtime > 0 to query in APEL plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Slurm collector: Migration script to change milli-sec to sec for TotalCPU field ([@raghuvar-vijay](https://github.com/raghuvar-vijay))
 
 ### Changed
+- Apel plugin: Add runtime greater than zero to query ([@dirksammel](https://github.com/dirksammel))
 - AUDITOR: Stop archival if the file already exists ([@raghuvar-vijay](https://github.com/raghuvar-vijay))
 - AUDITOR: Fix terminate query using `true` instead of `runtime is not null` ([@raghuvar-vijay](https://github.com/raghuvar-vijay))
 - AUDITOR-Client: Add linebreak to concatenate client cert and client key ([@raghuvar-vijay](https://github.com/raghuvar-vijay))

--- a/plugins/apel/src/auditor_apel_plugin/core.py
+++ b/plugins/apel/src/auditor_apel_plugin/core.py
@@ -50,9 +50,12 @@ def get_records(config: Config, client, start_time, site=None, end_time=None):
     records = []
 
     try:
+        runtime_value = Value.set_runtime(0)
+        runtime_operator = Operator().gt(runtime_value)
+        runtime_query = QueryBuilder().with_runtime(runtime_operator)
         start_time_value = Value.set_datetime(start_time)
         get_since_operator = Operator().gte(start_time_value)
-        stop_time_query = QueryBuilder().with_stop_time(get_since_operator)
+        stop_time_query = runtime_query.with_stop_time(get_since_operator)
         if end_time is not None:
             end_time_value = Value.set_datetime(end_time)
             get_range_operator = get_since_operator.lt(end_time_value)


### PR DESCRIPTION
Since there can be records in the AUDITOR database without stop_time and therefore without runtime, this PR solves this case by adding runtime>0 to the query.