### PR TITLE
add default value 1 for NodeCount

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Changed
+- Apel plugin: Add default value of 1 for NodeCount ([@dirksammel](https://github.com/dirksammel))
 - Dependencies: Update actions/setup-python from 6 to 7 ([@dirksammel](https://github.com/dirksammel))
 - Dependencies: Update cryptography from 49.0.0 to 50.0.0 ([@dirksammel](https://github.com/dirksammel))
 - Dependencies: Update ruff from 0.15.21 to 0.15.22 ([@dirksammel](https://github.com/dirksammel))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - slurm, slurm-epilog, kubernetes collector: Add collector version info to meta col for every record ([@raghuvar-vijay](https://github.com/raghuvar-vijay))
 
 ### Changed
+- Apel plugin: Add default value of 1 for NodeCount ([@dirksammel](https://github.com/dirksammel))
 - Dependencies: Update actions/setup-python from 6 to 7 ([@dirksammel](https://github.com/dirksammel))
 - Dependencies: Update actix-web from 4.14.0 to 4.15.0 ([@raghuvar-vijay](https://github.com/raghuvar-vijay))
 - Dependencies: Update anyhow from 1.0.103 to 1.0.104 ([@raghuvar-vijay](https://github.com/raghuvar-vijay))

--- a/media/website/content/_index.md
+++ b/media/website/content/_index.md
@@ -1122,6 +1122,8 @@ summary_fields:
       regex: (?<=/).*?(?=/|$)
     Processors: !ComponentField
       name: Cores
+    NodeCount: !ComponentField
+      name: NNodes
     SubmitHost: !MetaField
       name: headnode
     NormalisedWallDuration: !NormalisedField
@@ -1148,8 +1150,6 @@ summary_fields:
       regex: '(?=Role).*?(?=/|$)'
     Infrastructure: !ConstantField
       value: grid
-    NodeCount: !ComponentField
-      name: NNodes
 ```
 
 The individual parameters in the config file are:
@@ -1183,14 +1183,17 @@ The section `summary_fields` has the subsections `mandatory` and `optional`. `ma
 
 | Name                     | Data type |
 |:-------------------------|:---------:|
-| `CpuDuration`            | `int`     |
-| `NormalisedCpuDuration`  | `int`     |
-| `NormalisedWallDuration` | `int`     |
-| `VO`                     | `str`     |
-| `SubmitHost`             | `str`     |
-| `Processors`             | `int`     |
+| `CpuDuration`            |   `int`   |
+| `NormalisedCpuDuration`  |   `int`   |
+| `NormalisedWallDuration` |   `int`   |
+| `VO`                     |   `str`   |
+| `SubmitHost`             |   `str`   |
+| `Processors`             |   `int`   |
+| `NodeCount`              |   `int`   |
 
-`CpuDuration` and `NormalisedCpuDuration` have to contain the sum of user- and system CPU time, and the sum of all cores that were running (e.g. `RemoteSysCpu + RemoteUserCpu` for HTCondor). `NormalisedWallDuration` has to contain the time the job was actually running, i.e. **not** multiplied by the number of cores (this is done later in the APEL pipeline). 
+`CpuDuration` and `NormalisedCpuDuration` have to contain the sum of user- and system CPU time, and the sum of all cores that were running (e.g. `RemoteSysCpu + RemoteUserCpu` for HTCondor). `NormalisedWallDuration` has to contain the time the job was actually running, i.e. **not** multiplied by the number of cores (this is done later in the APEL pipeline).
+
+If `NodeCount` is not present in the config, a default value of 1 is assumed.
 
 There are actually more mandatory fields, but they are handled internally and don't need any input from the user.
 
@@ -1202,9 +1205,8 @@ There are actually more mandatory fields, but they are handled internally and do
 | `VOGroup`        | `str`     |
 | `VORole`         | `str`     |
 | `Infrastructure` | `str`     |
-| `NodeCount`      | `int`     |
 
-Except for `NodeCount`, none of the `optional` information appears on the [EGI Accounting Portal](https://accounting.egi.eu/), so it is possible that this information is not used at all.
+Except for `Infrastructure`, none of the `optional` information appears on the [EGI Accounting Portal](https://accounting.egi.eu/), so it is possible that this information is not used at all.
 
 The information about the possible fields, their required data types, and what is mandatory or optional, is taken from [https://github.com/apel/apel/tree/master/apel/db/records](https://github.com/apel/apel/tree/master/apel/db/records). Exceptions are `VO`, `SubmitHost`, and `Processors`, which the APEL plugin considers necessary.
 

--- a/media/website/content/_index.md
+++ b/media/website/content/_index.md
@@ -1121,6 +1121,8 @@ summary_fields:
       regex: (?<=/).*?(?=/|$)
     Processors: !ComponentField
       name: Cores
+    NodeCount: !ComponentField
+      name: NNodes
     SubmitHost: !MetaField
       name: headnode
     NormalisedWallDuration: !NormalisedField
@@ -1147,8 +1149,6 @@ summary_fields:
       regex: '(?=Role).*?(?=/|$)'
     Infrastructure: !ConstantField
       value: grid
-    NodeCount: !ComponentField
-      name: NNodes
 ```
 
 The individual parameters in the config file are:
@@ -1183,14 +1183,17 @@ The section `summary_fields` has the subsections `mandatory` and `optional`. `ma
 
 | Name                     | Data type |
 |:-------------------------|:---------:|
-| `CpuDuration`            | `int`     |
-| `NormalisedCpuDuration`  | `int`     |
-| `NormalisedWallDuration` | `int`     |
-| `VO`                     | `str`     |
-| `SubmitHost`             | `str`     |
-| `Processors`             | `int`     |
+| `CpuDuration`            |   `int`   |
+| `NormalisedCpuDuration`  |   `int`   |
+| `NormalisedWallDuration` |   `int`   |
+| `VO`                     |   `str`   |
+| `SubmitHost`             |   `str`   |
+| `Processors`             |   `int`   |
+| `NodeCount`              |   `int`   |
 
-`CpuDuration` and `NormalisedCpuDuration` have to contain the sum of user- and system CPU time, and the sum of all cores that were running (e.g. `RemoteSysCpu + RemoteUserCpu` for HTCondor). `NormalisedWallDuration` has to contain the time the job was actually running, i.e. **not** multiplied by the number of cores (this is done later in the APEL pipeline). 
+`CpuDuration` and `NormalisedCpuDuration` have to contain the sum of user- and system CPU time, and the sum of all cores that were running (e.g. `RemoteSysCpu + RemoteUserCpu` for HTCondor). `NormalisedWallDuration` has to contain the time the job was actually running, i.e. **not** multiplied by the number of cores (this is done later in the APEL pipeline).
+
+If `NodeCount` is not present in the config, a default value of 1 is assumed.
 
 There are actually more mandatory fields, but they are handled internally and don't need any input from the user.
 
@@ -1202,9 +1205,8 @@ There are actually more mandatory fields, but they are handled internally and do
 | `VOGroup`        | `str`     |
 | `VORole`         | `str`     |
 | `Infrastructure` | `str`     |
-| `NodeCount`      | `int`     |
 
-Except for `NodeCount`, none of the `optional` information appears on the [EGI Accounting Portal](https://accounting.egi.eu/), so it is possible that this information is not used at all.
+Except for `Infrastructure`, none of the `optional` information appears on the [EGI Accounting Portal](https://accounting.egi.eu/), so it is possible that this information is not used at all.
 
 The information about the possible fields, their required data types, and what is mandatory or optional, is taken from [https://github.com/apel/apel/tree/master/apel/db/records](https://github.com/apel/apel/tree/master/apel/db/records). Exceptions are `VO`, `SubmitHost`, and `Processors`, which the APEL plugin considers necessary.
 

--- a/plugins/apel/configs/auditor_apel_plugin_template.yml
+++ b/plugins/apel/configs/auditor_apel_plugin_template.yml
@@ -45,6 +45,8 @@
 #       regex: (?<=/).*?(?=/|$)
 #     Processors: !ComponentField
 #       name: Cores
+#     NodeCount: !ComponentField
+#       name: NNodes
 #     SubmitHost: !MetaField
 #       name: headnode
 #     NormalisedWallDuration: !NormalisedField
@@ -71,5 +73,3 @@
 #       regex: '(?=Role).*?(?=/|$)'
 #     Infrastructure: !ConstantField
 #       value: grid
-#     NodeCount: !ComponentField
-#       name: NNodes

--- a/plugins/apel/configs/auditor_apel_plugin_template.yml
+++ b/plugins/apel/configs/auditor_apel_plugin_template.yml
@@ -46,6 +46,8 @@
 #       regex: (?<=/).*?(?=/|$)
 #     Processors: !ComponentField
 #       name: Cores
+#     NodeCount: !ComponentField
+#       name: NNodes
 #     SubmitHost: !MetaField
 #       name: headnode
 #     NormalisedWallDuration: !NormalisedField
@@ -72,5 +74,3 @@
 #       regex: '(?=Role).*?(?=/|$)'
 #     Infrastructure: !ConstantField
 #       value: grid
-#     NodeCount: !ComponentField
-#       name: NNodes

--- a/plugins/apel/src/auditor_apel_plugin/config.py
+++ b/plugins/apel/src/auditor_apel_plugin/config.py
@@ -294,6 +294,12 @@ class Config(Configurable):
             logger.critical("summary_fields missing in config!")
             raise ValueError
 
+        if (
+            "NodeCount" not in field_config.mandatory
+            and "NodeCount" not in field_config.optional
+        ):
+            field_config.mandatory["NodeCount"] = ConstantField(value=1)
+
         return field_config
 
     def get_mandatory_fields(self) -> dict[str, Field]:

--- a/plugins/apel/src/auditor_apel_plugin/message.py
+++ b/plugins/apel/src/auditor_apel_plugin/message.py
@@ -27,7 +27,15 @@ class SummaryMessage(Message):
         "RecordID TEXT UNIQUE NOT NULL",
     ]
 
-    group_by: list[str] = ["Site", "Month", "Year", "VO", "SubmitHost", "Processors"]
+    group_by: list[str] = [
+        "Site",
+        "Month",
+        "Year",
+        "VO",
+        "SubmitHost",
+        "Processors",
+        "NodeCount",
+    ]
 
     store_as: list[str] = [
         "COUNT(RecordID) as NumberOfJobs",

--- a/plugins/apel/src/auditor_apel_plugin/message.py
+++ b/plugins/apel/src/auditor_apel_plugin/message.py
@@ -34,6 +34,7 @@ class SummaryMessage(Message):
         "SubmitHost",
         "Processors",
         "InfrastructureDescription",
+        "NodeCount",
     ]
 
     store_as: list[str] = [


### PR DESCRIPTION
This PR adds a default value of 1 for `NodeCount`, since this is a mandatory field for APEL. Want to avoid a breaking change at this point, therefore not adding it to the mandatory fields.